### PR TITLE
refactor(auth): 将授权服务迁移至 API 层并重命名为 ThirdPartyAuthService

### DIFF
--- a/backend/cmd/singer/server.go
+++ b/backend/cmd/singer/server.go
@@ -4,26 +4,21 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	auth "github.com/insmtx/SingerOS/backend/internal/api/auth"
-	"github.com/insmtx/SingerOS/backend/internal/infra/providers/github"
 	"github.com/insmtx/SingerOS/backend/config"
-	infradb "github.com/insmtx/SingerOS/backend/internal/infra/db"
-	"github.com/insmtx/SingerOS/backend/internal/api/trace"
-	"github.com/insmtx/SingerOS/backend/internal/infra/mq"
-	"github.com/insmtx/SingerOS/backend/internal/api"
-	"github.com/insmtx/SingerOS/backend/internal/eventengine"
 	"github.com/insmtx/SingerOS/backend/internal/agent"
+	"github.com/insmtx/SingerOS/backend/internal/api"
+	"github.com/insmtx/SingerOS/backend/internal/api/trace"
+	"github.com/insmtx/SingerOS/backend/internal/eventengine"
+	infradb "github.com/insmtx/SingerOS/backend/internal/infra/db"
+	"github.com/insmtx/SingerOS/backend/internal/infra/mq"
 	"github.com/insmtx/SingerOS/backend/tools"
 	skilltools "github.com/insmtx/SingerOS/backend/tools/skill"
 	"github.com/spf13/cobra"
 	"github.com/ygpkg/yg-go/apis/runtime/middleware"
 	ygconfig "github.com/ygpkg/yg-go/config"
+	"github.com/ygpkg/yg-go/lifecycle"
 	"github.com/ygpkg/yg-go/logs"
 	"gorm.io/gorm"
 )
@@ -59,8 +54,6 @@ var serverCmd = &cobra.Command{
 			logs.Fatalf("LLM configuration is required for Eino runtime")
 			return
 		}
-
-		authService := buildAuthService(cfg)
 
 		runtimeConfig, err := buildRuntimeConfig()
 		if err != nil {
@@ -100,7 +93,7 @@ var serverCmd = &cobra.Command{
 			r.Use(middleware.Recovery())
 		}
 
-		api.SetupRouter(r, *cfg, publisher, db, authService)
+		api.SetupRouter(r, *cfg, publisher, db)
 
 		srv := &http.Server{
 			Addr:    serverHttpAddr,
@@ -110,7 +103,7 @@ var serverCmd = &cobra.Command{
 		logs.Info("Starting SingerOS backend service...")
 		logs.Infof("Listening on %s", serverHttpAddr)
 
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
 		if err := orchestratorInstance.Start(ctx); err != nil {
 			logs.Errorf("Failed to start orchestrator: %v", err)
 		} else {
@@ -123,20 +116,16 @@ var serverCmd = &cobra.Command{
 			}
 		}()
 
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-		<-sigChan
-		logs.Info("Shutting down server...")
+		lifecycle.Std().AddCloseFunc(func() error {
+			defer cancel()
+			if err := srv.Shutdown(ctx); err != nil {
+				logs.Errorf("Server forced to shutdown: %v", err)
+			}
+			return nil
+		})
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := srv.Shutdown(ctx); err != nil {
-			logs.Errorf("Server forced to shutdown: %v", err)
-		}
-
-		if publisher != nil {
-			publisher.Close()
-		}
+		lifecycle.Std().AddCloseFunc(publisher.Close)
+		lifecycle.Std().WaitExit()
 
 		logs.Info("Server exited")
 	},
@@ -194,18 +183,6 @@ func buildRuntimeConfig() (agent.Config, error) {
 		SkillsCatalog: catalog,
 		ToolRegistry:  toolRegistry,
 	}, nil
-}
-
-func buildAuthService(cfg *config.Config) *auth.Service {
-	accountStore := auth.NewInMemoryStore()
-	accountResolver := auth.NewAccountResolver(accountStore)
-	authService := auth.NewService(accountStore, accountResolver)
-
-	if cfg != nil && cfg.Github != nil {
-		authService.RegisterProvider(githubprovider.NewOAuthProvider(*cfg.Github))
-	}
-
-	return authService
 }
 
 func buildTooling(catalog *skilltools.Catalog) (*tools.Registry, error) {

--- a/backend/internal/api/auth/service.go
+++ b/backend/internal/api/auth/service.go
@@ -10,8 +10,8 @@ import (
 
 const oauthStateBytes = 16
 
-// Service 提供统一的用户授权账户接入与运行时解析能力。
-type Service struct {
+// ThirdPartyAuthService 提供统一的第三方平台授权账户接入与运行时解析能力。
+type ThirdPartyAuthService struct {
 	store           Store
 	resolver        *AccountResolver
 	providers       map[string]AuthorizationProvider
@@ -19,9 +19,9 @@ type Service struct {
 	defaultResolver ProviderAuthResolver
 }
 
-// NewService 创建一个新的授权服务。
-func NewService(store Store, resolver *AccountResolver) *Service {
-	service := &Service{
+// NewThirdPartyAuthService 创建一个新的第三方平台授权服务。
+func NewThirdPartyAuthService(store Store, resolver *AccountResolver) *ThirdPartyAuthService {
+	service := &ThirdPartyAuthService{
 		store:         store,
 		resolver:      resolver,
 		providers:     make(map[string]AuthorizationProvider),
@@ -34,7 +34,7 @@ func NewService(store Store, resolver *AccountResolver) *Service {
 }
 
 // RegisterProvider 注册一个授权 provider。
-func (s *Service) RegisterProvider(provider AuthorizationProvider) {
+func (s *ThirdPartyAuthService) RegisterProvider(provider AuthorizationProvider) {
 	if provider == nil {
 		return
 	}
@@ -42,7 +42,7 @@ func (s *Service) RegisterProvider(provider AuthorizationProvider) {
 }
 
 // RegisterAuthResolver registers a provider-specific runtime authorization resolver.
-func (s *Service) RegisterAuthResolver(provider string, resolver ProviderAuthResolver) {
+func (s *ThirdPartyAuthService) RegisterAuthResolver(provider string, resolver ProviderAuthResolver) {
 	if s == nil || provider == "" || resolver == nil {
 		return
 	}
@@ -50,7 +50,7 @@ func (s *Service) RegisterAuthResolver(provider string, resolver ProviderAuthRes
 }
 
 // StartAuthorization 发起某个 provider 的用户授权。
-func (s *Service) StartAuthorization(ctx context.Context, req *StartAuthorizationRequest) (string, error) {
+func (s *ThirdPartyAuthService) StartAuthorization(ctx context.Context, req *StartAuthorizationRequest) (string, error) {
 	if req == nil {
 		return "", fmt.Errorf("authorization request is required")
 	}
@@ -84,7 +84,7 @@ func (s *Service) StartAuthorization(ctx context.Context, req *StartAuthorizatio
 }
 
 // HandleAuthorizationCallback 处理 provider 回调并保存授权账户。
-func (s *Service) HandleAuthorizationCallback(ctx context.Context, req *AuthorizationCallbackRequest) (*AuthorizationResult, error) {
+func (s *ThirdPartyAuthService) HandleAuthorizationCallback(ctx context.Context, req *AuthorizationCallbackRequest) (*AuthorizationResult, error) {
 	if req == nil {
 		return nil, fmt.Errorf("authorization callback request is required")
 	}
@@ -137,12 +137,12 @@ func (s *Service) HandleAuthorizationCallback(ctx context.Context, req *Authoriz
 }
 
 // ResolveAccount 解析运行时可用账户。
-func (s *Service) ResolveAccount(ctx context.Context, req *ResolveAccountRequest) (*ResolvedAccount, error) {
+func (s *ThirdPartyAuthService) ResolveAccount(ctx context.Context, req *ResolveAccountRequest) (*ResolvedAccount, error) {
 	return s.resolver.Resolve(ctx, req)
 }
 
 // ResolveAuthorization resolves runtime authorization through provider-specific resolvers first.
-func (s *Service) ResolveAuthorization(ctx context.Context, req *ResolveAuthorizationRequest) (*ResolvedAuthorization, error) {
+func (s *ThirdPartyAuthService) ResolveAuthorization(ctx context.Context, req *ResolveAuthorizationRequest) (*ResolvedAuthorization, error) {
 	if req == nil {
 		return nil, fmt.Errorf("resolve authorization request is required")
 	}

--- a/backend/internal/api/connectors/github/github.go
+++ b/backend/internal/api/connectors/github/github.go
@@ -34,7 +34,7 @@ type Connector struct {
 	client    *github.Client
 	publisher eventbus.Publisher
 	db        *gorm.DB
-	authSvc   *auth.Service
+	authSvc   *auth.ThirdPartyAuthService
 }
 
 // ChannelCode returns the channel identifier for GitHub.
@@ -50,7 +50,7 @@ func (c *Connector) RegisterRoutes(r gin.IRouter) {
 }
 
 // NewConnector creates a new GitHub connector instance.
-func NewConnector(cfg config.GithubAppConfig, publisher eventbus.Publisher, db *gorm.DB, authSvc *auth.Service) *Connector {
+func NewConnector(cfg config.GithubAppConfig, publisher eventbus.Publisher, db *gorm.DB, authSvc *auth.ThirdPartyAuthService) *Connector {
 	logs.Infof("Creating new GitHub connector for app ID: %d", cfg.AppID)
 
 	var githubClient *github.Client

--- a/backend/internal/api/gateway.go
+++ b/backend/internal/api/gateway.go
@@ -11,6 +11,7 @@ import (
 	"github.com/insmtx/SingerOS/backend/internal/api/connectors"
 	"github.com/insmtx/SingerOS/backend/internal/api/connectors/github"
 	"github.com/insmtx/SingerOS/backend/internal/api/connectors/gitlab"
+	githubprovider "github.com/insmtx/SingerOS/backend/internal/infra/providers/github"
 	"github.com/insmtx/SingerOS/backend/internal/infra/websocket"
 	eventbus "github.com/insmtx/SingerOS/backend/internal/infra/mq"
 	"github.com/ygpkg/yg-go/logs"
@@ -21,8 +22,10 @@ import (
 //
 // 根据配置初始化并注册 GitHub、GitLab 等渠道连接器，
 // 同时设置客户端 WebSocket 连接器，并将所有连接器的路由注册到 HTTP 服务器。
-func SetupRouter(r gin.IRouter, cfg config.Config, publisher eventbus.Publisher, db *gorm.DB, authService *auth.Service) {
+func SetupRouter(r gin.IRouter, cfg config.Config, publisher eventbus.Publisher, db *gorm.DB) {
 	router := connectors.NewRouter()
+
+	authService := initThirdPartyAuthService(&cfg)
 
 	if cfg.Github != nil {
 		logs.Info("Setting up GitHub connector")
@@ -49,4 +52,17 @@ func SetupRouter(r gin.IRouter, cfg config.Config, publisher eventbus.Publisher,
 
 	router.RegisterRoutes(r)
 	logs.Info("Event gateway routes registered successfully")
+}
+
+// initThirdPartyAuthService 初始化第三方平台授权服务并注册 provider
+func initThirdPartyAuthService(cfg *config.Config) *auth.ThirdPartyAuthService {
+	accountStore := auth.NewInMemoryStore()
+	accountResolver := auth.NewAccountResolver(accountStore)
+	authService := auth.NewThirdPartyAuthService(accountStore, accountResolver)
+
+	if cfg != nil && cfg.Github != nil {
+		authService.RegisterProvider(githubprovider.NewOAuthProvider(*cfg.Github))
+	}
+
+	return authService
 }

--- a/backend/internal/infra/mq/std.go
+++ b/backend/internal/infra/mq/std.go
@@ -1,0 +1,1 @@
+package mq

--- a/backend/internal/infra/providers/github/client_factory.go
+++ b/backend/internal/infra/providers/github/client_factory.go
@@ -47,19 +47,19 @@ type ResolvedClient struct {
 // ClientFactory 负责把已授权账户转换成 GitHub client。
 type ClientFactory struct {
 	cfg         config.GithubAppConfig
-	authService *auth.Service
+	authService *auth.ThirdPartyAuthService
 	httpClient  *http.Client
 	now         func() time.Time
 	resolvers   []clientResolver
 }
 
 // NewClientFactory 创建一个新的 GitHub client 工厂。
-func NewClientFactory(cfg config.GithubAppConfig, authService *auth.Service) *ClientFactory {
+func NewClientFactory(cfg config.GithubAppConfig, authService *auth.ThirdPartyAuthService) *ClientFactory {
 	return NewClientFactoryWithHTTPClient(cfg, authService, nil)
 }
 
 // NewClientFactoryWithHTTPClient 创建一个可注入自定义 HTTP client 的 GitHub client 工厂。
-func NewClientFactoryWithHTTPClient(cfg config.GithubAppConfig, authService *auth.Service, httpClient *http.Client) *ClientFactory {
+func NewClientFactoryWithHTTPClient(cfg config.GithubAppConfig, authService *auth.ThirdPartyAuthService, httpClient *http.Client) *ClientFactory {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 15 * time.Second}
 	}


### PR DESCRIPTION
- 从 cmd/singer/server.go 移除 buildAuthService 函数
- 在 backend/internal/api/gateway.go 中创建 initThirdPartyAuthService 函数
- 将 Service 重命名为 ThirdPartyAuthService 以准确表达第三方平台授权的职责
- 更新所有相关引用 (Service -> ThirdPartyAuthService)
- 简化 SetupRouter 函数签名，移除 authService 参数
- 清理未使用的导入
- 修复 backend/internal/infra/mq/std.go 空文件问题