### PR TITLE
feat(frontend): 前端与后端 API 联调

### DIFF
--- a/frontend/apps/desktop/src/renderer/src/components/layout/ConversationListPanel.tsx
+++ b/frontend/apps/desktop/src/renderer/src/components/layout/ConversationListPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from "@singeros/ui/components/ui/button";
 import { ScrollArea } from "@singeros/ui/components/ui/scroll-area";
 import { cn } from "@singeros/ui/lib/utils";
 import { Plus, Search, Trash2 } from "lucide-react";
+import { useEffect } from "react";
 
 export function ConversationListPanel() {
 	const {
@@ -16,9 +17,14 @@ export function ConversationListPanel() {
 		createConversation,
 		deleteConversation,
 		setConversationSearchQuery,
+		fetchConversations,
 	} = useLayoutStore((s) => s);
 
-	const { loadConversationMessages } = useChatStore((s) => s);
+	const { setActiveSession, loadConversationMessages } = useChatStore((s) => s);
+
+	useEffect(() => {
+		fetchConversations();
+	}, [fetchConversations]);
 
 	const filteredConversations = conversationSearchQuery
 		? conversations.filter((c) =>
@@ -26,14 +32,24 @@ export function ConversationListPanel() {
 			)
 		: conversations;
 
-	const handleConversationClick = (id: string) => {
+	const handleConversationClick = (id: string, sessionDbId: number) => {
 		switchConversation(id);
-		loadConversationMessages(id);
+		setActiveSession(sessionDbId, id);
+		loadConversationMessages(sessionDbId);
 	};
 
-	const handleCreateConversation = () => {
-		const id = createConversation("remote-1", "新会话");
-		handleConversationClick(id);
+	const handleCreateConversation = async () => {
+		const newId = await createConversation("新会话");
+		if (newId) {
+			const conv = conversations.find((c) => c.id === newId);
+			if (conv) {
+				handleConversationClick(conv.id, conv.sessionDbId);
+			}
+		}
+	};
+
+	const handleDeleteConversation = async (id: string) => {
+		await deleteConversation(id);
 	};
 
 	if (!conversationListOpen) return null;
@@ -76,7 +92,7 @@ export function ConversationListPanel() {
 									? "bg-blue-50 text-blue-700"
 									: "text-slate-600 hover:bg-slate-50",
 							)}
-							onClick={() => handleConversationClick(conv.id)}
+							onClick={() => handleConversationClick(conv.id, conv.sessionDbId)}
 						>
 							<span className="truncate flex-1">{conv.title}</span>
 							<Button
@@ -85,7 +101,7 @@ export function ConversationListPanel() {
 								className="opacity-0 group-hover:opacity-100 transition-opacity text-slate-400 hover:text-red-500"
 								onClick={(e) => {
 									e.stopPropagation();
-									deleteConversation(conv.id);
+									handleDeleteConversation(conv.id);
 								}}
 							>
 								<Trash2 className="size-3" />

--- a/frontend/apps/web/components/layout/ConversationListPanel.tsx
+++ b/frontend/apps/web/components/layout/ConversationListPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from "@singeros/ui/components/ui/button";
 import { ScrollArea } from "@singeros/ui/components/ui/scroll-area";
 import { cn } from "@singeros/ui/lib/utils";
 import { Plus, Search, Trash2 } from "lucide-react";
+import { useEffect } from "react";
 
 export function ConversationListPanel() {
 	const {
@@ -16,9 +17,14 @@ export function ConversationListPanel() {
 		createConversation,
 		deleteConversation,
 		setConversationSearchQuery,
+		fetchConversations,
 	} = useLayoutStore((s) => s);
 
-	const { loadConversationMessages } = useChatStore((s) => s);
+	const { setActiveSession, loadConversationMessages } = useChatStore((s) => s);
+
+	useEffect(() => {
+		fetchConversations();
+	}, [fetchConversations]);
 
 	const filteredConversations = conversationSearchQuery
 		? conversations.filter((c) =>
@@ -26,14 +32,24 @@ export function ConversationListPanel() {
 			)
 		: conversations;
 
-	const handleConversationClick = (id: string) => {
+	const handleConversationClick = (id: string, sessionDbId: number) => {
 		switchConversation(id);
-		loadConversationMessages(id);
+		setActiveSession(sessionDbId, id);
+		loadConversationMessages(sessionDbId);
 	};
 
-	const handleCreateConversation = () => {
-		const id = createConversation("remote-1", "新会话");
-		handleConversationClick(id);
+	const handleCreateConversation = async () => {
+		const newId = await createConversation("新会话");
+		if (newId) {
+			const conv = conversations.find((c) => c.id === newId);
+			if (conv) {
+				handleConversationClick(conv.id, conv.sessionDbId);
+			}
+		}
+	};
+
+	const handleDeleteConversation = async (id: string) => {
+		await deleteConversation(id);
 	};
 
 	if (!conversationListOpen) return null;
@@ -67,23 +83,16 @@ export function ConversationListPanel() {
 			<ScrollArea className="flex-1">
 				<div className="px-3 pb-2">
 					{filteredConversations.map((conv) => (
-						<div
+						<button
 							key={conv.id}
-							role="button"
-							tabIndex={0}
+							type="button"
 							className={cn(
 								"group relative flex items-center rounded-md px-2 py-1.5 text-sm cursor-pointer transition-colors w-full text-left",
 								activeConversationId === conv.id
 									? "bg-blue-50 text-blue-700"
 									: "text-slate-600 hover:bg-slate-50",
 							)}
-							onClick={() => handleConversationClick(conv.id)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
-									e.preventDefault();
-									handleConversationClick(conv.id);
-								}
-							}}
+							onClick={() => handleConversationClick(conv.id, conv.sessionDbId)}
 						>
 							<span className="truncate flex-1">{conv.title}</span>
 							<Button
@@ -92,12 +101,12 @@ export function ConversationListPanel() {
 								className="opacity-0 group-hover:opacity-100 transition-opacity text-slate-400 hover:text-red-500"
 								onClick={(e) => {
 									e.stopPropagation();
-									deleteConversation(conv.id);
+									handleDeleteConversation(conv.id);
 								}}
 							>
 								<Trash2 className="size-3" />
 							</Button>
-						</div>
+						</button>
 					))}
 				</div>
 			</ScrollArea>

--- a/frontend/apps/web/next.config.ts
+++ b/frontend/apps/web/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
 	transpilePackages: ["@singeros/ui", "@singeros/store"],
+	allowedDevOrigins: ["172.16.0.160"],
 };
 
 export default nextConfig;

--- a/frontend/packages/store/api/client.ts
+++ b/frontend/packages/store/api/client.ts
@@ -1,0 +1,5 @@
+import type { HttpClient } from "@singeros/ui/lib/request";
+import { createHttpClient } from "@singeros/ui/lib/request";
+import { API_BASE_URL } from "./config";
+
+export const apiClient: HttpClient = createHttpClient(API_BASE_URL);

--- a/frontend/packages/store/api/config.ts
+++ b/frontend/packages/store/api/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "http://192.144.198.60:8080/v1";

--- a/frontend/packages/store/api/digitalAssistantApi.ts
+++ b/frontend/packages/store/api/digitalAssistantApi.ts
@@ -1,0 +1,104 @@
+import { apiClient } from "./client";
+import type {
+	BackendDataResponse,
+	BackendDigitalAssistant,
+	BackendPaginatedResponse,
+} from "./types";
+
+export type CreateDAParams = {
+	code: string;
+	name: string;
+	org_id: number;
+	owner_id: number;
+	description?: string;
+	avatar?: string;
+	config?: {
+		llm_config?: { type?: string };
+		skills?: { skill_code?: string; version?: string }[];
+		channels?: { type?: string }[];
+		knowledge?: { type?: string; repo?: string; dataset_id?: string }[];
+		memory_config?: { type?: string };
+		policies_config?: { type?: string };
+		runtime_config?: { type?: string };
+	};
+};
+
+export type UpdateDAParams = {
+	id: number;
+	name?: string;
+	description?: string;
+	avatar?: string;
+	config?: {
+		llm_config?: { type?: string };
+		skills?: { skill_code?: string; version?: string }[];
+		channels?: { type?: string }[];
+		knowledge?: { type?: string; repo?: string; dataset_id?: string }[];
+		memory_config?: { type?: string };
+		policies_config?: { type?: string };
+		runtime_config?: { type?: string };
+	};
+};
+
+export type UpdateDAConfigParams = {
+	id: number;
+	config: {
+		llm_config?: { type?: string };
+		skills?: { skill_code?: string; version?: string }[];
+		channels?: { type?: string }[];
+		knowledge?: { type?: string; repo?: string; dataset_id?: string }[];
+		memory_config?: { type?: string };
+		policies_config?: { type?: string };
+		runtime_config?: { type?: string };
+	};
+};
+
+export type UpdateDAStatusParams = {
+	id: number;
+	status: string;
+};
+
+export type ListDAParams = {
+	page?: number;
+	per_page?: number;
+	org_id?: number;
+	owner_id?: number;
+	status?: string;
+	keyword?: string;
+};
+
+export type GetDAParams = {
+	id?: number;
+	code?: string;
+};
+
+const DA_ENDPOINTS = {
+	create: "/CreateDigitalAssistant",
+	list: "/ListDigitalAssistant",
+	get: "/GetDigitalAssistant",
+	update: "/UpdateDigitalAssistant",
+	updateConfig: "/UpdateDigitalAssistantConfig",
+	updateStatus: "/UpdateDigitalAssistantStatus",
+	delete: "/DeleteDigitalAssistant",
+};
+
+export const digitalAssistantApi = {
+	create: (params: CreateDAParams) =>
+		apiClient.post<BackendDataResponse<BackendDigitalAssistant>>(DA_ENDPOINTS.create, params),
+
+	list: (params: ListDAParams) =>
+		apiClient.post<BackendPaginatedResponse<BackendDigitalAssistant>>(DA_ENDPOINTS.list, params),
+
+	get: (params: GetDAParams) =>
+		apiClient.post<BackendDataResponse<BackendDigitalAssistant>>(DA_ENDPOINTS.get, params),
+
+	update: (params: UpdateDAParams) =>
+		apiClient.post<BackendDataResponse<BackendDigitalAssistant>>(DA_ENDPOINTS.update, params),
+
+	updateConfig: (params: UpdateDAConfigParams) =>
+		apiClient.post<BackendDataResponse<BackendDigitalAssistant>>(DA_ENDPOINTS.updateConfig, params),
+
+	updateStatus: (params: UpdateDAStatusParams) =>
+		apiClient.post<BackendDataResponse<null>>(DA_ENDPOINTS.updateStatus, params),
+
+	delete: (id: number) => apiClient.post<BackendDataResponse<null>>(DA_ENDPOINTS.delete, { id }),
+};

--- a/frontend/packages/store/api/index.ts
+++ b/frontend/packages/store/api/index.ts
@@ -1,0 +1,40 @@
+export { apiClient } from "./client";
+export { API_BASE_URL } from "./config";
+export type {
+	CreateDAParams,
+	GetDAParams,
+	ListDAParams,
+	UpdateDAConfigParams,
+	UpdateDAParams,
+	UpdateDAStatusParams,
+} from "./digitalAssistantApi";
+export { digitalAssistantApi } from "./digitalAssistantApi";
+export type {
+	AddMessageParams,
+	CreateSessionParams,
+	GetSessionParams,
+	ListSessionsParams,
+	UpdateSessionParams,
+} from "./sessionApi";
+export { sessionApi } from "./sessionApi";
+export type {
+	BackendAssistantConfig,
+	BackendBaseResponse,
+	BackendChannelRef,
+	BackendDataResponse,
+	BackendDigitalAssistant,
+	BackendErrorResponse,
+	BackendKnowledgeRef,
+	BackendLLMConfig,
+	BackendMemoryConfig,
+	BackendMessage,
+	BackendMessageMetadata,
+	BackendPaginatedResponse,
+	BackendPolicyConfig,
+	BackendRuntimeConfig,
+	BackendSession,
+	BackendSessionMetadata,
+	BackendSkillRef,
+	BackendToolCall,
+	SSEMessageEvent,
+} from "./types";

--- a/frontend/packages/store/api/sessionApi.ts
+++ b/frontend/packages/store/api/sessionApi.ts
@@ -1,0 +1,133 @@
+import { apiClient } from "./client";
+import { API_BASE_URL } from "./config";
+import type {
+	BackendDataResponse,
+	BackendMessage,
+	BackendPaginatedResponse,
+	BackendSession,
+} from "./types";
+
+export type CreateSessionParams = {
+	type: string;
+	title?: string;
+	assistant_id?: number;
+	assistant_code?: string;
+	session_id?: string;
+	user_id?: number;
+	expired_at?: string;
+	metadata?: {
+		user_agent?: string;
+		ip_address?: string;
+		tags?: string[];
+		extra?: Record<string, unknown>;
+	};
+};
+
+export type UpdateSessionParams = {
+	id: number;
+	title?: string;
+	expired_at?: string;
+	metadata?: {
+		user_agent?: string;
+		ip_address?: string;
+		tags?: string[];
+		extra?: Record<string, unknown>;
+	};
+};
+
+export type ListSessionsParams = {
+	page?: number;
+	per_page?: number;
+	type?: string;
+	status?: string;
+	keyword?: string;
+	assistant_id?: number;
+	assistant_code?: string;
+	user_id?: number;
+};
+
+export type GetSessionParams = {
+	id?: number;
+	session_id?: string;
+};
+
+export type AddMessageParams = {
+	session_id: number;
+	role: string;
+	content: string;
+	message_type?: string;
+	status?: string;
+	thinking?: string;
+	metadata?: {
+		model?: string;
+		tokens?: number;
+		latency?: number;
+		image_url?: string;
+		file_url?: string;
+		file_name?: string;
+		language?: string;
+		extra?: Record<string, unknown>;
+	};
+	tool_calls?: {
+		id: string;
+		name: string;
+		arguments: Record<string, unknown>;
+		status: string;
+		result?: Record<string, unknown>;
+		duration?: number;
+	}[];
+	chunks?: string[];
+};
+
+const SESSION_ENDPOINTS = {
+	create: "/CreateSession",
+	list: "/ListSessions",
+	get: "/GetSession",
+	update: "/UpdateSession",
+	delete: "/DeleteSession",
+	addMessage: "/AddMessage",
+	getMessages: "/GetSessionMessages",
+	deleteMessage: "/DeleteMessage",
+	clearMessages: "/ClearSessionMessages",
+	sessionEvents: "/SessionEvents",
+};
+
+export const sessionApi = {
+	create: (params: CreateSessionParams) =>
+		apiClient.post<BackendDataResponse<BackendSession>>(SESSION_ENDPOINTS.create, params),
+
+	list: (params: ListSessionsParams) =>
+		apiClient.post<BackendPaginatedResponse<BackendSession>>(SESSION_ENDPOINTS.list, params),
+
+	get: (params: GetSessionParams) =>
+		apiClient.post<BackendDataResponse<BackendSession>>(SESSION_ENDPOINTS.get, params),
+
+	update: (params: UpdateSessionParams) =>
+		apiClient.post<BackendDataResponse<BackendSession>>(SESSION_ENDPOINTS.update, params),
+
+	delete: (id: number) =>
+		apiClient.post<BackendDataResponse<null>>(SESSION_ENDPOINTS.delete, { id }),
+
+	addMessage: (params: AddMessageParams) =>
+		apiClient.post<BackendDataResponse<BackendMessage>>(SESSION_ENDPOINTS.addMessage, params),
+
+	getMessages: (sessionId: number, page?: number, perPage?: number) =>
+		apiClient.post<BackendPaginatedResponse<BackendMessage>>(SESSION_ENDPOINTS.getMessages, {
+			session_id: sessionId,
+			page: page ?? 1,
+			per_page: perPage ?? 50,
+		}),
+
+	deleteMessage: (messageId: number) =>
+		apiClient.post<BackendDataResponse<null>>(SESSION_ENDPOINTS.deleteMessage, {
+			message_id: messageId,
+		}),
+
+	clearMessages: (sessionId: number) =>
+		apiClient.post<BackendDataResponse<null>>(SESSION_ENDPOINTS.clearMessages, {
+			session_id: sessionId,
+		}),
+
+	getSessionEventsURL: (_sessionId?: string, _lastSequence?: number) =>
+		`${API_BASE_URL}/SessionEvents`,
+};

--- a/frontend/packages/store/api/types.ts
+++ b/frontend/packages/store/api/types.ts
@@ -1,0 +1,150 @@
+export type BackendBaseResponse = {
+	code: number;
+	message: string;
+};
+
+export type BackendErrorResponse = BackendBaseResponse & {
+	details?: string;
+};
+
+export type BackendPaginatedResponse<T> = BackendBaseResponse & {
+	data: {
+		total: number;
+		page: number;
+		items: T[];
+	};
+};
+
+export type BackendDataResponse<T> = BackendBaseResponse & {
+	data: T;
+};
+
+export type BackendSession = {
+	id: number;
+	session_id: string;
+	type: string;
+	user_id: number;
+	assistant_id: number;
+	assistant_code: string;
+	status: string;
+	title: string;
+	message_count: number;
+	last_message_at?: string;
+	metadata?: BackendSessionMetadata;
+	expired_at?: string;
+	created_at: string;
+	updated_at: string;
+};
+
+export type BackendSessionMetadata = {
+	user_agent?: string;
+	ip_address?: string;
+	tags?: string[];
+	extra?: Record<string, unknown>;
+};
+
+export type BackendMessage = {
+	id: string;
+	conversation_id: string;
+	role: string;
+	content: string;
+	status: string;
+	timestamp: number;
+	message_type: string;
+	sequence: number;
+	metadata?: BackendMessageMetadata;
+	thinking?: string;
+	tool_calls?: BackendToolCall[];
+	chunks?: string[];
+	created_at: string;
+};
+
+export type BackendMessageMetadata = {
+	model?: string;
+	tokens?: number;
+	latency?: number;
+	image_url?: string;
+	file_url?: string;
+	file_name?: string;
+	language?: string;
+	extra?: Record<string, unknown>;
+};
+
+export type BackendToolCall = {
+	id: string;
+	name: string;
+	arguments: Record<string, unknown>;
+	status: string;
+	result?: Record<string, unknown>;
+	duration?: number;
+};
+
+export type BackendDigitalAssistant = {
+	id: number;
+	code: string;
+	name: string;
+	description?: string;
+	avatar?: string;
+	org_id: number;
+	owner_id: number;
+	status: string;
+	config?: BackendAssistantConfig;
+	version: number;
+	created_at: string;
+	updated_at: string;
+};
+
+export type BackendAssistantConfig = {
+	llm_config?: BackendLLMConfig;
+	skills?: BackendSkillRef[];
+	channels?: BackendChannelRef[];
+	knowledge?: BackendKnowledgeRef[];
+	memory_config?: BackendMemoryConfig;
+	policies_config?: BackendPolicyConfig;
+	runtime_config?: BackendRuntimeConfig;
+};
+
+export type BackendLLMConfig = {
+	type?: string;
+};
+
+export type BackendSkillRef = {
+	skill_code?: string;
+	version?: string;
+};
+
+export type BackendChannelRef = {
+	type?: string;
+};
+
+export type BackendKnowledgeRef = {
+	type?: string;
+	repo?: string;
+	dataset_id?: string;
+};
+
+export type BackendMemoryConfig = {
+	type?: string;
+};
+
+export type BackendPolicyConfig = {
+	type?: string;
+};
+
+export type BackendRuntimeConfig = {
+	type?: string;
+};
+
+export type SSEMessageEvent = {
+	type: string;
+	message_id?: string;
+	conversation_id?: string;
+	role?: string;
+	content?: string;
+	chunk?: string;
+	status?: string;
+	thinking?: string;
+	tool_calls?: BackendToolCall[];
+	metadata?: BackendMessageMetadata;
+	sequence?: number;
+};

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -1,3 +1,6 @@
+export { API_BASE_URL } from "./api/config";
+export { digitalAssistantApi } from "./api/digitalAssistantApi";
+export { sessionApi } from "./api/sessionApi";
 export type { AppAction, AppStore } from "./appStore";
 export { useAppStore, useChatStore, useLayoutStore, useTopicStore } from "./appStore";
 export type { ChatAction, ChatState, ChatStore } from "./slices/chatSlice";

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -1,7 +1,18 @@
-import { mockMessages, mockModelOptions, mockStreamContent } from "../mocks/chatMocks";
-import { mockStreamResponse } from "../mocks/streamSimulator";
+import { FetchSSEClient } from "@singeros/ui/lib/fetch-sse";
+import { API_BASE_URL } from "../api/config";
+import { sessionApi } from "../api/sessionApi";
+import type { BackendMessage, BackendToolCall, SSEMessageEvent } from "../api/types";
+import { mockModelOptions } from "../mocks/chatMocks";
 import type { SliceCreator } from "../types";
-import type { Attachment, Message, ModelOption, ToolCallStatus } from "../types/chat";
+import type {
+	Attachment,
+	Message,
+	MessageRole,
+	MessageStatus,
+	ModelOption,
+	ToolCall,
+	ToolCallStatus,
+} from "../types/chat";
 import { flattenActions } from "../utils";
 
 export type ChatState = {
@@ -16,6 +27,8 @@ export type ChatState = {
 	inputFocused: boolean;
 	selectedModel: string;
 	modelOptions: ModelOption[];
+	activeSessionDbId: number | null;
+	activeSessionId: string | null;
 
 	tokenUsage: { total: number; currentSession: number };
 };
@@ -35,8 +48,10 @@ const _initialState: ChatState = {
 	inputFocused: false,
 	selectedModel: "gpt-4",
 	modelOptions: mockModelOptions,
+	activeSessionDbId: null,
+	activeSessionId: null,
 
-	tokenUsage: { total: 239500, currentSession: 12500 },
+	tokenUsage: { total: 0, currentSession: 0 },
 };
 
 type SetState = (
@@ -44,15 +59,56 @@ type SetState = (
 	replace?: boolean,
 ) => void;
 
-export const createChatSlice = (set: SetState, get: () => ChatStore, _api?: unknown) =>
-	new ChatActionImpl(set, get, _api);
+function mapBackendMessage(msg: BackendMessage): Message {
+	const toolCalls: ToolCall[] | undefined = msg.tool_calls?.map((tc: BackendToolCall) => ({
+		id: tc.id,
+		name: tc.name,
+		arguments: tc.arguments ?? {},
+		status: (tc.status as ToolCallStatus) ?? "pending",
+		result: tc.result,
+		duration: tc.duration,
+	}));
+
+	return {
+		id: String(msg.id),
+		conversationId: msg.conversation_id,
+		role: msg.role as MessageRole,
+		content: msg.content ?? "",
+		status: (msg.status as MessageStatus) ?? "complete",
+		timestamp: msg.timestamp ?? new Date(msg.created_at).getTime(),
+		toolCalls,
+		thinking: msg.thinking,
+		metadata: msg.metadata
+			? {
+					model: msg.metadata.model,
+					tokens: msg.metadata.tokens,
+					latency: msg.metadata.latency,
+				}
+			: undefined,
+	};
+}
+
+function mapToolCalls(tcList?: BackendToolCall[]): ToolCall[] | undefined {
+	if (!tcList) return undefined;
+	return tcList.map((tc) => ({
+		id: tc.id,
+		name: tc.name,
+		arguments: tc.arguments ?? {},
+		status: tc.status as ToolCallStatus,
+		result: tc.result,
+		duration: tc.duration,
+	}));
+}
+
+export const createChatSlice = (set: SetState, get: () => ChatStore) =>
+	new ChatActionImpl(set, get);
 
 export class ChatActionImpl {
 	readonly #set: SetState;
 	readonly #get: () => ChatStore;
+	#sseClient: FetchSSEClient | null = null;
 
-	constructor(set: SetState, get: () => ChatStore, _api?: unknown) {
-		void _api;
+	constructor(set: SetState, get: () => ChatStore) {
 		this.#set = set;
 		this.#get = get;
 	}
@@ -61,15 +117,33 @@ export class ChatActionImpl {
 		this.#set((state) => chatReducer(state, action));
 	};
 
-	sendMessage = (content: string, attachments?: Attachment[]) => {
+	setActiveSession = (sessionDbId: number, sessionId: string) => {
+		this.#set({ activeSessionDbId: sessionDbId, activeSessionId: sessionId });
+	};
+
+	sendMessage = async (content: string, attachments?: Attachment[]) => {
 		if (!content.trim() && !attachments?.length) return;
 
-		const now = Date.now();
-		const conversationId = "conv-1";
+		const state = this.#get();
+		const { activeSessionDbId, activeSessionId } = state;
+		if (!activeSessionDbId || !activeSessionId) return;
 
+		try {
+			await sessionApi.addMessage({
+				session_id: activeSessionDbId,
+				role: "user",
+				content,
+				message_type: "text",
+			});
+		} catch (err) {
+			console.error("sendMessage addMessage error:", err);
+			return;
+		}
+
+		const now = Date.now();
 		const userMsg: Message = {
 			id: `msg-user-${now}`,
-			conversationId,
+			conversationId: activeSessionId,
 			role: "user",
 			content,
 			status: "complete",
@@ -78,7 +152,7 @@ export class ChatActionImpl {
 
 		const assistantMsg: Message = {
 			id: `msg-assistant-${now}`,
-			conversationId,
+			conversationId: activeSessionId,
 			role: "assistant",
 			content: "",
 			status: "streaming",
@@ -92,50 +166,109 @@ export class ChatActionImpl {
 			isGenerating: true,
 			inputText: "",
 			inputAttachments: [],
-			tokenUsage: {
-				total: this.#get().tokenUsage.total + Math.floor(Math.random() * 200 + 100),
-				currentSession:
-					this.#get().tokenUsage.currentSession + Math.floor(Math.random() * 200 + 100),
-			},
 		});
 
-		this.internal_startStream(assistantMsg.id);
+		this.#startSSE(activeSessionId, assistantMsg.id);
 	};
 
-	internal_startStream = (messageId: string) => {
-		const { cancel } = mockStreamResponse({
-			content: mockStreamContent,
-			chunkSize: 3,
-			chunkDelay: 30,
-			onChunk: (chunk) => {
-				const state = this.#get();
-				const msg = state.messagesMap[messageId];
-				if (!msg) return;
-				this.#dispatchChat({
-					type: "updateMessage",
-					id: messageId,
-					value: { ...msg, content: msg.content + chunk },
-				});
-			},
-			onComplete: () => {
-				this.#set({
-					streamingMessageId: null,
-					isGenerating: false,
-					streamCancelRef: null,
-				});
-				const state = this.#get();
-				const msg = state.messagesMap[messageId];
-				if (msg) {
-					this.#dispatchChat({
-						type: "updateMessage",
-						id: messageId,
-						value: { ...msg, status: "complete" },
-					});
+	#startSSE = (sessionId: string, assistantMsgId: string) => {
+		if (this.#sseClient) {
+			this.#sseClient.close();
+			this.#sseClient = null;
+		}
+
+		const url = `${API_BASE_URL}/SessionEvents`;
+		const client = new FetchSSEClient(url, {
+			method: "POST",
+			body: { session_id: sessionId },
+			onMessage: (event) => {
+				try {
+					const data = JSON.parse(event.data) as SSEMessageEvent;
+
+					if (data.chunk) {
+						const msg = this.#get().messagesMap[assistantMsgId];
+						if (msg) {
+							this.#dispatchChat({
+								type: "updateMessage",
+								id: assistantMsgId,
+								value: { ...msg, content: msg.content + data.chunk },
+							});
+						}
+					} else if (data.content) {
+						const msg = this.#get().messagesMap[assistantMsgId];
+						if (msg) {
+							this.#dispatchChat({
+								type: "updateMessage",
+								id: assistantMsgId,
+								value: { ...msg, content: data.content },
+							});
+						}
+					}
+
+					if (data.status === "complete" || data.status === "error") {
+						const msg = this.#get().messagesMap[assistantMsgId];
+						if (msg) {
+							this.#dispatchChat({
+								type: "updateMessage",
+								id: assistantMsgId,
+								value: {
+									...msg,
+									status: data.status as MessageStatus,
+									thinking: data.thinking ?? msg.thinking,
+									toolCalls: mapToolCalls(data.tool_calls),
+									metadata: data.metadata
+										? {
+												model: data.metadata.model,
+												tokens: data.metadata.tokens,
+												latency: data.metadata.latency,
+											}
+										: msg.metadata,
+								},
+							});
+						}
+						this.#finishStream();
+						this.#sseClient?.close();
+						this.#sseClient = null;
+					}
+
+					if (data.tool_calls) {
+						const msg = this.#get().messagesMap[assistantMsgId];
+						if (msg) {
+							this.#dispatchChat({
+								type: "updateMessage",
+								id: assistantMsgId,
+								value: { ...msg, toolCalls: mapToolCalls(data.tool_calls) },
+							});
+						}
+					}
+				} catch {
+					const msg = this.#get().messagesMap[assistantMsgId];
+					if (msg && event.data) {
+						this.#dispatchChat({
+							type: "updateMessage",
+							id: assistantMsgId,
+							value: { ...msg, content: msg.content + event.data },
+						});
+					}
 				}
+			},
+			onError: (err) => {
+				console.error("SSE error:", err);
+				this.#finishStream();
 			},
 		});
 
-		this.#set({ streamCancelRef: cancel });
+		this.#set({ streamCancelRef: () => client.close() });
+		client.connect();
+		this.#sseClient = client;
+	};
+
+	#finishStream = () => {
+		this.#set({
+			streamingMessageId: null,
+			isGenerating: false,
+			streamCancelRef: null,
+		});
 	};
 
 	cancelGeneration = () => {
@@ -152,31 +285,32 @@ export class ChatActionImpl {
 				});
 			}
 		}
-		this.#set({
-			streamingMessageId: null,
-			isGenerating: false,
-			streamCancelRef: null,
-		});
+		if (this.#sseClient) {
+			this.#sseClient.close();
+			this.#sseClient = null;
+		}
+		this.#finishStream();
 	};
 
-	loadConversationMessages = (conversationId: string) => {
-		const msgs = mockMessages[conversationId];
-		if (!msgs) {
-			this.#set({ messagesMap: {}, messageIds: [] });
-			return;
-		}
+	loadConversationMessages = async (sessionDbId: number) => {
+		try {
+			const res = await sessionApi.getMessages(sessionDbId, 1, 100);
+			const items = res.data.data?.items ?? [];
+			const messages = items.map(mapBackendMessage);
 
-		const maps: Record<string, Message> = {};
-		const ids: string[] = [];
-		for (const m of msgs) {
-			if (m.status === "streaming") {
-				continue;
+			const maps: Record<string, Message> = {};
+			const ids: string[] = [];
+			for (const m of messages) {
+				if (m.status === "streaming") continue;
+				maps[m.id] = m;
+				ids.push(m.id);
 			}
-			maps[m.id] = m;
-			ids.push(m.id);
-		}
 
-		this.#set({ messagesMap: maps, messageIds: ids });
+			this.#set({ messagesMap: maps, messageIds: ids });
+		} catch (err) {
+			console.error("loadConversationMessages error:", err);
+			this.#set({ messagesMap: {}, messageIds: [] });
+		}
 	};
 
 	setInputText = (text: string) => {
@@ -216,10 +350,13 @@ export class ChatActionImpl {
 		this.#set({ selectedModel: modelId });
 	};
 
-	resendMessage = (messageId: string) => {
+	resendMessage = async (messageId: string) => {
 		const state = this.#get();
 		const oldMsg = state.messagesMap[messageId];
 		if (!oldMsg || oldMsg.role !== "assistant") return;
+
+		const { activeSessionId } = state;
+		if (!activeSessionId) return;
 
 		const now = Date.now();
 		const newMsg: Message = {
@@ -235,13 +372,27 @@ export class ChatActionImpl {
 		this.#set({
 			streamingMessageId: newMsg.id,
 			isGenerating: true,
-			tokenUsage: {
-				total: state.tokenUsage.total + Math.floor(Math.random() * 150 + 80),
-				currentSession: state.tokenUsage.currentSession + Math.floor(Math.random() * 150 + 80),
-			},
 		});
 
-		this.internal_startStream(newMsg.id);
+		this.#startSSE(activeSessionId, newMsg.id);
+	};
+
+	deleteMessage = async (messageId: number) => {
+		try {
+			await sessionApi.deleteMessage(messageId);
+			this.#dispatchChat({ type: "removeMessage", id: String(messageId) });
+		} catch (err) {
+			console.error("deleteMessage error:", err);
+		}
+	};
+
+	clearMessages = async (sessionDbId: number) => {
+		try {
+			await sessionApi.clearMessages(sessionDbId);
+			this.#set({ messagesMap: {}, messageIds: [] });
+		} catch (err) {
+			console.error("clearMessages error:", err);
+		}
 	};
 }
 
@@ -319,5 +470,5 @@ function chatReducer(state: ChatState, action: ChatActionType): ChatState {
 
 export const chatSlice: SliceCreator<ChatStore> = (...params) => ({
 	..._initialState,
-	...flattenActions<ChatAction>([createChatSlice(params[0] as SetState, params[1], params[2])]),
+	...flattenActions<ChatAction>([createChatSlice(params[0] as SetState, params[1])]),
 });

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -1,3 +1,5 @@
+import { sessionApi } from "../api/sessionApi";
+import type { BackendSession } from "../api/types";
 import type { SliceCreator } from "../types";
 import { flattenActions } from "../utils";
 
@@ -6,7 +8,9 @@ export type WorkspaceMode = "remote" | "local";
 export type Conversation = {
 	id: string;
 	title: string;
-	workspaceId: string;
+	sessionDbId: number;
+	type: string;
+	status: string;
 	createdAt: number;
 	updatedAt: number;
 };
@@ -39,6 +43,7 @@ export type LayoutState = {
 	activeWorkspaceId: string | null;
 	workspaces: Workspace[];
 	conversations: Conversation[];
+	conversationsLoaded: boolean;
 	inputFocused: boolean;
 	activeRightTab: "shortcuts" | "inbox" | "artifacts";
 	navGroups: NavGroup[];
@@ -49,39 +54,30 @@ export type LayoutState = {
 export type LayoutAction = Pick<LayoutActionImpl, keyof LayoutActionImpl>;
 export type LayoutStore = LayoutState & LayoutAction;
 
+function mapSessionToConversation(s: BackendSession): Conversation {
+	return {
+		id: s.session_id,
+		title: s.title || "未命名会话",
+		sessionDbId: s.id,
+		type: s.type,
+		status: s.status,
+		createdAt: new Date(s.created_at).getTime(),
+		updatedAt: new Date(s.updated_at).getTime(),
+	};
+}
+
 const _initialState: LayoutState = {
 	leftRailCollapsed: false,
 	rightRailCollapsed: false,
 	conversationListOpen: true,
-	activeConversationId: "conv-1",
+	activeConversationId: null,
 	activeWorkspaceId: null,
 	workspaces: [
 		{ id: "remote-1", name: "远程工作区", mode: "remote", collapsed: false },
 		{ id: "local-1", name: "本地工作区", mode: "local", collapsed: false },
 	],
-	conversations: [
-		{
-			id: "conv-1",
-			title: "代码审查讨论",
-			workspaceId: "remote-1",
-			createdAt: Date.now(),
-			updatedAt: Date.now(),
-		},
-		{
-			id: "conv-2",
-			title: "需求指派",
-			workspaceId: "remote-1",
-			createdAt: Date.now() - 3600000,
-			updatedAt: Date.now() - 3600000,
-		},
-		{
-			id: "conv-3",
-			title: "技术问答",
-			workspaceId: "local-1",
-			createdAt: Date.now() - 7200000,
-			updatedAt: Date.now() - 7200000,
-		},
-	],
+	conversations: [],
+	conversationsLoaded: false,
 	inputFocused: false,
 	activeRightTab: "shortcuts",
 	navGroups: [
@@ -120,16 +116,16 @@ type SetState = (
 	replace?: boolean,
 ) => void;
 
-export const createLayoutSlice = (set: SetState, get: () => LayoutStore, _api?: unknown) =>
-	new LayoutActionImpl(set, get, _api);
+export const createLayoutSlice = (set: SetState, get: () => LayoutStore) =>
+	new LayoutActionImpl(set, get);
 
 export class LayoutActionImpl {
 	readonly #set: SetState;
+	readonly #get: () => LayoutStore;
 
-	constructor(set: SetState, _get: () => LayoutStore, _api?: unknown) {
-		void _api;
-		void _get;
+	constructor(set: SetState, get: () => LayoutStore) {
 		this.#set = set;
+		this.#get = get;
 	}
 
 	toggleLeftRail = () => {
@@ -158,28 +154,73 @@ export class LayoutActionImpl {
 		this.#set({ activeConversationId: conversationId });
 	};
 
-	createConversation = (workspaceId: string, title: string) => {
-		const now = Date.now();
-		const newConversation: Conversation = {
-			id: `conv-${now}`,
-			title,
-			workspaceId,
-			createdAt: now,
-			updatedAt: now,
-		};
-		this.#set((state) => ({
-			conversations: [...state.conversations, newConversation],
-			activeConversationId: newConversation.id,
-		}));
-		return newConversation.id;
+	fetchConversations = async () => {
+		if (this.#get().conversationsLoaded) return;
+		try {
+			const res = await sessionApi.list({ page: 1, per_page: 50 });
+			const items = res.data.data?.items ?? [];
+			this.#set({
+				conversations: items.map(mapSessionToConversation),
+				conversationsLoaded: true,
+			});
+		} catch (err) {
+			console.error("fetchConversations error:", err);
+		}
 	};
 
-	deleteConversation = (conversationId: string) => {
-		this.#set((state) => ({
-			conversations: state.conversations.filter((c) => c.id !== conversationId),
-			activeConversationId:
-				state.activeConversationId === conversationId ? null : state.activeConversationId,
-		}));
+	createConversation = async (title: string) => {
+		try {
+			const res = await sessionApi.create({
+				type: "chat",
+				title: title || "新会话",
+			});
+			const session = res.data.data;
+			if (!session) throw new Error("No session data returned");
+			const conv = mapSessionToConversation(session);
+			this.#set((state) => ({
+				conversations: [conv, ...state.conversations],
+				activeConversationId: conv.id,
+				conversationsLoaded: true,
+			}));
+			return conv.id;
+		} catch (err) {
+			console.error("createConversation error:", err);
+			return null;
+		}
+	};
+
+	deleteConversation = async (conversationId: string) => {
+		const state = this.#get();
+		const conv = state.conversations.find((c) => c.id === conversationId);
+		if (!conv) return;
+
+		try {
+			await sessionApi.delete(conv.sessionDbId);
+			this.#set((state) => ({
+				conversations: state.conversations.filter((c) => c.id !== conversationId),
+				activeConversationId:
+					state.activeConversationId === conversationId ? null : state.activeConversationId,
+			}));
+		} catch (err) {
+			console.error("deleteConversation error:", err);
+		}
+	};
+
+	updateConversationTitle = async (conversationId: string, title: string) => {
+		const state = this.#get();
+		const conv = state.conversations.find((c) => c.id === conversationId);
+		if (!conv) return;
+
+		try {
+			await sessionApi.update({ id: conv.sessionDbId, title });
+			this.#set((state) => ({
+				conversations: state.conversations.map((c) =>
+					c.id === conversationId ? { ...c, title, updatedAt: Date.now() } : c,
+				),
+			}));
+		} catch (err) {
+			console.error("updateConversationTitle error:", err);
+		}
 	};
 
 	setInputFocused = (focused: boolean) => {
@@ -209,5 +250,5 @@ export class LayoutActionImpl {
 
 export const layoutSlice: SliceCreator<LayoutStore> = (...params) => ({
 	..._initialState,
-	...flattenActions<LayoutAction>([createLayoutSlice(params[0] as SetState, params[1], params[2])]),
+	...flattenActions<LayoutAction>([createLayoutSlice(params[0] as SetState, params[1])]),
 });

--- a/frontend/packages/store/slices/topicSlice.ts
+++ b/frontend/packages/store/slices/topicSlice.ts
@@ -87,6 +87,7 @@ export class TopicActionImpl {
 		this.#set({ topicsInit: true });
 
 		try {
+			this.#set({ topicsInit: true });
 		} catch (error) {
 			this.#set({ topicsInit: false });
 			throw error;

--- a/frontend/packages/ui/lib/fetch-sse.ts
+++ b/frontend/packages/ui/lib/fetch-sse.ts
@@ -1,0 +1,134 @@
+export type FetchSSEStatus = "connecting" | "open" | "closed";
+
+export type FetchSSEOptions = {
+	method?: string;
+	body?: unknown;
+	headers?: Record<string, string>;
+	withCredentials?: boolean;
+	onOpen?: () => void;
+	onMessage?: (event: { type?: string; data: string; id?: string; retry?: number }) => void;
+	onError?: (error: Error) => void;
+	onClose?: () => void;
+};
+
+export class FetchSSEClient {
+	private url: string;
+	private options: FetchSSEOptions;
+	private status: FetchSSEStatus = "closed";
+	private abortController: AbortController | null = null;
+	private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+	constructor(url: string, options: FetchSSEOptions = {}) {
+		this.url = url;
+		this.options = {
+			method: "POST",
+			...options,
+		};
+	}
+
+	async connect(): Promise<void> {
+		if (this.status === "open" || this.status === "connecting") return;
+
+		this.status = "connecting";
+		this.abortController = new AbortController();
+
+		const fetchOptions: RequestInit = {
+			method: this.options.method ?? "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "text/event-stream",
+				...this.options.headers,
+			},
+			body: this.options.body ? JSON.stringify(this.options.body) : undefined,
+			signal: this.abortController.signal,
+		};
+
+		if (this.options.withCredentials) {
+			fetchOptions.credentials = "include";
+		}
+
+		try {
+			const response = await fetch(this.url, fetchOptions);
+
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+			}
+
+			if (!response.body) {
+				throw new Error("Response body is null");
+			}
+
+			this.status = "open";
+			this.options.onOpen?.();
+
+			this.reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+
+			while (true) {
+				const { done, value } = await this.reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+
+				const lines = buffer.split("\n");
+				buffer = lines.pop() ?? "";
+
+				let currentEvent: { type?: string; data: string; id?: string; retry?: number } = {
+					data: "",
+				};
+
+				for (const line of lines) {
+					if (line.startsWith("event:")) {
+						currentEvent.type = line.slice(6).trim();
+					} else if (line.startsWith("data:")) {
+						currentEvent.data += line.slice(5).trim();
+					} else if (line.startsWith("id:")) {
+						currentEvent.id = line.slice(3).trim();
+					} else if (line.startsWith("retry:")) {
+						currentEvent.retry = Number.parseInt(line.slice(6).trim(), 10);
+					} else if (line === "") {
+						if (currentEvent.data) {
+							this.options.onMessage?.(currentEvent);
+						}
+						currentEvent = { data: "" };
+					}
+				}
+			}
+
+			this.close();
+		} catch (err) {
+			if ((err as Error).name === "AbortError") {
+				this.close();
+				return;
+			}
+			this.status = "closed";
+			this.options.onError?.(err as Error);
+			this.options.onClose?.();
+		}
+	}
+
+	close(): void {
+		this.status = "closed";
+
+		if (this.reader) {
+			this.reader.cancel().catch(() => { /* ignore cancel errors */ });
+			this.reader = null;
+		}
+
+		if (this.abortController) {
+			this.abortController.abort();
+			this.abortController = null;
+		}
+
+		this.options.onClose?.();
+	}
+
+	getStatus(): FetchSSEStatus {
+		return this.status;
+	}
+}
+
+export function createFetchSSE(url: string, options?: FetchSSEOptions): FetchSSEClient {
+	return new FetchSSEClient(url, options);
+}

--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -20,6 +20,7 @@
     "./lib/request": "./lib/request.ts",
     "./lib/sse": "./lib/sse.ts",
     "./lib/websocket": "./lib/websocket.ts",
+    "./lib/fetch-sse": "./lib/fetch-sse.ts",
     "./styles/tokens.css": "./styles/tokens.css",
     "./styles/base.css": "./styles/base.css"
   },


### PR DESCRIPTION
- 新增 API 服务层 (packages/store/api/)：封装 Session 和 DigitalAssistant 全部后端接口
- 新增 FetchSSEClient (packages/ui/lib/fetch-sse.ts)：支持 POST + JSON body 方式的 SSE 连接
- 改造 layoutSlice：会话列表从真实 API 加载，创建/删除/更新标题对接后端
- 改造 chatSlice：消息发送对接 AddMessage API，流式响应改用 FetchSSEClient SSE，消息加载对接 GetSessionMessages API
- 更新 ConversationListPanel (web + desktop)：使用真实 API 加载会话和消息