### PR TITLE
refactor: change event bus to use *nats.Msg directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ docs/swagger.json
 docs/swagger.yaml
 singer
 .worktrees
+frontend/.pnpm-store
+.pnpm-store

--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,9 @@ dev-worker: build
 	LEROS_DEV=true ./bundles/leros worker --worker-id 1 --config ./deployments/dev/worker.config.yaml
 
 dev-frontend:
-	cd deployments/dev && ./dev-frontend.sh
+	-docker rm -f leros-dev-frontend || true
+	docker run -it --name leros-dev-frontend \
+	 --network host \
+	 -v $(PWD)/frontend:/app \
+	 -w /app \
+	 registry.yygu.cn/base/node:24 bash 

--- a/backend/internal/api/handler/session_handler.go
+++ b/backend/internal/api/handler/session_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/ygpkg/yg-go/logs"
 
 	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/api/dto"
@@ -236,22 +237,28 @@ func (h *SessionHandler) SessionEvents(ctx *gin.Context) {
 
 	go func() {
 		defer close(eventChan)
-		if err := h.service.StreamSessionEvents(ctx, req.SessionID, req.LastSequence, sink); err != nil {
+		err := h.service.StreamSessionEvents(ctx, req.SessionID, req.LastSequence, sink)
+		if err != nil {
+			logs.ErrorContextf(ctx, "failed to stream session events for session %s: %v", req.SessionID, err)
 			ctx.SSEvent("error", dto.Error(dto.CodeInternalError, err.Error()))
 		}
+		logs.DebugContextf(ctx, "session event stream goroutine exiting for session %s", req.SessionID)
 	}()
 
 	for {
 		select {
 		case event, ok := <-eventChan:
 			if !ok {
+				logs.WarnContextf(ctx, "event channel closed for session %s", req.SessionID)
 				return
 			}
 			ctx.SSEvent(string(event.Type), event.Content)
 			ctx.Writer.Flush()
 		case <-ctx.Writer.CloseNotify():
+			logs.InfoContextf(ctx, "client closed connection for session %s event stream", req.SessionID)
 			return
 		case <-ctx.Done():
+			logs.InfoContextf(ctx, "client closed connection for session %s event stream (Done)", req.SessionID)
 			return
 		}
 	}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -74,7 +74,7 @@ func SetupRouter(cfg config.Config, eventbus eventbus.EventBus, db *gorm.DB) *gi
 		logs.Info("Digital assistant routes registered successfully")
 
 		inferrer := service.NewDefaultAssistantInferrer(1)
-		sessionService := service.NewSessionService(db, eventbus, eventbus, inferrer)
+		sessionService := service.NewSessionService(db, eventbus, inferrer)
 		handler.RegisterSessionRoutes(v1, sessionService)
 		logs.Info("Session routes registered successfully")
 	}

--- a/backend/internal/eventengine/orchestrator.go
+++ b/backend/internal/eventengine/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nats-io/nats.go"
 	"github.com/insmtx/Leros/backend/internal/agent"
 	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
 	interactionevent "github.com/insmtx/Leros/backend/pkg/event"
@@ -57,16 +58,10 @@ func (o *Orchestrator) Start(ctx context.Context) error {
 	for topic, handler := range o.handlers {
 		go func(t string, h EventHandlerFunc) {
 			logs.InfoContextf(ctx, "Starting subscription for topic: %s", t)
-			err := o.subscriber.Subscribe(ctx, t, func(event any) {
-				// 将通用interface{}转换为	interactionevent.Event
-				jsonBytes, err := json.Marshal(event)
-				if err != nil {
-					logs.ErrorContextf(ctx, "Failed to marshal event to JSON: %v", err)
-					return
-				}
-
+			err := o.subscriber.Subscribe(ctx, t, func(msg *nats.Msg) {
+				// 将 nats.Msg 转换为 interactionevent.Event
 				var interactionEvent interactionevent.Event
-				if err := json.Unmarshal(jsonBytes, &interactionEvent); err != nil {
+				if err := json.Unmarshal(msg.Data, &interactionEvent); err != nil {
 					logs.ErrorContextf(ctx, "Failed to unmarshal event: %v", err)
 					return
 				}

--- a/backend/internal/eventengine/orchestrator_test.go
+++ b/backend/internal/eventengine/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/nats-io/nats.go"
 	"github.com/insmtx/Leros/backend/internal/agent"
 	interactionevent "github.com/insmtx/Leros/backend/pkg/event"
 )
@@ -70,7 +71,7 @@ func TestOrchestratorRegisterAndGet(t *testing.T) {
 // 简单的mock subscriber实现
 type mockSubscriber struct{}
 
-func (ms *mockSubscriber) Subscribe(ctx context.Context, topic string, handler func(event any)) error {
+func (ms *mockSubscriber) Subscribe(ctx context.Context, topic string, handler func(msg *nats.Msg)) error {
 	return nil
 }
 

--- a/backend/internal/infra/mq/bus.go
+++ b/backend/internal/infra/mq/bus.go
@@ -4,7 +4,10 @@
 // 支持多种事件总线实现，如 RabbitMQ、Redis 等。
 package mq
 
-import "context"
+import (
+	"context"
+	"github.com/nats-io/nats.go"
+)
 
 // Publisher 是事件发布者接口，定义了向指定主题发布事件的方法
 type Publisher interface {
@@ -21,11 +24,19 @@ type RealtimePublisher interface {
 // Subscriber 是事件订阅者接口，定义了订阅指定主题事件的方法
 type Subscriber interface {
 	// Subscribe 订阅指定主题的事件，并使用提供的处理函数处理收到的事件
-	Subscribe(ctx context.Context, topic string, handler func(event any)) error
+	Subscribe(ctx context.Context, topic string, handler func(msg *nats.Msg)) error
+}
+
+// RealtimeSubscriber 是实时消息订阅者接口，用于接收 PublishRealtime 发布的消息。
+type RealtimeSubscriber interface {
+	// SubscribeRealtime 订阅实时消息主题，不依赖 JetStream 持久化。
+	SubscribeRealtime(ctx context.Context, topic string, handler func(msg *nats.Msg)) error
 }
 
 // EventBus 组合了发布和订阅能力，提供完整的事件总线功能
 type EventBus interface {
 	Publisher
 	Subscriber
+	RealtimePublisher
+	RealtimeSubscriber
 }

--- a/backend/internal/infra/mq/nats.go
+++ b/backend/internal/infra/mq/nats.go
@@ -113,7 +113,7 @@ func (p *natsPublisher) PublishRealtimeWithContext(ctx context.Context, topic st
 }
 
 // SubscribeWithContext 在给定上下文环境中订阅特定主题的消息
-func (p *natsPublisher) SubscribeWithContext(ctx context.Context, topic string, handler func(event any)) error {
+func (p *natsPublisher) SubscribeWithContext(ctx context.Context, topic string, handler func(msg *nats.Msg)) error {
 	// 声明 Stream (如果不存在)
 	streamName := streamNameFromTopic(topic)
 	_, err := p.js.AddStream(&nats.StreamConfig{
@@ -128,13 +128,6 @@ func (p *natsPublisher) SubscribeWithContext(ctx context.Context, topic string, 
 	// 创建持久化订阅
 	durableName := fmt.Sprintf("%s_SUBSCRIBER", strings.ReplaceAll(topic, ".", "_"))
 	sub, err := p.js.Subscribe(topic, func(msg *nats.Msg) {
-		// 解析收到的消息
-		var message interface{}
-		if err := json.Unmarshal(msg.Data, &message); err != nil {
-			logs.ErrorContextf(ctx, "Failed to unmarshal message for topic '%s': %v", topic, err)
-			return
-		}
-
 		// Ack before invoking the handler so long-running worker tasks do not
 		// exceed JetStream AckWait and get redelivered while still running.
 		if err := msg.Ack(); err != nil {
@@ -143,7 +136,7 @@ func (p *natsPublisher) SubscribeWithContext(ctx context.Context, topic string, 
 		}
 
 		// 调用用户定义的处理函数
-		handler(message)
+		handler(msg)
 	},
 		nats.Durable(durableName),
 		nats.ManualAck(),
@@ -176,8 +169,37 @@ func (p *natsPublisher) PublishRealtime(ctx context.Context, topic string, event
 }
 
 // Subscribe implements the eventbus.Subscriber interface
-func (p *natsPublisher) Subscribe(ctx context.Context, topic string, handler func(event any)) error {
+func (p *natsPublisher) Subscribe(ctx context.Context, topic string, handler func(msg *nats.Msg)) error {
 	return p.SubscribeWithContext(ctx, topic, handler)
+}
+
+// SubscribeRealtime implements the eventbus.RealtimeSubscriber interface
+func (p *natsPublisher) SubscribeRealtime(ctx context.Context, topic string, handler func(msg *nats.Msg)) error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return fmt.Errorf("NATS client is closed")
+	}
+	p.mu.Unlock()
+
+	// 使用 Core NATS 订阅，不依赖 JetStream
+	sub, err := p.conn.Subscribe(topic, func(msg *nats.Msg) {
+		handler(msg)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to realtime topic '%s': %w", topic, err)
+	}
+
+	// 在 context 取消时清理订阅
+	go func() {
+		<-ctx.Done()
+		if err := sub.Unsubscribe(); err != nil {
+			logs.WarnContextf(ctx, "Failed to unsubscribe from realtime topic '%s': %v", topic, err)
+		}
+		logs.InfoContextf(ctx, "Unsubscribed from realtime topic: %s", topic)
+	}()
+
+	return nil
 }
 
 // Close 关闭 NATS 连接并释放资源

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"gorm.io/gorm"
 
 	"github.com/insmtx/Leros/backend/internal/agent/eventtypes"
@@ -25,18 +26,16 @@ import (
 var _ contract.SessionService = (*sessionService)(nil)
 
 type sessionService struct {
-	db         *gorm.DB
-	subscriber eventbus.Subscriber
-	publisher  eventbus.Publisher
-	inferrer   AssistantInferrer
+	db       *gorm.DB
+	eventbus eventbus.EventBus
+	inferrer AssistantInferrer
 }
 
-func NewSessionService(db *gorm.DB, subscriber eventbus.Subscriber, publisher eventbus.Publisher, inferrer AssistantInferrer) contract.SessionService {
+func NewSessionService(db *gorm.DB, eventbus eventbus.EventBus, inferrer AssistantInferrer) contract.SessionService {
 	return &sessionService{
-		db:         db,
-		subscriber: subscriber,
-		publisher:  publisher,
-		inferrer:   inferrer,
+		db:       db,
+		eventbus: eventbus,
+		inferrer: inferrer,
 	}
 }
 
@@ -377,7 +376,7 @@ func (s *sessionService) AddMessage(ctx context.Context, sessionID uint, req *co
 		},
 	}
 
-	if err := s.publisher.Publish(ctx, topic, messagePayload); err != nil {
+	if err := s.eventbus.Publish(ctx, topic, messagePayload); err != nil {
 		logs.ErrorContextf(ctx, "Failed to publish message to assistant %d: %v", session.AllocatedAssistantID, err)
 		return nil, fmt.Errorf("failed to publish message to assistant: %w", err)
 	}
@@ -463,50 +462,68 @@ func (s *sessionService) StreamSessionEvents(ctx context.Context, sessionID stri
 	if err != nil {
 		return fmt.Errorf("failed to construct session result stream topic: %w", err)
 	}
-	return s.subscriber.Subscribe(ctx, topic, func(event any) {
-		switch msg := event.(type) {
-		case eventtypes.MessageStreamMessage:
-			if msg.Body.Seq <= lastSequence {
-				return
-			}
+	err = s.eventbus.SubscribeRealtime(ctx, topic, func(msg *nats.Msg) {
+		var streamMsg eventtypes.MessageStreamMessage
+		if err := json.Unmarshal(msg.Data, &streamMsg); err != nil {
+			logs.WarnContextf(ctx, "failed to unmarshal to MessageStreamMessage: %v", err)
+			return
+		}
 
-			se := dto.SessionEvent{
-				SessionID: msg.Route.SessionID,
-				Sequence:  msg.Body.Seq,
-				Timestamp: msg.CreatedAt.UnixMilli(),
-			}
+		// 现在处理正确类型的消息
+		if streamMsg.Body.Seq <= lastSequence {
+			logs.DebugContextf(ctx, "skipping old message for session %s: seq=%d lastSequence=%d", sessionID, streamMsg.Body.Seq, lastSequence)
+			return
+		}
 
-			switch msg.Body.Event {
-			case eventtypes.StreamEventMessageDelta:
-				se.Type = dto.SessionEventTypeMessageDelta
-				se.Payload = dto.MessageDeltaPayload{
-					Role:    string(msg.Body.Payload.Role),
-					Content: msg.Body.Payload.Content,
-				}
-			case eventtypes.StreamEventToolCallStarted:
-				se.Type = dto.SessionEventTypeToolCallStarted
-				if tc := msg.Body.Payload.ToolCall; tc != nil {
-					se.Payload = dto.ToolCallDeltaPayload{
-						ID:   tc.ID,
-						Name: tc.Name,
-					}
-				}
-			case eventtypes.StreamEventRunStarted:
-				se.Type = dto.SessionEventTypeRunStarted
-			case eventtypes.StreamEventRunCompleted:
-				se.Type = dto.SessionEventTypeRunCompleted
-			case eventtypes.StreamEventRunFailed:
-				se.Type = dto.SessionEventTypeRunFailed
-			default:
-				logs.Warnf("unknown stream event type: %v", msg.Body.Event)
-				return
+		se := dto.SessionEvent{
+			SessionID: streamMsg.Route.SessionID,
+			Sequence:  streamMsg.Body.Seq,
+			Timestamp: streamMsg.CreatedAt.UnixMilli(),
+		}
+
+		switch streamMsg.Body.Event {
+		case eventtypes.StreamEventMessageDelta:
+			se.Type = dto.SessionEventTypeMessageDelta
+			se.Payload = dto.MessageDeltaPayload{
+				Role:    string(streamMsg.Body.Payload.Role),
+				Content: streamMsg.Body.Payload.Content,
 			}
-			_ = sink.Emit(ctx, &events.Event{
-				Type:    events.EventType(se.Type),
-				Content: toJSONString(se),
-			})
+		case eventtypes.StreamEventToolCallStarted:
+			se.Type = dto.SessionEventTypeToolCallStarted
+			if tc := streamMsg.Body.Payload.ToolCall; tc != nil {
+				se.Payload = dto.ToolCallDeltaPayload{
+					ID:   tc.ID,
+					Name: tc.Name,
+				}
+			}
+		case eventtypes.StreamEventRunStarted:
+			se.Type = dto.SessionEventTypeRunStarted
+		case eventtypes.StreamEventRunCompleted:
+			se.Type = dto.SessionEventTypeRunCompleted
+		case eventtypes.StreamEventRunFailed:
+			se.Type = dto.SessionEventTypeRunFailed
+		default:
+			logs.WarnContextf(ctx, "unknown stream event type: %v", streamMsg.Body.Event)
+			return
+		}
+		err = sink.Emit(ctx, &events.Event{
+			Type:    events.EventType(se.Type),
+			Content: toJSONString(se),
+		})
+		if err != nil {
+			logs.ErrorContextf(ctx, "failed to emit session event for session %s: %v", sessionID, err)
 		}
 	})
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to session result stream topic: %w", err)
+	}
+	logs.DebugContextf(ctx, "subscribed to session result stream topic: %s", topic)
+
+	// 阻塞等待 context 结束，这样 goroutine 不会立即退出
+	<-ctx.Done()
+	logs.DebugContextf(ctx, "session event stream ended for session: %s", sessionID)
+
+	return nil
 }
 
 func convertToContractSession(session *types.Session) *contract.Session {

--- a/backend/internal/service/session_service_test.go
+++ b/backend/internal/service/session_service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/nats-io/nats.go"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -28,16 +29,47 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
+// mockEventBus 是一个简单的 Mock 实现，用于测试
+type mockEventBus struct{}
+
+func (m *mockEventBus) Publish(ctx context.Context, topic string, event any) error {
+	return nil
+}
+
+func (m *mockEventBus) PublishRealtime(ctx context.Context, topic string, event any) error {
+	return nil
+}
+
+func (m *mockEventBus) Subscribe(ctx context.Context, topic string, handler func(msg *nats.Msg)) error {
+	return nil
+}
+
+func (m *mockEventBus) SubscribeRealtime(ctx context.Context, topic string, handler func(msg *nats.Msg)) error {
+	return nil
+}
+
 func setupTestService(t *testing.T) contract.SessionService {
 	t.Helper()
 	db := setupTestDB(t)
-	return NewSessionService(db, nil, nil, nil)
+	return NewSessionService(db, &mockEventBus{}, nil)
 }
 
 func setupTestServiceWithSubscriber(t *testing.T, subscriber mq.Subscriber) contract.SessionService {
 	t.Helper()
 	db := setupTestDB(t)
-	return NewSessionService(db, subscriber, nil, nil)
+	// 使用 mockEventBus 包装 subscriber
+	eb := &struct {
+		mq.Publisher
+		mq.Subscriber
+		mq.RealtimePublisher
+		mq.RealtimeSubscriber
+	}{
+		RealtimeSubscriber: &mockEventBus{},
+		RealtimePublisher:  &mockEventBus{},
+		Publisher:          &mockEventBus{},
+		Subscriber:         subscriber,
+	}
+	return NewSessionService(db, eb, nil)
 }
 
 func setupTestContextWithoutCaller(t *testing.T) context.Context {

--- a/backend/internal/worker/taskconsumer/consumer.go
+++ b/backend/internal/worker/taskconsumer/consumer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nats-io/nats.go"
 	"github.com/insmtx/Leros/backend/internal/agent"
 	agentevents "github.com/insmtx/Leros/backend/internal/agent/events"
 	"github.com/insmtx/Leros/backend/internal/agent/eventtypes"
@@ -64,39 +65,39 @@ func (c *Consumer) TaskTopic() string {
 func (c *Consumer) Start(ctx context.Context) error {
 	topic := c.TaskTopic()
 	logs.InfoContextf(ctx, "Starting worker task subscription: %s", topic)
-	return c.subscriber.Subscribe(ctx, topic, func(event any) {
+	return c.subscriber.Subscribe(ctx, topic, func(msg *nats.Msg) {
 		logs.InfoContextf(ctx, "Received worker task event from topic: %s", topic)
-		if err := c.handleEvent(ctx, event); err != nil {
+		if err := c.handleEvent(ctx, msg); err != nil {
 			logs.ErrorContextf(ctx, "Failed to handle worker task: %v", err)
 		}
 	})
 }
 
-func (c *Consumer) handleEvent(ctx context.Context, event any) error {
-	msg, err := decodeWorkerTask(event)
+func (c *Consumer) handleEvent(ctx context.Context, msg *nats.Msg) error {
+	taskMsg, err := decodeWorkerTask(msg)
 	if err != nil {
 		return err
 	}
-	if err := c.validateRoute(msg); err != nil {
+	if err := c.validateRoute(taskMsg); err != nil {
 		return err
 	}
-	if msg.Body.TaskType != eventtypes.TaskTypeAgentRun {
-		return fmt.Errorf("unsupported worker task type %q", msg.Body.TaskType)
+	if taskMsg.Body.TaskType != eventtypes.TaskTypeAgentRun {
+		return fmt.Errorf("unsupported worker task type %q", taskMsg.Body.TaskType)
 	}
 
 	logs.InfoContextf(ctx,
 		"Received worker task: msg_id=%s task_id=%s run_id=%s org_id=%s worker_id=%s session_id=%s task_type=%s",
-		msg.ID,
-		msg.Trace.TaskID,
-		msg.Trace.RunID,
-		msg.Route.OrgID,
-		msg.Route.WorkerID,
-		msg.Route.SessionID,
-		msg.Body.TaskType,
+		taskMsg.ID,
+		taskMsg.Trace.TaskID,
+		taskMsg.Trace.RunID,
+		taskMsg.Route.OrgID,
+		taskMsg.Route.WorkerID,
+		taskMsg.Route.SessionID,
+		taskMsg.Body.TaskType,
 	)
 
-	req := RequestFromWorkerTask(msg)
-	req.EventSink = NewMQStreamSink(c.publisher, msg)
+	req := RequestFromWorkerTask(taskMsg)
+	req.EventSink = NewMQStreamSink(c.publisher, taskMsg)
 
 	logs.InfoContextf(ctx,
 		"Starting worker task run: task_id=%s run_id=%s runtime=%s assistant_id=%s agent_id=%s",
@@ -104,7 +105,7 @@ func (c *Consumer) handleEvent(ctx context.Context, event any) error {
 		req.RunID,
 		req.Runtime.Kind,
 		req.Assistant.ID,
-		msg.Body.Execution.AgentID,
+		taskMsg.Body.Execution.AgentID,
 	)
 
 	result, err := c.runner.Run(ctx, req)
@@ -117,19 +118,15 @@ func (c *Consumer) handleEvent(ctx context.Context, event any) error {
 	return nil
 }
 
-func decodeWorkerTask(event any) (eventtypes.WorkerTaskMessage, error) {
-	var msg eventtypes.WorkerTaskMessage
-	body, err := json.Marshal(event)
-	if err != nil {
-		return msg, fmt.Errorf("marshal worker task: %w", err)
+func decodeWorkerTask(msg *nats.Msg) (eventtypes.WorkerTaskMessage, error) {
+	var taskMsg eventtypes.WorkerTaskMessage
+	if err := json.Unmarshal(msg.Data, &taskMsg); err != nil {
+		return taskMsg, fmt.Errorf("unmarshal worker task: %w", err)
 	}
-	if err := json.Unmarshal(body, &msg); err != nil {
-		return msg, fmt.Errorf("unmarshal worker task: %w", err)
+	if taskMsg.Type != "" && taskMsg.Type != eventtypes.MessageTypeWorkerTask {
+		return taskMsg, fmt.Errorf("unexpected worker task message type %q", taskMsg.Type)
 	}
-	if msg.Type != "" && msg.Type != eventtypes.MessageTypeWorkerTask {
-		return msg, fmt.Errorf("unexpected worker task message type %q", msg.Type)
-	}
-	return msg, nil
+	return taskMsg, nil
 }
 
 func (c *Consumer) validateRoute(msg eventtypes.WorkerTaskMessage) error {

--- a/backend/pkg/dm/topic.go
+++ b/backend/pkg/dm/topic.go
@@ -31,3 +31,15 @@ func SessionResultStreamTopic(orgid uint, sessionid string) (string, error) {
 	orgidStr := fmt.Sprintf("%d", orgid)
 	return topic().Org(orgidStr).Session(sessionid).Message().Stream().Build(), nil
 }
+
+// SessionCompletedTopic 构造会话完成 topic，格式为 "org.{org_id}.session.{session_id}.completed"。
+func SessionCompletedTopic(orgid uint, sessionid string) (string, error) {
+	if orgid == 0 {
+		return "", errors.New("orgid is required")
+	}
+	if sessionid == "" {
+		return "", errors.New("sessionid is required")
+	}
+	orgidStr := fmt.Sprintf("%d", orgid)
+	return topic().Org(orgidStr).Session(sessionid).Completed().Build(), nil
+}

--- a/backend/pkg/dm/topic_builder.go
+++ b/backend/pkg/dm/topic_builder.go
@@ -50,6 +50,11 @@ func (b topicBuilder) Message() topicBuilder {
 	return b.Add("message")
 }
 
+// Completed 追加 completed 字段片段。
+func (b topicBuilder) Completed() topicBuilder {
+	return b.Add("completed")
+}
+
 // Stream 追加 stream 字段片段。
 func (b topicBuilder) Stream() topicBuilder {
 	return b.Add("stream")

--- a/frontend/apps/web/next.config.ts
+++ b/frontend/apps/web/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
 	transpilePackages: ["@leros/ui", "@leros/store"],
-	allowedDevOrigins: ["172.16.0.160"],
+	allowedDevOrigins: ["172.16.0.160","*","*.*.*.*","192.144.198.60"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Update Subscriber and RealtimeSubscriber interfaces to use *nats.Msg
- Modify Subscribe and SubscribeRealtime implementations
- Update session service to handle *nats.Msg directly
- Update worker task consumer and event engine
- Simplify message deserialization process