### PR TITLE
fix(pagination): 统一分页接口为 Offset/Limit 模式，修复 ListSessions 等接口返回空数据

### DIFF
--- a/backend/internal/api/contract/digital_assistant_type.go
+++ b/backend/internal/api/contract/digital_assistant_type.go
@@ -150,17 +150,17 @@ type UpdateDigitalAssistantStatusRequest struct {
 
 // ListDigitalAssistantRequest 查询数字助手列表请求
 type ListDigitalAssistantRequest struct {
-	Status  *string `form:"status,omitempty"`
-	Keyword *string `form:"keyword,omitempty"`
-	Page    int     `form:"page,default=1"`
-	PerPage int     `form:"per_page,default=20"`
+	Status  *string `json:"status,omitempty"`
+	Keyword *string `json:"keyword,omitempty"`
+	Pagination
 }
 
 // DigitalAssistantList 数字助手列表响应
 type DigitalAssistantList struct {
-	Total int64              `json:"total"`
-	Page  int                `json:"page"`
-	Items []DigitalAssistant `json:"items"`
+	Total  int64              `json:"total"`
+	Offset int                `json:"offset"`
+	Limit  int                `json:"limit"`
+	Items  []DigitalAssistant `json:"items"`
 }
 
 // DigitalAssistantDetail 数字助手详情响应

--- a/backend/internal/api/contract/llm_model_type.go
+++ b/backend/internal/api/contract/llm_model_type.go
@@ -52,18 +52,18 @@ type UpdateLLMModelRequest struct {
 
 // ListLLMModelsRequest 查询LLM模型配置列表请求
 type ListLLMModelsRequest struct {
-	Provider *string `json:"provider,omitempty" form:"provider,omitempty"`
-	Status   *string `json:"status,omitempty" form:"status,omitempty"`
-	Keyword  *string `json:"keyword,omitempty" form:"keyword,omitempty"`
-	Page     int     `json:"page,omitempty" form:"page,default=1"`
-	PerPage  int     `json:"per_page,omitempty" form:"per_page,default=20"`
+	Provider *string `json:"provider,omitempty"`
+	Status   *string `json:"status,omitempty"`
+	Keyword  *string `json:"keyword,omitempty"`
+	Pagination
 }
 
 // LLMModelList LLM模型配置列表响应
 type LLMModelList struct {
-	Total int64      `json:"total"`
-	Page  int        `json:"page"`
-	Items []LLMModel `json:"items"`
+	Total  int64      `json:"total"`
+	Offset int        `json:"offset"`
+	Limit  int        `json:"limit"`
+	Items  []LLMModel `json:"items"`
 }
 
 // TestLLMModelRequest 测试LLM模型配置请求

--- a/backend/internal/api/contract/pagination.go
+++ b/backend/internal/api/contract/pagination.go
@@ -1,0 +1,25 @@
+package contract
+
+import (
+	apiobj "github.com/ygpkg/yg-go/apis/apiobj"
+)
+
+// Pagination pagination request base
+type Pagination struct {
+	Offset  int `json:"offset,omitempty"`
+	Limit   int `json:"limit,omitempty"`
+	ListAll bool `json:"list_all,omitempty"`
+}
+
+// Fill 设置分页默认值，行为同 apiobj.PageQuery.Fill
+func (p *Pagination) Fill() {
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
+	if p.Limit <= 0 || p.Limit > apiobj.PageMaxCount {
+		p.Limit = apiobj.DefaultPageSize
+	}
+	if p.ListAll {
+		p.Limit = apiobj.PageMaxCount
+	}
+}

--- a/backend/internal/api/contract/session_type.go
+++ b/backend/internal/api/contract/session_type.go
@@ -25,13 +25,12 @@ type UpdateSessionRequest struct {
 
 // ListSessionsRequest 查询会话列表请求
 type ListSessionsRequest struct {
-	Type          *string `form:"type,omitempty"`
-	Status        *string `form:"status,omitempty"`
-	AssistantID   *uint   `form:"assistant_id,omitempty"`
-	AssistantCode *string `form:"assistant_code,omitempty"`
-	Keyword       *string `form:"keyword,omitempty"`
-	Page          int     `form:"page,default=1"`
-	PerPage       int     `form:"per_page,default=20"`
+	Type          *string `json:"type,omitempty"`
+	Status        *string `json:"status,omitempty"`
+	AssistantID   *uint   `json:"assistant_id,omitempty"`
+	AssistantCode *string `json:"assistant_code,omitempty"`
+	Keyword       *string `json:"keyword,omitempty"`
+	Pagination
 }
 
 // AddMessageRequest 添加消息请求
@@ -85,9 +84,10 @@ type SessionMessage struct {
 
 // SessionList 会话列表响应
 type SessionList struct {
-	Total int64     `json:"total"`
-	Page  int       `json:"page"`
-	Items []Session `json:"items"`
+	Total  int64     `json:"total"`
+	Offset int       `json:"offset"`
+	Limit  int       `json:"limit"`
+	Items  []Session `json:"items"`
 }
 
 // MessageList 消息列表响应

--- a/backend/internal/api/handler/digital_assistant_handler.go
+++ b/backend/internal/api/handler/digital_assistant_handler.go
@@ -209,6 +209,8 @@ func (h *DigitalAssistantHandler) ListDigitalAssistant(ctx *gin.Context) {
 		return
 	}
 
+	req.Pagination.Fill()
+
 	result, err := h.service.ListDigitalAssistant(ctx, &req)
 	if err != nil {
 		if err.Error() == "user not authenticated or org not set" {

--- a/backend/internal/api/handler/llm_model_handler.go
+++ b/backend/internal/api/handler/llm_model_handler.go
@@ -213,6 +213,8 @@ func (h *LLMModelHandler) ListLLMModels(ctx *gin.Context) {
 		return
 	}
 
+	req.Pagination.Fill()
+
 	result, err := h.service.ListLLMModels(ctx, &req)
 	if err != nil {
 		handleLLMModelServiceError(ctx, err)

--- a/backend/internal/api/handler/session_handler.go
+++ b/backend/internal/api/handler/session_handler.go
@@ -195,6 +195,8 @@ func (h *SessionHandler) ListSessions(ctx *gin.Context) {
 		return
 	}
 
+	req.Pagination.Fill()
+
 	result, err := h.service.ListSessions(ctx, &req)
 	if err != nil {
 		handleSessionServiceError(ctx, err)

--- a/backend/internal/infra/db/digital_assistant_dao.go
+++ b/backend/internal/infra/db/digital_assistant_dao.go
@@ -65,7 +65,7 @@ func DigitalAssistantCodeExists(ctx context.Context, db *gorm.DB, code string, e
 }
 
 // ListDigitalAssistant 分页查询数字助手列表
-func ListDigitalAssistant(ctx context.Context, db *gorm.DB, orgID *uint, ownerID *uint, status *string, keyword *string, page, perPage int) ([]*types.DigitalAssistant, int64, error) {
+func ListDigitalAssistant(ctx context.Context, db *gorm.DB, orgID *uint, ownerID *uint, status *string, keyword *string, offset, limit int) ([]*types.DigitalAssistant, int64, error) {
 	var entities []*types.DigitalAssistant
 	var total int64
 
@@ -89,8 +89,7 @@ func ListDigitalAssistant(ctx context.Context, db *gorm.DB, orgID *uint, ownerID
 		return nil, 0, err
 	}
 
-	offset := (page - 1) * perPage
-	err = query.Offset(offset).Limit(perPage).Order("created_at DESC").Find(&entities).Error
+	err = query.Offset(offset).Limit(limit).Order("created_at DESC").Find(&entities).Error
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/infra/db/llm_model_dao.go
+++ b/backend/internal/infra/db/llm_model_dao.go
@@ -67,7 +67,7 @@ func DeleteLLMModel(ctx context.Context, db *gorm.DB, id uint) error {
 }
 
 // ListLLMModels 分页查询LLM模型配置列表
-func ListLLMModels(ctx context.Context, db *gorm.DB, orgID *uint, provider *string, status *string, keyword *string, page, perPage int) ([]*types.LLMModel, int64, error) {
+func ListLLMModels(ctx context.Context, db *gorm.DB, orgID *uint, provider *string, status *string, keyword *string, offset, limit int) ([]*types.LLMModel, int64, error) {
 	var entities []*types.LLMModel
 	var total int64
 
@@ -92,15 +92,7 @@ func ListLLMModels(ctx context.Context, db *gorm.DB, orgID *uint, provider *stri
 		return nil, 0, err
 	}
 
-	if page <= 0 {
-		page = 1
-	}
-	if perPage <= 0 {
-		perPage = 20
-	}
-
-	offset := (page - 1) * perPage
-	err = query.Offset(offset).Limit(perPage).Order("is_default DESC, created_at DESC").Find(&entities).Error
+	err = query.Offset(offset).Limit(limit).Order("is_default DESC, created_at DESC").Find(&entities).Error
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/infra/db/llm_model_dao_test.go
+++ b/backend/internal/infra/db/llm_model_dao_test.go
@@ -138,7 +138,7 @@ func TestListLLMModels(t *testing.T) {
 
 	orgID := uint(1)
 	provider := string(types.LLMProviderDeepSeek)
-	items, total, err := ListLLMModels(ctx, database, &orgID, &provider, nil, nil, 1, 20)
+	items, total, err := ListLLMModels(ctx, database, &orgID, &provider, nil, nil, 0, 20)
 	if err != nil {
 		t.Fatalf("ListLLMModels failed: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestListLLMModels(t *testing.T) {
 	}
 
 	keyword := "openai"
-	items, total, err = ListLLMModels(ctx, database, &orgID, nil, nil, &keyword, 1, 20)
+	items, total, err = ListLLMModels(ctx, database, &orgID, nil, nil, &keyword, 0, 20)
 	if err != nil {
 		t.Fatalf("ListLLMModels failed: %v", err)
 	}

--- a/backend/internal/infra/db/session_dao.go
+++ b/backend/internal/infra/db/session_dao.go
@@ -81,7 +81,7 @@ func ExpireSessions(ctx context.Context, db *gorm.DB) error {
 }
 
 // ListSessions 分页查询会话列表
-func ListSessions(ctx context.Context, db *gorm.DB, sessionType *string, status *string, userID *uint, orgID *uint, assistantID *uint, assistantCode *string, keyword *string, page, perPage int) ([]*types.Session, int64, error) {
+func ListSessions(ctx context.Context, db *gorm.DB, sessionType *string, status *string, userID *uint, orgID *uint, assistantID *uint, assistantCode *string, keyword *string, offset, limit int) ([]*types.Session, int64, error) {
 	var entities []*types.Session
 	var total int64
 
@@ -114,8 +114,7 @@ func ListSessions(ctx context.Context, db *gorm.DB, sessionType *string, status 
 		return nil, 0, err
 	}
 
-	offset := (page - 1) * perPage
-	err = query.Offset(offset).Limit(perPage).Order("created_at DESC").Find(&entities).Error
+	err = query.Offset(offset).Limit(limit).Order("created_at DESC").Find(&entities).Error
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/infra/db/session_dao_test.go
+++ b/backend/internal/infra/db/session_dao_test.go
@@ -373,7 +373,7 @@ func TestListSessions_ByType(t *testing.T) {
 	}
 
 	typeFilter := string(types.SessionTypeUserChat)
-	sessions, total, err := ListSessions(ctx, db, &typeFilter, nil, nil, nil, nil, nil, nil, 1, 20)
+	sessions, total, err := ListSessions(ctx, db, &typeFilter, nil, nil, nil, nil, nil, nil, 0, 20)
 	if err != nil {
 		t.Fatalf("ListSessions failed: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestListSessions_ByStatus(t *testing.T) {
 	}
 
 	statusFilter := string(types.SessionStatusActive)
-	sessions, total, err := ListSessions(ctx, db, nil, &statusFilter, nil, nil, nil, nil, nil, 1, 20)
+	sessions, total, err := ListSessions(ctx, db, nil, &statusFilter, nil, nil, nil, nil, nil, 0, 20)
 	if err != nil {
 		t.Fatalf("ListSessions failed: %v", err)
 	}
@@ -451,7 +451,7 @@ func TestListSessions_ByKeyword(t *testing.T) {
 	}
 
 	keyword := "Alpha"
-	sessions, total, err := ListSessions(ctx, db, nil, nil, nil, nil, nil, nil, &keyword, 1, 20)
+	sessions, total, err := ListSessions(ctx, db, nil, nil, nil, nil, nil, nil, &keyword, 0, 20)
 	if err != nil {
 		t.Fatalf("ListSessions failed: %v", err)
 	}
@@ -479,7 +479,7 @@ func TestListSessions_Pagination(t *testing.T) {
 		}
 	}
 
-	sessions, total, err := ListSessions(ctx, db, nil, nil, nil, nil, nil, nil, nil, 1, 2)
+	sessions, total, err := ListSessions(ctx, db, nil, nil, nil, nil, nil, nil, nil, 0, 2)
 	if err != nil {
 		t.Fatalf("ListSessions failed: %v", err)
 	}

--- a/backend/internal/service/digital_assistant_service.go
+++ b/backend/internal/service/digital_assistant_service.go
@@ -208,7 +208,8 @@ func (s *digitalAssistantService) ListDigitalAssistant(ctx context.Context, req 
 		return nil, err
 	}
 
-	entities, total, err := db.ListDigitalAssistant(ctx, s.db, &orgID, nil, req.Status, req.Keyword, req.Page, req.PerPage)
+	entities, total, err := db.ListDigitalAssistant(ctx, s.db, &orgID, nil, req.Status, req.Keyword, req.Offset, req.Limit)
+
 	if err != nil {
 		return nil, err
 	}
@@ -219,9 +220,10 @@ func (s *digitalAssistantService) ListDigitalAssistant(ctx context.Context, req 
 	}
 
 	return &contract.DigitalAssistantList{
-		Total: total,
-		Page:  req.Page,
-		Items: items,
+		Total:  total,
+		Offset: req.Offset,
+		Limit:  req.Limit,
+		Items:  items,
 	}, nil
 }
 

--- a/backend/internal/service/llm_model_service.go
+++ b/backend/internal/service/llm_model_service.go
@@ -219,7 +219,7 @@ func (s *llmModelService) ListLLMModels(ctx context.Context, req *contract.ListL
 		return nil, err
 	}
 
-	models, total, err := db.ListLLMModels(ctx, s.db, &caller.OrgID, req.Provider, req.Status, req.Keyword, req.Page, req.PerPage)
+	models, total, err := db.ListLLMModels(ctx, s.db, &caller.OrgID, req.Provider, req.Status, req.Keyword, req.Offset, req.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -229,9 +229,10 @@ func (s *llmModelService) ListLLMModels(ctx context.Context, req *contract.ListL
 		items = append(items, *convertToContractLLMModel(model))
 	}
 	return &contract.LLMModelList{
-		Total: total,
-		Page:  req.Page,
-		Items: items,
+		Total:  total,
+		Offset: req.Offset,
+		Limit:  req.Limit,
+		Items:  items,
 	}, nil
 }
 

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -167,8 +167,8 @@ func (s *sessionService) ListSessions(ctx context.Context, req *contract.ListSes
 		req.AssistantID,
 		req.AssistantCode,
 		req.Keyword,
-		req.Page,
-		req.PerPage,
+		req.Offset,
+		req.Limit,
 	)
 	if err != nil {
 		return nil, err
@@ -180,9 +180,10 @@ func (s *sessionService) ListSessions(ctx context.Context, req *contract.ListSes
 	}
 
 	return &contract.SessionList{
-		Total: total,
-		Page:  req.Page,
-		Items: items,
+		Total:  total,
+		Offset: req.Offset,
+		Limit:  req.Limit,
+		Items:  items,
 	}, nil
 }
 

--- a/backend/internal/service/session_service_test.go
+++ b/backend/internal/service/session_service_test.go
@@ -540,9 +540,11 @@ func TestListSessions_FilterByType(t *testing.T) {
 
 	typeFilter := string(types.SessionTypeUserChat)
 	listReq := &contract.ListSessionsRequest{
-		Type:    &typeFilter,
-		Page:    1,
-		PerPage: 20,
+		Type: &typeFilter,
+		Pagination: contract.Pagination{
+			Offset: 0,
+			Limit:  20,
+		},
 	}
 
 	result, err := service.ListSessions(ctx, listReq)
@@ -583,9 +585,11 @@ func TestListSessions_FilterByStatus(t *testing.T) {
 
 	statusFilter := string(types.SessionStatusActive)
 	listReq := &contract.ListSessionsRequest{
-		Status:  &statusFilter,
-		Page:    1,
-		PerPage: 20,
+		Status: &statusFilter,
+		Pagination: contract.Pagination{
+			Offset: 0,
+			Limit:  20,
+		},
 	}
 
 	result, err := service.ListSessions(ctx, listReq)


### PR DESCRIPTION
根因: 前端通过 JSON body 请求时，form tag 的 default 值不生效，导致 Page/PerPage 为 0 时 DAO 层执行 LIMIT 0 查询返回空结果。

变更:
- 新增 contract.Pagination 嵌入结构体，复用 apiobj.PageQuery.Fill() 逻辑 (Offset/Limit/ListAll，Limit 默认 10，最大 150)
- 三个 List 请求结构体替换为嵌入 Pagination: ListSessionsRequest / ListDigitalAssistantRequest / ListLLMModelsRequest
- Handler 层调用 req.Pagination.Fill() 替代手写默认值检查
- DAO 层参数从 (page, perPage) 改为 (offset, limit)，去除重复转换逻辑
- 列表响应体统一为 Offset/Limit 响应字段
- 同步更新测试用例