### PR TITLE
feat(session): add session completed message consumer with runnable

### DIFF
--- a/backend/internal/api/contract/session.go
+++ b/backend/internal/api/contract/session.go
@@ -1,8 +1,10 @@
 package contract
 
-import "context"
+import (
+	"context"
 
-import "github.com/insmtx/Leros/backend/internal/agent/runtime/events"
+	"github.com/insmtx/Leros/backend/internal/agent/runtime/events"
+)
 
 // SessionService 定义会话服务接口
 type SessionService interface {
@@ -27,4 +29,9 @@ type SessionService interface {
 
 	// Event streaming
 	StreamSessionEvents(ctx context.Context, sessionID string, lastSequence int64, sink events.Sink) error
+
+	// CompleteSessionMessage 处理 session 完成事件，将最终回复消息入库
+	CompleteSessionMessage(ctx context.Context, req *CompleteSessionMessageRequest) error
+	// FailedSessionMessage 处理 session 失败事件，将错误消息入库
+	FailedSessionMessage(ctx context.Context, req *FailedSessionMessageRequest) error
 }

--- a/backend/internal/api/contract/session_type.go
+++ b/backend/internal/api/contract/session_type.go
@@ -96,3 +96,22 @@ type MessageList struct {
 	Page  int              `json:"page"`
 	Items []SessionMessage `json:"items"`
 }
+
+// CompleteSessionMessageRequest 处理 session 完成事件请求
+type CompleteSessionMessageRequest struct {
+	SessionID string                 `json:"session_id"`
+	Content   string                 `json:"content"`
+	ToolCalls []types.ToolCall       `json:"tool_calls,omitempty"`
+	Metadata  *types.MessageMetadata `json:"metadata,omitempty"`
+	Seq       int64                  `json:"seq"`
+	CreatedAt time.Time              `json:"created_at"`
+}
+
+// FailedSessionMessageRequest 处理 session 失败事件请求
+type FailedSessionMessageRequest struct {
+	SessionID string `json:"session_id"`
+	ErrorMsg  string `json:"error_msg"`
+	ErrorCode string `json:"error_code,omitempty"`
+	Seq       int64  `json:"seq"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -5,6 +5,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
 	"github.com/insmtx/Leros/backend/config"
 	auth "github.com/insmtx/Leros/backend/internal/api/auth"
@@ -15,6 +17,7 @@ import (
 	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
 	githubprovider "github.com/insmtx/Leros/backend/internal/infra/providers/github"
 	"github.com/insmtx/Leros/backend/internal/infra/websocket"
+	"github.com/insmtx/Leros/backend/internal/runnable"
 	"github.com/insmtx/Leros/backend/internal/service"
 	"github.com/insmtx/Leros/backend/internal/worker/scheduler"
 	workerserver "github.com/insmtx/Leros/backend/internal/worker/server"
@@ -80,6 +83,10 @@ func SetupRouter(cfg config.Config, eventbus eventbus.EventBus, db *gorm.DB) *gi
 		sessionService := service.NewSessionService(db, eventbus, inferrer)
 		handler.RegisterSessionRoutes(v1, sessionService)
 		logs.Info("Session routes registered successfully")
+
+		// Start session completed consumer in background
+		go runnable.StartSessionCompleted(context.Background(), sessionService, eventbus)
+		logs.Info("Session completed runnable started")
 	}
 
 	// Swagger UI 路由

--- a/backend/internal/runnable/runner.go
+++ b/backend/internal/runnable/runner.go
@@ -1,0 +1,46 @@
+// Package runnable provides background task runners with recover and keep-alive.
+package runnable
+
+import (
+	"context"
+	"time"
+
+	"github.com/ygpkg/yg-go/logs"
+)
+
+// Run starts a named background task with panic recovery and auto-restart on error.
+func Run(ctx context.Context, name string, fn func(ctx context.Context)) {
+	const restartDelay = 5 * time.Second
+	for {
+		select {
+		case <-ctx.Done():
+			logs.InfoContextf(ctx, "runnable %s stopped", name)
+			return
+		default:
+		}
+
+		finished := make(chan struct{}, 1)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logs.ErrorContextf(ctx, "runnable %s panicked: %v", name, r)
+				}
+				finished <- struct{}{}
+			}()
+			fn(ctx)
+		}()
+
+		<-finished
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		logs.WarnContextf(ctx, "runnable %s exited, restarting in %v", name, restartDelay)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(restartDelay):
+		}
+	}
+}

--- a/backend/internal/runnable/session_completed.go
+++ b/backend/internal/runnable/session_completed.go
@@ -1,0 +1,84 @@
+package runnable
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/insmtx/Leros/backend/internal/agent/runtime/events"
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
+	"github.com/insmtx/Leros/backend/pkg/dm"
+	"github.com/insmtx/Leros/backend/types"
+	"github.com/ygpkg/yg-go/logs"
+)
+
+// StartSessionCompleted subscribes to session completed events and dispatches to the service.
+func StartSessionCompleted(ctx context.Context, service contract.SessionService, eb eventbus.EventBus) {
+	topic := dm.SessionCompletedTopicWildcard()
+	logs.InfoContextf(ctx, "starting session completed runnable: %s", topic)
+
+	Run(ctx, "session_completed", func(ctx context.Context) {
+		if err := eb.Subscribe(ctx, topic, func(msg *nats.Msg) {
+			handleSessionCompletedMessage(ctx, service, msg)
+		}); err != nil {
+			logs.ErrorContextf(ctx, "subscribe to %s failed: %v", topic, err)
+		}
+	})
+}
+
+func handleSessionCompletedMessage(ctx context.Context, service contract.SessionService, msg *nats.Msg) {
+	var streamMsg events.MessageStreamMessage
+	if err := json.Unmarshal(msg.Data, &streamMsg); err != nil {
+		logs.WarnContextf(ctx, "unmarshal session completed message: %v", err)
+		return
+	}
+
+	sessionID := streamMsg.Route.SessionID
+	if sessionID == "" {
+		return
+	}
+
+	switch streamMsg.Body.Event {
+	case events.StreamEventRunCompleted:
+		req := &contract.CompleteSessionMessageRequest{
+			SessionID: sessionID,
+			Content:   streamMsg.Body.Payload.Content,
+			Seq:       streamMsg.Body.Seq,
+			CreatedAt: streamMsg.CreatedAt,
+		}
+		if tc := streamMsg.Body.Payload.ToolCall; tc != nil {
+			req.ToolCalls = []types.ToolCall{{
+				ID: tc.ID, Name: tc.Name, Arguments: tc.Arguments, Status: types.ToolCallStatusSuccess,
+			}}
+		}
+		if u := streamMsg.Body.Usage; u != nil {
+			req.Metadata = &types.MessageMetadata{Tokens: u.TotalTokens}
+		}
+		if err := service.CompleteSessionMessage(ctx, req); err != nil {
+			logs.ErrorContextf(ctx, "complete session message: %v", err)
+		}
+
+	case events.StreamEventRunFailed:
+		errMsg := streamMsg.Body.Payload.Content
+		if streamMsg.Body.Error != nil {
+			errMsg = streamMsg.Body.Error.Message
+		}
+		req := &contract.FailedSessionMessageRequest{
+			SessionID: sessionID,
+			ErrorMsg:  errMsg,
+			Seq:       streamMsg.Body.Seq,
+			CreatedAt: streamMsg.CreatedAt,
+		}
+		if streamMsg.Body.Error != nil {
+			req.ErrorCode = streamMsg.Body.Error.Code
+		}
+		if err := service.FailedSessionMessage(ctx, req); err != nil {
+			logs.ErrorContextf(ctx, "failed session message: %v", err)
+		}
+
+	default:
+		logs.DebugContextf(ctx, "ignoring session completed event: %s", streamMsg.Body.Event)
+	}
+}

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -561,7 +561,7 @@ func convertToContractSession(session *types.Session) *contract.Session {
 
 func convertToContractSessionMessage(message *types.SessionMessage) *contract.SessionMessage {
 	result := &contract.SessionMessage{
-		ID:          fmt.Sprintf("%d", message.ID), // 转换为 string 以匹配前端
+		ID:          fmt.Sprintf("%d", message.ID),
 		SessionID:   message.SessionID,
 		Role:        message.Role,
 		Content:     message.Content,
@@ -589,4 +589,104 @@ func convertToContractSessionMessage(message *types.SessionMessage) *contract.Se
 	}
 
 	return result
+}
+
+func (s *sessionService) CompleteSessionMessage(ctx context.Context, req *contract.CompleteSessionMessageRequest) error {
+	if req.SessionID == "" {
+		return errors.New("session_id is required")
+	}
+
+	session, err := db.GetSessionBySessionID(ctx, s.db, req.SessionID)
+	if err != nil {
+		return fmt.Errorf("find session %s: %w", req.SessionID, err)
+	}
+	if session == nil {
+		return fmt.Errorf("session %s not found", req.SessionID)
+	}
+
+	sequence, err := db.GetNextSequence(ctx, s.db, req.SessionID)
+	if err != nil {
+		return fmt.Errorf("get sequence for %s: %w", req.SessionID, err)
+	}
+
+	msgEntity := &types.SessionMessage{
+		SessionID:   req.SessionID,
+		Role:        string(types.MessageRoleAssistant),
+		Content:     req.Content,
+		MessageType: string(types.MessageTypeText),
+		Status:      string(types.MessageStatusComplete),
+		Sequence:    sequence,
+		Timestamp:   req.CreatedAt.UnixMilli(),
+	}
+
+	if req.ToolCalls != nil && len(req.ToolCalls) > 0 {
+		msgEntity.ToolCalls = req.ToolCalls
+		for i := range msgEntity.ToolCalls {
+			msgEntity.ToolCalls[i].Status = types.ToolCallStatusSuccess
+		}
+	}
+
+	if req.Metadata != nil {
+		msgEntity.Metadata = *req.Metadata
+	}
+
+	if err := db.CreateMessage(ctx, s.db, msgEntity); err != nil {
+		return fmt.Errorf("create message for %s: %w", req.SessionID, err)
+	}
+
+	now := time.Now()
+	if err := db.IncrementMessageCount(ctx, s.db, session.ID); err != nil {
+		logs.WarnContextf(ctx, "increment count for %s: %v", req.SessionID, err)
+	}
+	if err := db.UpdateLastMessageAt(ctx, s.db, session.ID, now); err != nil {
+		logs.WarnContextf(ctx, "update last_message_at for %s: %v", req.SessionID, err)
+	}
+
+	logs.DebugContextf(ctx, "persisted completed session message: session_id=%s seq=%d", req.SessionID, sequence)
+	return nil
+}
+
+func (s *sessionService) FailedSessionMessage(ctx context.Context, req *contract.FailedSessionMessageRequest) error {
+	if req.SessionID == "" {
+		return errors.New("session_id is required")
+	}
+
+	session, err := db.GetSessionBySessionID(ctx, s.db, req.SessionID)
+	if err != nil {
+		return fmt.Errorf("find session %s: %w", req.SessionID, err)
+	}
+	if session == nil {
+		return fmt.Errorf("session %s not found", req.SessionID)
+	}
+
+	sequence, err := db.GetNextSequence(ctx, s.db, req.SessionID)
+	if err != nil {
+		return fmt.Errorf("get sequence for %s: %w", req.SessionID, err)
+	}
+
+	msgEntity := &types.SessionMessage{
+		SessionID:   req.SessionID,
+		Role:        string(types.MessageRoleSystem),
+		Content:     req.ErrorMsg,
+		MessageType: string(types.MessageTypeText),
+		Status:      string(types.MessageStatusError),
+		Sequence:    sequence,
+		Timestamp:   req.CreatedAt.UnixMilli(),
+		Metadata:    types.MessageMetadata{Extra: map[string]interface{}{"error_code": req.ErrorCode}},
+	}
+
+	if err := db.CreateMessage(ctx, s.db, msgEntity); err != nil {
+		return fmt.Errorf("create message for %s: %w", req.SessionID, err)
+	}
+
+	now := time.Now()
+	if err := db.IncrementMessageCount(ctx, s.db, session.ID); err != nil {
+		logs.WarnContextf(ctx, "increment count for %s: %v", req.SessionID, err)
+	}
+	if err := db.UpdateLastMessageAt(ctx, s.db, session.ID, now); err != nil {
+		logs.WarnContextf(ctx, "update last_message_at for %s: %v", req.SessionID, err)
+	}
+
+	logs.DebugContextf(ctx, "persisted failed session message: session_id=%s seq=%d", req.SessionID, sequence)
+	return nil
 }

--- a/backend/pkg/dm/topic.go
+++ b/backend/pkg/dm/topic.go
@@ -43,3 +43,8 @@ func SessionCompletedTopic(orgid uint, sessionid string) (string, error) {
 	orgidStr := fmt.Sprintf("%d", orgid)
 	return topic().Org(orgidStr).Session(sessionid).Completed().Build(), nil
 }
+
+// SessionCompletedTopicWildcard 构造会话完成 topic 的通配符模式，格式为 "org.*.session.*.completed"。
+func SessionCompletedTopicWildcard() string {
+	return topic().Org(wildcard).Session(wildcard).Completed().Build()
+}


### PR DESCRIPTION
- Add CompleteSessionMessage and FailedSessionMessage to SessionService interface
- Implement message persistence in session_service.go
- Add SessionCompletedTopicWildcard() to pkg/dm for wildcard topic pattern
- Create internal/runnable package with Run() for recover + keep-alive
- Subscribe to org.*.session.*.completed and dispatch to service handlers
- No panic allowed, all goroutines protected with recover and auto-restart