### PR TITLE
fix(db): 添加迁移清理遗留的 config 列，修复创建数字助手 500 错误

### DIFF
--- a/backend/internal/infra/db/database.go
+++ b/backend/internal/infra/db/database.go
@@ -16,6 +16,17 @@ import (
 	"github.com/insmtx/Leros/backend/types"
 )
 
+// legacyColumnsToDrop 记录了从模型中被移除但数据库中残留的列。
+// GORM AutoMigrate 不会删除列，需要手动清理。
+type legacyColumn struct {
+	table  string
+	column string
+}
+
+var legacyColumns = []legacyColumn{
+	{table: types.TableNameDigitalAssistant, column: "config"},
+}
+
 // dbName 是数据库名称常量
 const dbName = "leros"
 
@@ -73,7 +84,26 @@ func runMigrations(db *gorm.DB) error {
 		return err
 	}
 
+	if err := dropLegacyColumns(db); err != nil {
+		return err
+	}
+
 	logs.Info("Database migrations completed")
+	return nil
+}
+
+// dropLegacyColumns 清理从模型中被移除的数据库列
+func dropLegacyColumns(db *gorm.DB) error {
+	for _, lc := range legacyColumns {
+		if ok := db.Migrator().HasColumn(lc.table, lc.column); ok {
+			logs.Infof("[migration] dropping legacy column %s.%s", lc.table, lc.column)
+			if err := db.Migrator().DropColumn(lc.table, lc.column); err != nil {
+				logs.Errorf("[migration] failed to drop column %s.%s: %v", lc.table, lc.column, err)
+				return err
+			}
+			logs.Infof("[migration] dropped legacy column %s.%s", lc.table, lc.column)
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/service/digital_assistant_gin_test.go
+++ b/backend/internal/service/digital_assistant_gin_test.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/insmtx/Leros/backend/internal/api/auth"
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/api/handler"
+	"github.com/insmtx/Leros/backend/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestCreateDigitalAssistantViaGin simulates the exact HTTP flow:
+// gin middleware sets caller via WithGinContext, then handler calls service
+func TestCreateDigitalAssistantViaGin(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&types.DigitalAssistant{}); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Simulate the middleware setting the caller via WithGinContext
+	router.Use(func(ctx *gin.Context) {
+		caller := &auth.Caller{
+			Uin:   1,
+			OrgID: 1,
+			State: auth.AuthStateSucc,
+		}
+		trace := &auth.Trace{
+			RequestID: "test-request-id",
+			TraceID:   "test-trace-id",
+		}
+		auth.WithGinContext(ctx, caller, trace)
+		ctx.Next()
+	})
+
+	svc := NewDigitalAssistantService(db, nil)
+	handler.RegisterDigitalAssistantRoutes(router.Group("/v1"), svc)
+
+	body, _ := json.Marshal(contract.CreateDigitalAssistantRequest{
+		Code:         "code-from-gin",
+		Name:         "Gin Test",
+		Description:  "test",
+		SystemPrompt: "you are a test",
+	})
+
+	req := httptest.NewRequest("POST", "/v1/CreateDigitalAssistant", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateDigitalAssistantViaGin_NoCaller simulates the exact curl scenario:
+// no Authorization header, so caller has OrgID=0
+func TestCreateDigitalAssistantViaGin_NoCaller(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&types.DigitalAssistant{}); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Simulate middleware behavior when no Authorization header is present
+	router.Use(func(ctx *gin.Context) {
+		caller := &auth.Caller{
+			Uin:   0,
+			OrgID: 0,
+			State: auth.AuthStateNil,
+		}
+		trace := &auth.Trace{
+			RequestID: "test-request-id",
+			TraceID:   "test-trace-id",
+		}
+		auth.WithGinContext(ctx, caller, trace)
+		ctx.Next()
+	})
+
+	svc := NewDigitalAssistantService(db, nil)
+	handler.RegisterDigitalAssistantRoutes(router.Group("/v1"), svc)
+
+	body, _ := json.Marshal(contract.CreateDigitalAssistantRequest{
+		Code: "code-no-auth",
+		Name: "No Auth Test",
+	})
+
+	req := httptest.NewRequest("POST", "/v1/CreateDigitalAssistant", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Should return 401 Unauthorized
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/service/digital_assistant_service_test.go
+++ b/backend/internal/service/digital_assistant_service_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupDigitalAssistantDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&types.DigitalAssistant{}); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+	return db
+}
+
+func TestCreateDigitalAssistant_ValidInput(t *testing.T) {
+	db := setupDigitalAssistantDB(t)
+	ctx := setupTestContextWithCaller(t)
+
+	service := NewDigitalAssistantService(db, nil)
+
+	req := &contract.CreateDigitalAssistantRequest{
+		Code:         "test-code",
+		Name:         "Test Name",
+		Description:  "Test Description",
+		SystemPrompt: "You are a test assistant",
+	}
+
+	result, err := service.CreateDigitalAssistant(ctx, req)
+	if err != nil {
+		t.Fatalf("CreateDigitalAssistant failed: %v", err)
+	}
+
+	if result.Code != "test-code" {
+		t.Errorf("expected code test-code, got %s", result.Code)
+	}
+	if result.Name != "Test Name" {
+		t.Errorf("expected name 'Test Name', got %s", result.Name)
+	}
+}
+
+func TestCreateDigitalAssistant_WithoutCaller(t *testing.T) {
+	db := setupDigitalAssistantDB(t)
+	ctx := setupTestContextWithoutCaller(t)
+
+	service := NewDigitalAssistantService(db, nil)
+
+	req := &contract.CreateDigitalAssistantRequest{
+		Code: "test-code",
+		Name: "Test Name",
+	}
+
+	_, err := service.CreateDigitalAssistant(ctx, req)
+	if err == nil {
+		t.Fatal("expected error when caller is not in context")
+	}
+	if err.Error() != "user not authenticated or org not set" {
+		t.Errorf("expected 'user not authenticated or org not set', got %v", err)
+	}
+}
+
+func TestCreateDigitalAssistant_MissingCode(t *testing.T) {
+	db := setupDigitalAssistantDB(t)
+	ctx := setupTestContextWithCaller(t)
+
+	service := NewDigitalAssistantService(db, nil)
+
+	req := &contract.CreateDigitalAssistantRequest{
+		Name: "Test Name",
+	}
+
+	_, err := service.CreateDigitalAssistant(ctx, req)
+	if err == nil {
+		t.Fatal("expected error when code is missing")
+	}
+}
+
+func TestCreateDigitalAssistant_MissingName(t *testing.T) {
+	db := setupDigitalAssistantDB(t)
+	ctx := setupTestContextWithCaller(t)
+
+	service := NewDigitalAssistantService(db, nil)
+
+	req := &contract.CreateDigitalAssistantRequest{
+		Code: "test-code",
+	}
+
+	_, err := service.CreateDigitalAssistant(ctx, req)
+	if err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+}


### PR DESCRIPTION
GORM AutoMigrate 不会删除已被模型移除的列。commit 91a52f9 从
types.DigitalAssistant 中移除了 Config 字段，但数据库 leros_digital_assistant 表的 config 列仍残留（NOT NULL），导致创建数字助手时 PostgreSQL 拒绝写入。

添加 dropLegacyColumns 迁移函数，启动时自动检测并删除 config 列。