### PR TITLE
refactor(session): 统一使用 string session_id，移除自增 id 依赖

### DIFF
--- a/backend/internal/api/contract/session.go
+++ b/backend/internal/api/contract/session.go
@@ -10,22 +10,22 @@ import (
 type SessionService interface {
 	// Session CRUD
 	CreateSession(ctx context.Context, req *CreateSessionRequest) (*Session, error)
-	GetSession(ctx context.Context, id uint, sessionID string) (*Session, error)
-	UpdateSession(ctx context.Context, id uint, req *UpdateSessionRequest) (*Session, error)
-	DeleteSession(ctx context.Context, id uint) error
+	GetSession(ctx context.Context, sessionID string) (*Session, error)
+	UpdateSession(ctx context.Context, sessionID string, req *UpdateSessionRequest) (*Session, error)
+	DeleteSession(ctx context.Context, sessionID string) error
 	ListSessions(ctx context.Context, req *ListSessionsRequest) (*SessionList, error)
 
 	// Lifecycle management
-	ActivateSession(ctx context.Context, id uint) error
-	PauseSession(ctx context.Context, id uint) error
-	EndSession(ctx context.Context, id uint) error
-	ResumeSession(ctx context.Context, id uint) error
+	ActivateSession(ctx context.Context, sessionID string) error
+	PauseSession(ctx context.Context, sessionID string) error
+	EndSession(ctx context.Context, sessionID string) error
+	ResumeSession(ctx context.Context, sessionID string) error
 
 	// Message management
-	AddMessage(ctx context.Context, sessionID uint, req *AddMessageRequest) (*SessionMessage, error)
-	GetSessionMessages(ctx context.Context, sessionID uint, page, perPage int) (*MessageList, error)
+	AddMessage(ctx context.Context, sessionID string, req *AddMessageRequest) (*SessionMessage, error)
+	GetSessionMessages(ctx context.Context, sessionID string, page, perPage int) (*MessageList, error)
 	DeleteMessage(ctx context.Context, messageID uint) error
-	ClearSessionMessages(ctx context.Context, sessionID uint) error
+	ClearSessionMessages(ctx context.Context, sessionID string) error
 
 	// Event streaming
 	StreamSessionEvents(ctx context.Context, sessionID string, lastSequence int64, sink events.Sink) error

--- a/backend/internal/api/handler/session_handler.go
+++ b/backend/internal/api/handler/session_handler.go
@@ -67,12 +67,11 @@ func (h *SessionHandler) CreateSession(ctx *gin.Context) {
 }
 
 type GetSessionRequest struct {
-	ID        *uint   `json:"id,omitempty"`
-	SessionID *string `json:"session_id,omitempty"`
+	SessionID string `json:"session_id" binding:"required"`
 }
 
 // @Summary 获取会话详情
-// @Description 根据ID或SessionID获取会话详情
+// @Description 根据SessionID获取会话详情
 // @Tags Session
 // @Accept json
 // @Produce json
@@ -90,20 +89,7 @@ func (h *SessionHandler) GetSession(ctx *gin.Context) {
 		return
 	}
 
-	if req.ID == nil && req.SessionID == nil {
-		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "id or session_id is required"))
-		return
-	}
-
-	var result interface{}
-	var err error
-
-	if req.ID != nil {
-		result, err = h.service.GetSession(ctx, *req.ID, "")
-	} else {
-		result, err = h.service.GetSession(ctx, 0, *req.SessionID)
-	}
-
+	result, err := h.service.GetSession(ctx, req.SessionID)
 	if err != nil {
 		handleSessionServiceError(ctx, err)
 		return
@@ -113,7 +99,7 @@ func (h *SessionHandler) GetSession(ctx *gin.Context) {
 }
 
 type UpdateSessionRequest struct {
-	ID uint `json:"id" binding:"required"`
+	SessionID string `json:"session_id" binding:"required"`
 	contract.UpdateSessionRequest
 }
 
@@ -136,7 +122,7 @@ func (h *SessionHandler) UpdateSession(ctx *gin.Context) {
 		return
 	}
 
-	result, err := h.service.UpdateSession(ctx, req.ID, &req.UpdateSessionRequest)
+	result, err := h.service.UpdateSession(ctx, req.SessionID, &req.UpdateSessionRequest)
 	if err != nil {
 		handleSessionServiceError(ctx, err)
 		return
@@ -146,7 +132,7 @@ func (h *SessionHandler) UpdateSession(ctx *gin.Context) {
 }
 
 type DeleteSessionRequest struct {
-	ID uint `json:"id" binding:"required"`
+	SessionID string `json:"session_id" binding:"required"`
 }
 
 // @Summary 删除会话
@@ -168,7 +154,7 @@ func (h *SessionHandler) DeleteSession(ctx *gin.Context) {
 		return
 	}
 
-	err := h.service.DeleteSession(ctx, req.ID)
+	err := h.service.DeleteSession(ctx, req.SessionID)
 	if err != nil {
 		handleSessionServiceError(ctx, err)
 		return
@@ -267,7 +253,7 @@ func (h *SessionHandler) SessionEvents(ctx *gin.Context) {
 }
 
 type AddMessageRequest struct {
-	SessionID uint `json:"session_id" binding:"required"`
+	SessionID string `json:"session_id" binding:"required"`
 	contract.AddMessageRequest
 }
 
@@ -300,9 +286,9 @@ func (h *SessionHandler) AddMessage(ctx *gin.Context) {
 }
 
 type GetSessionMessagesRequest struct {
-	SessionID uint `json:"session_id" binding:"required"`
-	Page      int  `json:"page,omitempty"`
-	PerPage   int  `json:"per_page,omitempty"`
+	SessionID string `json:"session_id" binding:"required"`
+	Page      int    `json:"page,omitempty"`
+	PerPage   int    `json:"per_page,omitempty"`
 }
 
 // @Summary 获取会话消息列表
@@ -375,7 +361,7 @@ func (h *SessionHandler) DeleteMessage(ctx *gin.Context) {
 }
 
 type ClearSessionMessagesRequest struct {
-	SessionID uint `json:"session_id" binding:"required"`
+	SessionID string `json:"session_id" binding:"required"`
 }
 
 // @Summary 清空会话消息

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -88,18 +88,12 @@ func (s *sessionService) CreateSession(ctx context.Context, req *contract.Create
 	return convertToContractSession(session), nil
 }
 
-func (s *sessionService) GetSession(ctx context.Context, id uint, sessionID string) (*contract.Session, error) {
-	var session *types.Session
-	var err error
-
-	if id > 0 {
-		session, err = db.GetSessionByID(ctx, s.db, id)
-	} else if sessionID != "" {
-		session, err = db.GetSessionBySessionID(ctx, s.db, sessionID)
-	} else {
-		return nil, errors.New("id or session_id is required")
+func (s *sessionService) GetSession(ctx context.Context, sessionID string) (*contract.Session, error) {
+	if sessionID == "" {
+		return nil, errors.New("session_id is required")
 	}
 
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +104,8 @@ func (s *sessionService) GetSession(ctx context.Context, id uint, sessionID stri
 	return convertToContractSession(session), nil
 }
 
-func (s *sessionService) UpdateSession(ctx context.Context, id uint, req *contract.UpdateSessionRequest) (*contract.Session, error) {
-	session, err := db.GetSessionByID(ctx, s.db, id)
+func (s *sessionService) UpdateSession(ctx context.Context, sessionID string, req *contract.UpdateSessionRequest) (*contract.Session, error) {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -139,8 +133,8 @@ func (s *sessionService) UpdateSession(ctx context.Context, id uint, req *contra
 	return convertToContractSession(session), nil
 }
 
-func (s *sessionService) DeleteSession(ctx context.Context, id uint) error {
-	session, err := db.GetSessionByID(ctx, s.db, id)
+func (s *sessionService) DeleteSession(ctx context.Context, sessionID string) error {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return err
 	}
@@ -148,7 +142,7 @@ func (s *sessionService) DeleteSession(ctx context.Context, id uint) error {
 		return errors.New("session not found")
 	}
 
-	return db.DeleteSession(ctx, s.db, id)
+	return db.DeleteSession(ctx, s.db, session.ID)
 }
 
 func (s *sessionService) ListSessions(ctx context.Context, req *contract.ListSessionsRequest) (*contract.SessionList, error) {
@@ -191,8 +185,8 @@ func (s *sessionService) ListSessions(ctx context.Context, req *contract.ListSes
 	}, nil
 }
 
-func (s *sessionService) ActivateSession(ctx context.Context, id uint) error {
-	session, err := db.GetSessionByID(ctx, s.db, id)
+func (s *sessionService) ActivateSession(ctx context.Context, sessionID string) error {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return err
 	}
@@ -204,11 +198,11 @@ func (s *sessionService) ActivateSession(ctx context.Context, id uint) error {
 		return errors.New("cannot activate from ended state")
 	}
 
-	return db.ActivateSession(ctx, s.db, id)
+	return db.ActivateSession(ctx, s.db, session.ID)
 }
 
-func (s *sessionService) PauseSession(ctx context.Context, id uint) error {
-	session, err := db.GetSessionByID(ctx, s.db, id)
+func (s *sessionService) PauseSession(ctx context.Context, sessionID string) error {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return err
 	}
@@ -220,11 +214,11 @@ func (s *sessionService) PauseSession(ctx context.Context, id uint) error {
 		return fmt.Errorf("cannot pause from %s state", session.Status)
 	}
 
-	return db.PauseSession(ctx, s.db, id)
+	return db.PauseSession(ctx, s.db, session.ID)
 }
 
-func (s *sessionService) EndSession(ctx context.Context, id uint) error {
-	session, err := db.GetSessionByID(ctx, s.db, id)
+func (s *sessionService) EndSession(ctx context.Context, sessionID string) error {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return err
 	}
@@ -236,11 +230,11 @@ func (s *sessionService) EndSession(ctx context.Context, id uint) error {
 		return errors.New("session already ended")
 	}
 
-	return db.EndSession(ctx, s.db, id)
+	return db.EndSession(ctx, s.db, session.ID)
 }
 
-func (s *sessionService) ResumeSession(ctx context.Context, id uint) error {
-	session, err := db.GetSessionByID(ctx, s.db, id)
+func (s *sessionService) ResumeSession(ctx context.Context, sessionID string) error {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return err
 	}
@@ -252,10 +246,10 @@ func (s *sessionService) ResumeSession(ctx context.Context, id uint) error {
 		return errors.New("can only resume from paused state")
 	}
 
-	return db.ResumeSession(ctx, s.db, id)
+	return db.ResumeSession(ctx, s.db, session.ID)
 }
 
-func (s *sessionService) AddMessage(ctx context.Context, sessionID uint, req *contract.AddMessageRequest) (*contract.SessionMessage, error) {
+func (s *sessionService) AddMessage(ctx context.Context, sessionID string, req *contract.AddMessageRequest) (*contract.SessionMessage, error) {
 	if req.Role == "" {
 		return nil, errors.New("role is required")
 	}
@@ -263,7 +257,7 @@ func (s *sessionService) AddMessage(ctx context.Context, sessionID uint, req *co
 		return nil, errors.New("content is required")
 	}
 
-	session, err := db.GetSessionByID(ctx, s.db, sessionID)
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -284,10 +278,10 @@ func (s *sessionService) AddMessage(ctx context.Context, sessionID uint, req *co
 	}
 
 	now := time.Now()
-	if err := db.IncrementMessageCount(ctx, s.db, sessionID); err != nil {
+	if err := db.IncrementMessageCount(ctx, s.db, session.ID); err != nil {
 		return nil, err
 	}
-	if err := db.UpdateLastMessageAt(ctx, s.db, sessionID, now); err != nil {
+	if err := db.UpdateLastMessageAt(ctx, s.db, session.ID, now); err != nil {
 		return nil, err
 	}
 
@@ -492,8 +486,8 @@ func (s *sessionService) publishWorkerTask(ctx context.Context, session *types.S
 	return nil
 }
 
-func (s *sessionService) GetSessionMessages(ctx context.Context, sessionID uint, page, perPage int) (*contract.MessageList, error) {
-	session, err := db.GetSessionByID(ctx, s.db, sessionID)
+func (s *sessionService) GetSessionMessages(ctx context.Context, sessionID string, page, perPage int) (*contract.MessageList, error) {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -534,8 +528,8 @@ func (s *sessionService) DeleteMessage(ctx context.Context, messageID uint) erro
 	return nil
 }
 
-func (s *sessionService) ClearSessionMessages(ctx context.Context, sessionID uint) error {
-	session, err := db.GetSessionByID(ctx, s.db, sessionID)
+func (s *sessionService) ClearSessionMessages(ctx context.Context, sessionID string) error {
+	session, err := db.GetSessionBySessionID(ctx, s.db, sessionID)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/service/session_service_test.go
+++ b/backend/internal/service/session_service_test.go
@@ -93,7 +93,7 @@ func setupTestContextWithCaller(t *testing.T) context.Context {
 	return auth.WithContext(context.Background(), caller, trace)
 }
 
-func addMessage(t *testing.T, service contract.SessionService, ctx context.Context, sessionID uint, content string) {
+func addMessage(t *testing.T, service contract.SessionService, ctx context.Context, sessionID string, content string) {
 	t.Helper()
 	_, err := service.AddMessage(ctx, sessionID, &contract.AddMessageRequest{
 		Role:    string(types.MessageRoleUser),
@@ -197,7 +197,7 @@ func TestGetSession_NotFound(t *testing.T) {
 	service := setupTestService(t)
 	ctx := setupTestContextWithCaller(t)
 
-	_, err := service.GetSession(ctx, 1, "")
+	_, err := service.GetSession(ctx, "nonexistent")
 	if err == nil {
 		t.Error("expected error for non-existent session")
 	}
@@ -221,7 +221,7 @@ func TestGetSession_ByID(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestUpdateSession(t *testing.T) {
 		Title: "Updated Title",
 	}
 
-	updated, err := service.UpdateSession(ctx, session.ID, updateReq)
+	updated, err := service.UpdateSession(ctx, session.SessionID, updateReq)
 	if err != nil {
 		t.Fatalf("UpdateSession failed: %v", err)
 	}
@@ -277,12 +277,12 @@ func TestUpdateSession_MarksTitleManuallySet(t *testing.T) {
 		Title: "Updated Title",
 	}
 
-	_, err = service.UpdateSession(ctx, session.ID, updateReq)
+	_, err = service.UpdateSession(ctx, session.SessionID, updateReq)
 	if err != nil {
 		t.Fatalf("UpdateSession failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -301,18 +301,18 @@ func TestHandleSessionTitleRequest_AfterManualRename(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	_, err = service.UpdateSession(ctx, session.ID, &contract.UpdateSessionRequest{Title: "用户手动设置的标题"})
+	_, err = service.UpdateSession(ctx, session.SessionID, &contract.UpdateSessionRequest{Title: "用户手动设置的标题"})
 	if err != nil {
 		t.Fatalf("UpdateSession failed: %v", err)
 	}
 
-	addMessage(t, service, ctx, session.ID, "这是一条消息")
+	addMessage(t, service, ctx, session.SessionID, "这是一条消息")
 	err = service.HandleSessionTitleRequest(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("HandleSessionTitleRequest failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -337,12 +337,12 @@ func TestDeleteSession(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	err = service.DeleteSession(ctx, session.ID)
+	err = service.DeleteSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("DeleteSession failed: %v", err)
 	}
 
-	_, err = service.GetSession(ctx, session.ID, "")
+	_, err = service.GetSession(ctx, session.SessionID)
 	if err == nil {
 		t.Error("expected error for deleted session")
 	}
@@ -361,9 +361,9 @@ func TestActivateSession_InvalidState(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	service.EndSession(ctx, session.ID)
+	service.EndSession(ctx, session.SessionID)
 
-	err = service.ActivateSession(ctx, session.ID)
+	err = service.ActivateSession(ctx, session.SessionID)
 	if err == nil {
 		t.Error("expected error for activating from ended state")
 	}
@@ -386,12 +386,12 @@ func TestPauseSession(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	err = service.PauseSession(ctx, session.ID)
+	err = service.PauseSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("PauseSession failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -414,9 +414,9 @@ func TestEndSession_AlreadyEnded(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	service.EndSession(ctx, session.ID)
+	service.EndSession(ctx, session.SessionID)
 
-	err = service.EndSession(ctx, session.ID)
+	err = service.EndSession(ctx, session.SessionID)
 	if err == nil {
 		t.Error("expected error for ending already ended session")
 	}
@@ -439,7 +439,7 @@ func TestResumeSession_NotPaused(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	err = service.ResumeSession(ctx, session.ID)
+	err = service.ResumeSession(ctx, session.SessionID)
 	if err == nil {
 		t.Error("expected error for resuming non-paused session")
 	}
@@ -467,12 +467,12 @@ func TestAddMessage_UpdatesSession(t *testing.T) {
 		Content: "Test message",
 	}
 
-	_, err = service.AddMessage(ctx, session.ID, addReq)
+	_, err = service.AddMessage(ctx, session.SessionID, addReq)
 	if err != nil {
 		t.Fatalf("AddMessage failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -505,7 +505,7 @@ func TestAddMessage_AutoSequence(t *testing.T) {
 			Content: "Message " + string(rune(i)),
 		}
 
-		msg, err := service.AddMessage(ctx, session.ID, addReq)
+		msg, err := service.AddMessage(ctx, session.SessionID, addReq)
 		if err != nil {
 			t.Fatalf("AddMessage failed: %v", err)
 		}
@@ -533,7 +533,7 @@ func TestAddMessage_MissingContent(t *testing.T) {
 		Role: string(types.MessageRoleUser),
 	}
 
-	_, err = service.AddMessage(ctx, session.ID, addReq)
+	_, err = service.AddMessage(ctx, session.SessionID, addReq)
 	if err == nil {
 		t.Error("expected error for missing content")
 	}
@@ -552,13 +552,13 @@ func TestHandleSessionTitleRequest_EmptyTitle(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	addMessage(t, service, ctx, session.ID, "这是我的第一条消息")
+	addMessage(t, service, ctx, session.SessionID, "这是我的第一条消息")
 	err = service.HandleSessionTitleRequest(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("HandleSessionTitleRequest failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -579,13 +579,13 @@ func TestHandleSessionTitleRequest_XinSessionTitle(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	addMessage(t, service, ctx, session.ID, "我的第一条消息")
+	addMessage(t, service, ctx, session.SessionID, "我的第一条消息")
 	err = service.HandleSessionTitleRequest(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("HandleSessionTitleRequest failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -608,13 +608,13 @@ func TestHandleSessionTitleRequest_Truncated(t *testing.T) {
 		longContent += "a"
 	}
 
-	addMessage(t, service, ctx, session.ID, longContent)
+	addMessage(t, service, ctx, session.SessionID, longContent)
 	err = service.HandleSessionTitleRequest(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("HandleSessionTitleRequest failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -635,13 +635,13 @@ func TestHandleSessionTitleRequest_CustomTitleUnchanged(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	addMessage(t, service, ctx, session.ID, "一条消息")
+	addMessage(t, service, ctx, session.SessionID, "一条消息")
 	err = service.HandleSessionTitleRequest(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("HandleSessionTitleRequest failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -659,18 +659,18 @@ func TestHandleSessionTitleRequest_ManuallySetFlag(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	_, err = service.UpdateSession(ctx, session.ID, &contract.UpdateSessionRequest{Title: "手动标题"})
+	_, err = service.UpdateSession(ctx, session.SessionID, &contract.UpdateSessionRequest{Title: "手动标题"})
 	if err != nil {
 		t.Fatalf("UpdateSession failed: %v", err)
 	}
 
-	addMessage(t, service, ctx, session.ID, "新消息内容")
+	addMessage(t, service, ctx, session.SessionID, "新消息内容")
 	err = service.HandleSessionTitleRequest(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("HandleSessionTitleRequest failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -701,7 +701,7 @@ func TestDeleteMessage_UpdatesSession(t *testing.T) {
 	}
 
 	// 添加消息获取 ID
-	msg, err := service.AddMessage(ctx, session.ID, addReq)
+	msg, err := service.AddMessage(ctx, session.SessionID, addReq)
 	if err != nil {
 		t.Fatalf("AddMessage failed: %v", err)
 	}
@@ -715,7 +715,7 @@ func TestDeleteMessage_UpdatesSession(t *testing.T) {
 		t.Fatalf("DeleteMessage failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}
@@ -788,7 +788,7 @@ func TestListSessions_FilterByStatus(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	service.PauseSession(ctx, session2.ID)
+	service.PauseSession(ctx, session2.SessionID)
 
 	statusFilter := string(types.SessionStatusActive)
 	listReq := &contract.ListSessionsRequest{
@@ -827,13 +827,13 @@ func TestGetSessionMessages(t *testing.T) {
 			Role:    string(types.MessageRoleUser),
 			Content: "Message " + string(rune(i)),
 		}
-		_, err := service.AddMessage(ctx, session.ID, addReq)
+		_, err := service.AddMessage(ctx, session.SessionID, addReq)
 		if err != nil {
 			t.Fatalf("AddMessage failed: %v", err)
 		}
 	}
 
-	result, err := service.GetSessionMessages(ctx, session.ID, 1, 20)
+	result, err := service.GetSessionMessages(ctx, session.SessionID, 1, 20)
 	if err != nil {
 		t.Fatalf("GetSessionMessages failed: %v", err)
 	}
@@ -865,18 +865,18 @@ func TestClearSessionMessages(t *testing.T) {
 			Role:    string(types.MessageRoleUser),
 			Content: "Message " + string(rune(i)),
 		}
-		_, err := service.AddMessage(ctx, session.ID, addReq)
+		_, err := service.AddMessage(ctx, session.SessionID, addReq)
 		if err != nil {
 			t.Fatalf("AddMessage failed: %v", err)
 		}
 	}
 
-	err = service.ClearSessionMessages(ctx, session.ID)
+	err = service.ClearSessionMessages(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("ClearSessionMessages failed: %v", err)
 	}
 
-	retrieved, err := service.GetSession(ctx, session.ID, "")
+	retrieved, err := service.GetSession(ctx, session.SessionID)
 	if err != nil {
 		t.Fatalf("GetSession failed: %v", err)
 	}

--- a/frontend/apps/desktop/src/renderer/src/components/layout/ConversationListPanel.tsx
+++ b/frontend/apps/desktop/src/renderer/src/components/layout/ConversationListPanel.tsx
@@ -52,18 +52,18 @@ export function ConversationListPanel() {
 			)
 		: conversations;
 
-	const handleConversationClick = (id: string, sessionDbId: number) => {
+	const handleConversationClick = (id: string) => {
 		switchConversation(id);
-		setActiveSession(sessionDbId, id);
-		loadConversationMessages(sessionDbId);
+		setActiveSession(id);
+		loadConversationMessages(id);
 	};
 
 	const handleCreateConversation = async () => {
 		const conv = await createConversation("新会话");
 		if (conv) {
 			switchConversation(conv.id);
-			setActiveSession(conv.sessionDbId, conv.id);
-			loadConversationMessages(conv.sessionDbId);
+			setActiveSession(conv.id);
+			loadConversationMessages(conv.id);
 		}
 	};
 
@@ -127,7 +127,7 @@ export function ConversationListPanel() {
 										? "bg-blue-50 text-blue-700"
 										: "text-slate-600 hover:bg-slate-50",
 								)}
-								onClick={() => handleConversationClick(conv.id, conv.sessionDbId)}
+								onClick={() => handleConversationClick(conv.id)}
 							>
 								<span className="truncate flex-1">{conv.title}</span>
 								<DropdownMenu>

--- a/frontend/apps/web/components/layout/ConversationListPanel.tsx
+++ b/frontend/apps/web/components/layout/ConversationListPanel.tsx
@@ -52,18 +52,18 @@ export function ConversationListPanel() {
 			)
 		: conversations;
 
-	const handleConversationClick = (id: string, sessionDbId: number) => {
+	const handleConversationClick = (id: string) => {
 		switchConversation(id);
-		setActiveSession(sessionDbId, id);
-		loadConversationMessages(sessionDbId);
+		setActiveSession(id);
+		loadConversationMessages(id);
 	};
 
 	const handleCreateConversation = async () => {
 		const conv = await createConversation("新会话");
 		if (conv) {
 			switchConversation(conv.id);
-			setActiveSession(conv.sessionDbId, conv.id);
-			loadConversationMessages(conv.sessionDbId);
+			setActiveSession(conv.id);
+			loadConversationMessages(conv.id);
 		}
 	};
 
@@ -127,7 +127,7 @@ export function ConversationListPanel() {
 										? "bg-blue-50 text-blue-700"
 										: "text-slate-600 hover:bg-slate-50",
 								)}
-								onClick={() => handleConversationClick(conv.id, conv.sessionDbId)}
+								onClick={() => handleConversationClick(conv.id)}
 							>
 								<span className="truncate flex-1">{conv.title}</span>
 								<DropdownMenu>

--- a/frontend/packages/store/api/sessionApi.ts
+++ b/frontend/packages/store/api/sessionApi.ts
@@ -24,7 +24,7 @@ export type CreateSessionParams = {
 };
 
 export type UpdateSessionParams = {
-	id: number;
+	session_id: string;
 	title?: string;
 	expired_at?: string;
 	metadata?: {
@@ -52,7 +52,7 @@ export type GetSessionParams = {
 };
 
 export type AddMessageParams = {
-	session_id: number;
+	session_id: string;
 	role: string;
 	content: string;
 	message_type?: string;
@@ -105,13 +105,13 @@ export const sessionApi = {
 	update: (params: UpdateSessionParams) =>
 		apiClient.post<BackendDataResponse<BackendSession>>(SESSION_ENDPOINTS.update, params),
 
-	delete: (id: number) =>
-		apiClient.post<BackendDataResponse<null>>(SESSION_ENDPOINTS.delete, { id }),
+	delete: (sessionId: string) =>
+		apiClient.post<BackendDataResponse<null>>(SESSION_ENDPOINTS.delete, { session_id: sessionId }),
 
 	addMessage: (params: AddMessageParams) =>
 		apiClient.post<BackendDataResponse<BackendMessage>>(SESSION_ENDPOINTS.addMessage, params),
 
-	getMessages: (sessionId: number, page?: number, perPage?: number) =>
+	getMessages: (sessionId: string, page?: number, perPage?: number) =>
 		apiClient.post<BackendPaginatedResponse<BackendMessage>>(SESSION_ENDPOINTS.getMessages, {
 			session_id: sessionId,
 			page: page ?? 1,
@@ -123,7 +123,7 @@ export const sessionApi = {
 			message_id: messageId,
 		}),
 
-	clearMessages: (sessionId: number) =>
+	clearMessages: (sessionId: string) =>
 		apiClient.post<BackendDataResponse<null>>(SESSION_ENDPOINTS.clearMessages, {
 			session_id: sessionId,
 		}),

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -27,7 +27,6 @@ export type ChatState = {
 	inputFocused: boolean;
 	selectedModel: string;
 	modelOptions: ModelOption[];
-	activeSessionDbId: number | null;
 	activeSessionId: string | null;
 
 	tokenUsage: { total: number; currentSession: number };
@@ -48,7 +47,6 @@ const _initialState: ChatState = {
 	inputFocused: false,
 	selectedModel: "gpt-4",
 	modelOptions: mockModelOptions,
-	activeSessionDbId: null,
 	activeSessionId: null,
 
 	tokenUsage: { total: 0, currentSession: 0 },
@@ -118,27 +116,25 @@ export class ChatActionImpl {
 		this.#set((state) => chatReducer(state, action));
 	};
 
-	setActiveSession = (sessionDbId: number, sessionId: string) => {
-		this.#set({ activeSessionDbId: sessionDbId, activeSessionId: sessionId });
+	setActiveSession = (sessionId: string) => {
+		this.#set({ activeSessionId: sessionId });
 	};
 
 	sendMessage = async (content: string, attachments?: Attachment[]) => {
 		if (!content.trim() && !attachments?.length) return;
 
 		const state = this.#get();
-		let { activeSessionDbId, activeSessionId } = state;
+		let { activeSessionId } = state;
 
-		if (!activeSessionDbId || !activeSessionId) {
+		if (!activeSessionId) {
 			try {
 				const res = await sessionApi.create({ type: "chat", title: "新会话" });
 				const session = res.data.data;
 				if (!session) return;
-				activeSessionDbId = session.id;
 				activeSessionId = session.session_id;
 				const conv = {
 					id: session.session_id,
 					title: session.title || "未命名会话",
-					sessionDbId: session.id,
 					type: session.type,
 					status: session.status,
 					createdAt: new Date(session.created_at).getTime(),
@@ -150,7 +146,6 @@ export class ChatActionImpl {
 					conversationsLoaded: boolean;
 				};
 				(this.#set as (partial: Record<string, unknown>) => void)({
-					activeSessionDbId,
 					activeSessionId,
 					conversations: [conv, ...prevState.conversations],
 					activeConversationId: conv.id,
@@ -164,7 +159,7 @@ export class ChatActionImpl {
 
 		try {
 			await sessionApi.addMessage({
-				session_id: activeSessionDbId,
+				session_id: activeSessionId,
 				role: "user",
 				content,
 				message_type: "text",
@@ -391,9 +386,9 @@ export class ChatActionImpl {
 		this.#finishStream();
 	};
 
-	loadConversationMessages = async (sessionDbId: number) => {
+	loadConversationMessages = async (sessionId: string) => {
 		try {
-			const res = await sessionApi.getMessages(sessionDbId, 1, 100);
+			const res = await sessionApi.getMessages(sessionId, 1, 100);
 			const items = res.data.data?.items ?? [];
 			const messages = items.map(mapBackendMessage);
 
@@ -485,9 +480,9 @@ export class ChatActionImpl {
 		}
 	};
 
-	clearMessages = async (sessionDbId: number) => {
+	clearMessages = async (sessionId: string) => {
 		try {
-			await sessionApi.clearMessages(sessionDbId);
+			await sessionApi.clearMessages(sessionId);
 			this.#set({ messagesMap: {}, messageIds: [] });
 		} catch (err) {
 			console.error("clearMessages error:", err);

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -8,7 +8,6 @@ export type WorkspaceMode = "remote" | "local";
 export type Conversation = {
 	id: string;
 	title: string;
-	sessionDbId: number;
 	type: string;
 	status: string;
 	createdAt: number;
@@ -61,7 +60,6 @@ function mapSessionToConversation(s: BackendSession): Conversation {
 	return {
 		id: s.session_id,
 		title: s.title || "未命名会话",
-		sessionDbId: s.id,
 		type: s.type,
 		status: s.status,
 		createdAt: new Date(s.created_at).getTime(),
@@ -206,7 +204,7 @@ export class LayoutActionImpl {
 		if (!conv) return;
 
 		try {
-			await sessionApi.delete(conv.sessionDbId);
+			await sessionApi.delete(conv.id);
 			this.#set((state) => ({
 				conversations: state.conversations.filter((c) => c.id !== conversationId),
 				activeConversationId:
@@ -223,7 +221,7 @@ export class LayoutActionImpl {
 		if (!conv) return;
 
 		try {
-			await sessionApi.update({ id: conv.sessionDbId, title });
+			await sessionApi.update({ session_id: conv.id, title });
 			this.#set((state) => ({
 				conversations: state.conversations.map((c) =>
 					c.id === conversationId ? { ...c, title, updatedAt: Date.now() } : c,


### PR DESCRIPTION
所有 API 接口的 session_id 统一使用长字符串格式（sess_xxx），
不再暴露自增 uint 主键给前端。

后端：
- contract.SessionService 接口所有 uint 参数改为 string
- handler 请求结构体 ID 字段全部替换为 session_id string
- service 实现层通过 GetSessionBySessionID 查询，内部桥接 uint ID

前端：
- 移除 activeSessionDbId / sessionDbId，只使用 string session_id
- sessionApi.ts 参数类型统一为 string