### PR TITLE
feat(task): 新增Task数据模型

### DIFF
--- a/backend/internal/agent/externalcli/session_metadata_store.go
+++ b/backend/internal/agent/externalcli/session_metadata_store.go
@@ -117,7 +117,7 @@ func getSessionByInternalSessionID(ctx context.Context, db *gorm.DB, sessionID s
 	return &session, nil
 }
 
-func providerSessionsFromMetadata(metadata types.SessionMetadata) (map[string]ProviderSessionMetadata, error) {
+func providerSessionsFromMetadata(metadata types.ObjectMetadata) (map[string]ProviderSessionMetadata, error) {
 	if metadata.Extra == nil {
 		return map[string]ProviderSessionMetadata{}, nil
 	}

--- a/backend/internal/agent/externalcli/session_store_test.go
+++ b/backend/internal/agent/externalcli/session_store_test.go
@@ -28,9 +28,9 @@ func TestSessionMetadataProviderSessionStoreUpsertAndGet(t *testing.T) {
 	ctx := context.Background()
 	session := &types.Session{
 		PublicID: "sess_external_cli",
-		Type:      types.SessionTypeUserChat,
-		Status:    string(types.SessionStatusActive),
-		Metadata: types.SessionMetadata{
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusActive),
+		Metadata: types.ObjectMetadata{
 			Extra: map[string]interface{}{
 				"source": "test",
 			},
@@ -119,8 +119,8 @@ func TestSessionMetadataProviderSessionStoreMarkFailedPreservesBinding(t *testin
 	ctx := context.Background()
 	session := &types.Session{
 		PublicID: "sess_failed_preserve",
-		Type:      types.SessionTypeUserChat,
-		Status:    string(types.SessionStatusActive),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusActive),
 	}
 	if err := db.WithContext(ctx).Create(session).Error; err != nil {
 		t.Fatalf("create session: %v", err)

--- a/backend/internal/agent/externalcli/session_store_test.go
+++ b/backend/internal/agent/externalcli/session_store_test.go
@@ -28,7 +28,7 @@ func TestSessionMetadataProviderSessionStoreUpsertAndGet(t *testing.T) {
 	ctx := context.Background()
 	session := &types.Session{
 		PublicID: "sess_external_cli",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 		Status:    string(types.SessionStatusActive),
 		Metadata: types.SessionMetadata{
 			Extra: map[string]interface{}{
@@ -119,7 +119,7 @@ func TestSessionMetadataProviderSessionStoreMarkFailedPreservesBinding(t *testin
 	ctx := context.Background()
 	session := &types.Session{
 		PublicID: "sess_failed_preserve",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 		Status:    string(types.SessionStatusActive),
 	}
 	if err := db.WithContext(ctx).Create(session).Error; err != nil {

--- a/backend/internal/api/contract/session_type.go
+++ b/backend/internal/api/contract/session_type.go
@@ -8,19 +8,19 @@ import (
 
 // CreateSessionRequest creates a session.
 type CreateSessionRequest struct {
-	SessionID   string                 `json:"session_id,omitempty"`
-	Type        string                 `json:"type" binding:"required"`
-	AssistantID uint                   `json:"assistant_id,omitempty"`
-	Title       string                 `json:"title,omitempty"`
-	Metadata    *types.SessionMetadata `json:"metadata,omitempty"`
-	ExpiredAt   *time.Time             `json:"expired_at,omitempty"`
+	SessionID   string                `json:"session_id,omitempty"`
+	Type        string                `json:"type" binding:"required"`
+	AssistantID uint                  `json:"assistant_id,omitempty"`
+	Title       string                `json:"title,omitempty"`
+	Metadata    *types.ObjectMetadata `json:"metadata,omitempty"`
+	ExpiredAt   *time.Time            `json:"expired_at,omitempty"`
 }
 
 // UpdateSessionRequest updates basic session fields.
 type UpdateSessionRequest struct {
-	Title     string                 `json:"title,omitempty"`
-	Metadata  *types.SessionMetadata `json:"metadata,omitempty"`
-	ExpiredAt *time.Time             `json:"expired_at,omitempty"`
+	Title     string                `json:"title,omitempty"`
+	Metadata  *types.ObjectMetadata `json:"metadata,omitempty"`
+	ExpiredAt *time.Time            `json:"expired_at,omitempty"`
 }
 
 // ListSessionsRequest queries sessions.
@@ -35,49 +35,49 @@ type ListSessionsRequest struct {
 
 // AddMessageRequest adds a message to a session.
 type AddMessageRequest struct {
-	Role        string                 `json:"role" binding:"required"`
-	Content     string                 `json:"content" binding:"required"`
-	MessageType string                 `json:"message_type,omitempty"`
-	Chunks      []types.MessageChunk   `json:"chunks,omitempty"`
-	Thinking    string                 `json:"thinking,omitempty"`
-	Metadata    *types.MessageMetadata `json:"metadata,omitempty"`
-	Usage       *types.MessageUsage    `json:"usage,omitempty"`
+	Role        string                `json:"role" binding:"required"`
+	Content     string                `json:"content" binding:"required"`
+	MessageType string                `json:"message_type,omitempty"`
+	Chunks      []types.MessageChunk  `json:"chunks,omitempty"`
+	Thinking    string                `json:"thinking,omitempty"`
+	Metadata    *types.ObjectMetadata `json:"metadata,omitempty"`
+	Usage       *types.MessageUsage   `json:"usage,omitempty"`
 }
 
 // Session is the API response shape for a conversation.
 type Session struct {
-	ID                   uint                   `json:"id"`
-	SessionID            string                 `json:"session_id"`
-	Type                 string                 `json:"type"`
-	Uin                  uint                   `json:"uin"`
-	OrgID                uint                   `json:"org_id"`
-	AssistantID          uint                   `json:"assistant_id"`
-	AllocatedAssistantID uint                   `json:"allocated_assistant_id"`
-	AssistantCode        string                 `json:"assistant_code"`
-	Status               string                 `json:"status"`
-	Title                string                 `json:"title"`
-	TitleManuallySet     bool                   `json:"title_manually_set,omitempty"`
-	Metadata             *types.SessionMetadata `json:"metadata,omitempty"`
-	MessageCount         int                    `json:"message_count"`
-	LastMessageAt        *time.Time             `json:"last_message_at,omitempty"`
-	ExpiredAt            *time.Time             `json:"expired_at,omitempty"`
-	CreatedAt            time.Time              `json:"created_at"`
-	UpdatedAt            time.Time              `json:"updated_at"`
+	ID                   uint                  `json:"id"`
+	SessionID            string                `json:"session_id"`
+	Type                 string                `json:"type"`
+	Uin                  uint                  `json:"uin"`
+	OrgID                uint                  `json:"org_id"`
+	AssistantID          uint                  `json:"assistant_id"`
+	AllocatedAssistantID uint                  `json:"allocated_assistant_id"`
+	AssistantCode        string                `json:"assistant_code"`
+	Status               string                `json:"status"`
+	Title                string                `json:"title"`
+	TitleManuallySet     bool                  `json:"title_manually_set,omitempty"`
+	Metadata             *types.ObjectMetadata `json:"metadata,omitempty"`
+	MessageCount         int                   `json:"message_count"`
+	LastMessageAt        *time.Time            `json:"last_message_at,omitempty"`
+	ExpiredAt            *time.Time            `json:"expired_at,omitempty"`
+	CreatedAt            time.Time             `json:"created_at"`
+	UpdatedAt            time.Time             `json:"updated_at"`
 }
 
 // SessionMessage is the API response shape for a persisted conversation message.
 type SessionMessage struct {
-	ID          string                 `json:"id"`
-	SessionID   string                 `json:"session_id"`
-	Role        string                 `json:"role"`
-	Content     string                 `json:"content"`
-	Chunks      []SessionEvent         `json:"chunks,omitempty"`
-	Timestamp   int64                  `json:"timestamp"`
-	MessageType string                 `json:"message_type,omitempty"`
-	Metadata    *types.MessageMetadata `json:"metadata,omitempty"`
-	Usage       *types.MessageUsage    `json:"usage,omitempty"`
-	Sequence    int64                  `json:"sequence"`
-	CreatedAt   time.Time              `json:"created_at"`
+	ID          string                `json:"id"`
+	SessionID   string                `json:"session_id"`
+	Role        string                `json:"role"`
+	Content     string                `json:"content"`
+	Chunks      []SessionEvent        `json:"chunks,omitempty"`
+	Timestamp   int64                 `json:"timestamp"`
+	MessageType string                `json:"message_type,omitempty"`
+	Metadata    *types.ObjectMetadata `json:"metadata,omitempty"`
+	Usage       *types.MessageUsage   `json:"usage,omitempty"`
+	Sequence    int64                 `json:"sequence"`
+	CreatedAt   time.Time             `json:"created_at"`
 }
 
 // SessionEvent is the public event shape embedded in persisted message chunks.
@@ -106,25 +106,25 @@ type MessageList struct {
 
 // CompleteSessionMessageRequest persists a completed assistant message.
 type CompleteSessionMessageRequest struct {
-	SessionID string                 `json:"session_id"`
-	Content   string                 `json:"content"`
-	Chunks    []types.MessageChunk   `json:"chunks,omitempty"`
-	Metadata  *types.MessageMetadata `json:"metadata,omitempty"`
-	Usage     *types.MessageUsage    `json:"usage,omitempty"`
-	Seq       int64                  `json:"seq"`
-	CreatedAt time.Time              `json:"created_at"`
+	SessionID string                `json:"session_id"`
+	Content   string                `json:"content"`
+	Chunks    []types.MessageChunk  `json:"chunks,omitempty"`
+	Metadata  *types.ObjectMetadata `json:"metadata,omitempty"`
+	Usage     *types.MessageUsage   `json:"usage,omitempty"`
+	Seq       int64                 `json:"seq"`
+	CreatedAt time.Time             `json:"created_at"`
 }
 
 // FailedSessionMessageRequest persists a failed assistant message.
 type FailedSessionMessageRequest struct {
-	SessionID string                 `json:"session_id"`
-	Content   string                 `json:"content,omitempty"`
-	Chunks    []types.MessageChunk   `json:"chunks,omitempty"`
-	ErrorMsg  string                 `json:"error_msg"`
-	ErrorCode string                 `json:"error_code,omitempty"`
-	Status    string                 `json:"status,omitempty"`
-	Metadata  *types.MessageMetadata `json:"metadata,omitempty"`
-	Usage     *types.MessageUsage    `json:"usage,omitempty"`
-	Seq       int64                  `json:"seq"`
-	CreatedAt time.Time              `json:"created_at"`
+	SessionID string                `json:"session_id"`
+	Content   string                `json:"content,omitempty"`
+	Chunks    []types.MessageChunk  `json:"chunks,omitempty"`
+	ErrorMsg  string                `json:"error_msg"`
+	ErrorCode string                `json:"error_code,omitempty"`
+	Status    string                `json:"status,omitempty"`
+	Metadata  *types.ObjectMetadata `json:"metadata,omitempty"`
+	Usage     *types.MessageUsage   `json:"usage,omitempty"`
+	Seq       int64                 `json:"seq"`
+	CreatedAt time.Time             `json:"created_at"`
 }

--- a/backend/internal/infra/db/database.go
+++ b/backend/internal/infra/db/database.go
@@ -78,6 +78,9 @@ func runMigrations(db *gorm.DB) error {
 		&types.Session{},
 		&types.SessionMessage{},
 		&types.LLMModel{},
+		&types.Project{},
+		&types.ProjectMember{},
+		&types.Task{},
 	}
 
 	if err := dbtools.InitModel(db, models...); err != nil {

--- a/backend/internal/infra/db/session_dao.go
+++ b/backend/internal/infra/db/session_dao.go
@@ -81,7 +81,7 @@ func ExpireSessions(ctx context.Context, db *gorm.DB) error {
 }
 
 // ListSessions 分页查询会话列表
-func ListSessions(ctx context.Context, db *gorm.DB, sessionType *string, status *string, userID *uint, orgID *uint, assistantID *uint, assistantCode *string, keyword *string, offset, limit int) ([]*types.Session, int64, error) {
+func ListSessions(ctx context.Context, db *gorm.DB, sessionType *types.SessionType, status *string, userID *uint, orgID *uint, assistantID *uint, assistantCode *string, keyword *string, offset, limit int) ([]*types.Session, int64, error) {
 	var entities []*types.Session
 	var total int64
 

--- a/backend/internal/infra/db/session_dao_test.go
+++ b/backend/internal/infra/db/session_dao_test.go
@@ -362,7 +362,7 @@ func TestListSessions_ByType(t *testing.T) {
 	}
 	session2 := &types.Session{
 		PublicID: "type_test_2",
-		Type:     types.SessionTypeAssistantInstance,
+		Type:     types.SessionTypeTask,
 	}
 
 	if err := CreateSession(ctx, db, session1); err != nil {

--- a/backend/internal/infra/db/session_dao_test.go
+++ b/backend/internal/infra/db/session_dao_test.go
@@ -32,9 +32,9 @@ func TestCreateSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "test_session_1",
-		Type:      string(types.SessionTypeUserChat),
-		Uin:       1,
-		Title:     "Test Session",
+		Type:     types.SessionTypeUserChat,
+		Uin:      1,
+		Title:    "Test Session",
 	}
 
 	err := CreateSession(ctx, db, session)
@@ -57,7 +57,7 @@ func TestCreateSession_DuplicatePublicID(t *testing.T) {
 
 	session1 := &types.Session{
 		PublicID: "duplicate_id",
-		Type:      string(types.SessionTypeUserChat),
+		Type:     types.SessionTypeUserChat,
 	}
 
 	err := CreateSession(ctx, db, session1)
@@ -67,7 +67,7 @@ func TestCreateSession_DuplicatePublicID(t *testing.T) {
 
 	session2 := &types.Session{
 		PublicID: "duplicate_id",
-		Type:      string(types.SessionTypeUserChat),
+		Type:     types.SessionTypeUserChat,
 	}
 
 	err = CreateSession(ctx, db, session2)
@@ -82,9 +82,9 @@ func TestGetSessionByID(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "get_by_id_test",
-		Type:      string(types.SessionTypeUserChat),
-		Uin:       1,
-		Title:     "Get By ID Test",
+		Type:     types.SessionTypeUserChat,
+		Uin:      1,
+		Title:    "Get By ID Test",
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -125,8 +125,8 @@ func TestGetSessionByPublicID(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "get_by_session_id_test",
-		Type:      string(types.SessionTypeUserChat),
-		Title:     "Get By PublicID Test",
+		Type:     types.SessionTypeUserChat,
+		Title:    "Get By PublicID Test",
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -153,8 +153,8 @@ func TestUpdateSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "update_test",
-		Type:      string(types.SessionTypeUserChat),
-		Title:     "Original Title",
+		Type:     types.SessionTypeUserChat,
+		Title:    "Original Title",
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -183,7 +183,7 @@ func TestDeleteSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "delete_test",
-		Type:      string(types.SessionTypeUserChat),
+		Type:     types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -211,8 +211,8 @@ func TestActivateSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "activate_test",
-		Type:      string(types.SessionTypeUserChat),
-		Status:    string(types.SessionStatusEnded),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusEnded),
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -240,8 +240,8 @@ func TestPauseSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "pause_test",
-		Type:      string(types.SessionTypeUserChat),
-		Status:    string(types.SessionStatusActive),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusActive),
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -269,8 +269,8 @@ func TestEndSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "end_test",
-		Type:      string(types.SessionTypeUserChat),
-		Status:    string(types.SessionStatusActive),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusActive),
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -298,8 +298,8 @@ func TestResumeSession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "resume_test",
-		Type:      string(types.SessionTypeUserChat),
-		Status:    string(types.SessionStatusPaused),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusPaused),
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -327,8 +327,8 @@ func TestExpireSessions(t *testing.T) {
 
 	expiredAt := time.Now().Add(-1 * time.Hour)
 	session := &types.Session{
-		PublicID: "expire_test",
-		Type:      string(types.SessionTypeUserChat),
+		PublicID:  "expire_test",
+		Type:      types.SessionTypeUserChat,
 		Status:    string(types.SessionStatusActive),
 		ExpiredAt: &expiredAt,
 	}
@@ -358,11 +358,11 @@ func TestListSessions_ByType(t *testing.T) {
 
 	session1 := &types.Session{
 		PublicID: "type_test_1",
-		Type:      string(types.SessionTypeUserChat),
+		Type:     types.SessionTypeUserChat,
 	}
 	session2 := &types.Session{
 		PublicID: "type_test_2",
-		Type:      string(types.SessionTypeAssistantInstance),
+		Type:     types.SessionTypeAssistantInstance,
 	}
 
 	if err := CreateSession(ctx, db, session1); err != nil {
@@ -372,7 +372,7 @@ func TestListSessions_ByType(t *testing.T) {
 		t.Fatalf("failed to create session2: %v", err)
 	}
 
-	typeFilter := string(types.SessionTypeUserChat)
+	typeFilter := types.SessionTypeUserChat
 	sessions, total, err := ListSessions(ctx, db, &typeFilter, nil, nil, nil, nil, nil, nil, 0, 20)
 	if err != nil {
 		t.Fatalf("ListSessions failed: %v", err)
@@ -386,7 +386,7 @@ func TestListSessions_ByType(t *testing.T) {
 		t.Errorf("expected 1 session, got %d", len(sessions))
 	}
 
-	if sessions[0].Type != string(types.SessionTypeUserChat) {
+	if sessions[0].Type != types.SessionTypeUserChat {
 		t.Errorf("expected user_chat type, got %s", sessions[0].Type)
 	}
 }
@@ -397,13 +397,13 @@ func TestListSessions_ByStatus(t *testing.T) {
 
 	session1 := &types.Session{
 		PublicID: "status_test_1",
-		Type:      string(types.SessionTypeUserChat),
-		Status:    string(types.SessionStatusActive),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusActive),
 	}
 	session2 := &types.Session{
 		PublicID: "status_test_2",
-		Type:      string(types.SessionTypeUserChat),
-		Status:    string(types.SessionStatusPaused),
+		Type:     types.SessionTypeUserChat,
+		Status:   string(types.SessionStatusPaused),
 	}
 
 	if err := CreateSession(ctx, db, session1); err != nil {
@@ -434,13 +434,13 @@ func TestListSessions_ByKeyword(t *testing.T) {
 
 	session1 := &types.Session{
 		PublicID: "keyword_test_1",
-		Type:      string(types.SessionTypeUserChat),
-		Title:     "Project Alpha",
+		Type:     types.SessionTypeUserChat,
+		Title:    "Project Alpha",
 	}
 	session2 := &types.Session{
 		PublicID: "keyword_test_2",
-		Type:      string(types.SessionTypeUserChat),
-		Title:     "Project Beta",
+		Type:     types.SessionTypeUserChat,
+		Title:    "Project Beta",
 	}
 
 	if err := CreateSession(ctx, db, session1); err != nil {
@@ -472,7 +472,7 @@ func TestListSessions_Pagination(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		session := &types.Session{
 			PublicID: "pagination_test_" + string(rune(i)),
-			Type:      string(types.SessionTypeUserChat),
+			Type:     types.SessionTypeUserChat,
 		}
 		if err := CreateSession(ctx, db, session); err != nil {
 			t.Fatalf("failed to create session %d: %v", i, err)
@@ -498,8 +498,8 @@ func TestIncrementMessageCount(t *testing.T) {
 	ctx := context.Background()
 
 	session := &types.Session{
-		PublicID:    "increment_test",
-		Type:         string(types.SessionTypeUserChat),
+		PublicID:     "increment_test",
+		Type:         types.SessionTypeUserChat,
 		MessageCount: 0,
 	}
 
@@ -528,7 +528,7 @@ func TestUpdateLastMessageAt(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "last_message_test",
-		Type:      string(types.SessionTypeUserChat),
+		Type:     types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {

--- a/backend/internal/infra/db/session_message_dao_test.go
+++ b/backend/internal/infra/db/session_message_dao_test.go
@@ -13,7 +13,7 @@ func TestCreateMessage(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "create_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -43,7 +43,7 @@ func TestGetMessageByID(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "get_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -81,7 +81,7 @@ func TestGetSessionMessages(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "get_messages_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -124,7 +124,7 @@ func TestGetSessionMessages_Pagination(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "pagination_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -163,7 +163,7 @@ func TestDeleteMessage(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "delete_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -202,7 +202,7 @@ func TestClearSessionMessages(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "clear_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -242,7 +242,7 @@ func TestGetLatestMessage(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "latest_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -281,7 +281,7 @@ func TestGetMessageCount(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "count_msg_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -316,7 +316,7 @@ func TestGetNextSequence(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "sequence_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {
@@ -351,7 +351,7 @@ func TestGetNextSequence_EmptySession(t *testing.T) {
 
 	session := &types.Session{
 		PublicID: "empty_sequence_session",
-		Type:      string(types.SessionTypeUserChat),
+		Type:      types.SessionTypeUserChat,
 	}
 
 	if err := CreateSession(ctx, db, session); err != nil {

--- a/backend/internal/runnable/session_completed.go
+++ b/backend/internal/runnable/session_completed.go
@@ -124,7 +124,7 @@ func messageUsageFromRuntime(usage *events.UsagePayload) *types.MessageUsage {
 	}
 }
 
-func messageMetadataFromRunCompleted(completed *events.RunCompletedPayload) *types.MessageMetadata {
+func messageMetadataFromRunCompleted(completed *events.RunCompletedPayload) *types.ObjectMetadata {
 	if completed == nil {
 		return nil
 	}
@@ -138,7 +138,7 @@ func messageMetadataFromRunCompleted(completed *events.RunCompletedPayload) *typ
 	if err != nil {
 		return nil
 	}
-	msgMetadata := &types.MessageMetadata{}
+	msgMetadata := &types.ObjectMetadata{}
 	if err := json.Unmarshal(data, msgMetadata); err != nil {
 		return nil
 	}

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -65,7 +65,7 @@ func (s *sessionService) CreateSession(ctx context.Context, req *contract.Create
 
 	session := &types.Session{
 		PublicID:             sessionID,
-		Type:                 req.Type,
+		Type:                 types.SessionType(req.Type),
 		Uin:                  caller.Uin,
 		OrgID:                caller.OrgID,
 		AssistantID:          req.AssistantID,
@@ -154,10 +154,11 @@ func (s *sessionService) ListSessions(ctx context.Context, req *contract.ListSes
 		orgID = &caller.OrgID
 	}
 
+	sessionType := (*types.SessionType)(req.Type)
 	sessions, total, err := db.ListSessions(
 		ctx,
 		s.db,
-		req.Type,
+		sessionType,
 		req.Status,
 		uin,
 		orgID,
@@ -415,7 +416,7 @@ func (s *sessionService) publishWorkerTask(ctx context.Context, session *types.S
 	}
 
 	if session.AssistantID == 0 && session.AllocatedAssistantID == 0 && s.inferrer != nil {
-		assignedAssistantID := s.inferrer.InferAssignedAssistantID(ctx, orgID, session.Type)
+		assignedAssistantID := s.inferrer.InferAssignedAssistantID(ctx, orgID, string(session.Type))
 		if assignedAssistantID > 0 {
 			session.AllocatedAssistantID = assignedAssistantID
 			if err := db.UpdateAllocatedAssistantID(ctx, s.db, session.ID, assignedAssistantID); err != nil {
@@ -584,7 +585,7 @@ func convertToContractSession(session *types.Session) *contract.Session {
 	result := &contract.Session{
 		ID:                   session.ID,
 		SessionID:            session.PublicID,
-		Type:                 session.Type,
+		Type:                 string(session.Type),
 		Uin:                  session.Uin,
 		OrgID:                session.OrgID,
 		AssistantID:          session.AssistantID,

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -321,7 +321,7 @@ func (s *sessionService) buildMessage(req *contract.AddMessageRequest, sequence 
 	if req.Metadata != nil {
 		message.Metadata = *req.Metadata
 	} else {
-		message.Metadata = types.MessageMetadata{}
+		message.Metadata = types.ObjectMetadata{}
 	}
 	if req.Usage != nil {
 		message.Usage = *req.Usage
@@ -598,7 +598,7 @@ func convertToContractSession(session *types.Session) *contract.Session {
 		UpdatedAt:            session.UpdatedAt,
 	}
 
-	if session.Metadata.Tags != nil || session.Metadata.Extra != nil || session.Metadata.UserAgent != "" || session.Metadata.IPAddress != "" {
+	if session.Metadata.Tags != nil || session.Metadata.Extra != nil {
 		result.Metadata = &session.Metadata
 	}
 	if session.LastMessageAt != nil {
@@ -639,7 +639,7 @@ func convertToContractSessionMessage(message *types.SessionMessage, publicID str
 		}
 	}
 
-	if message.Metadata.Model != "" || message.Metadata.Latency != 0 || message.Metadata.Extra != nil {
+	if message.Metadata.Extra != nil {
 		result.Metadata = &message.Metadata
 	}
 

--- a/backend/internal/service/session_service_test.go
+++ b/backend/internal/service/session_service_test.go
@@ -736,7 +736,7 @@ func TestListSessions_FilterByType(t *testing.T) {
 		Type: string(types.SessionTypeUserChat),
 	}
 	req2 := &contract.CreateSessionRequest{
-		Type: string(types.SessionTypeAssistantInstance),
+		Type: string(types.SessionTypeTask),
 	}
 
 	_, err := service.CreateSession(ctx, req1)

--- a/backend/types/constants.go
+++ b/backend/types/constants.go
@@ -194,3 +194,24 @@ const (
 	// EventActionCommented 表示评论事件
 	EventActionCommented EventAction = "commented"
 )
+
+// TaskStatus 表示任务的当前状态
+type TaskStatus string
+
+const (
+	TaskStatusCreated           TaskStatus = "created"
+	TaskStatusPendingAssignment TaskStatus = "pending_assignment"
+	TaskStatusInProgress        TaskStatus = "in_progress"
+	TaskStatusPendingApproval   TaskStatus = "pending_approval"
+	TaskStatusCompleted         TaskStatus = "completed"
+	TaskStatusFailed            TaskStatus = "failed"
+	TaskStatusCancelled         TaskStatus = "cancelled"
+	TaskStatusPaused            TaskStatus = "paused"
+)
+
+type TaskType string
+
+const (
+	TaskTypeGeneral TaskType = "general"
+	TaskTypeCron    TaskType = "cron"
+)

--- a/backend/types/project.go
+++ b/backend/types/project.go
@@ -34,7 +34,7 @@ type Project struct {
 	Status string `gorm:"column:status;type:varchar(50);not null;default:'active';index"`
 
 	// project - 元数据（JSON格式存储标签等扩展信息），JSONB，允许为空
-	Metadata ProjectMetadata `gorm:"column:metadata;type:jsonb"`
+	Metadata ObjectMetadata `gorm:"column:metadata;type:jsonb"`
 }
 
 // TableName 指定Project结构体对应的数据库表名
@@ -42,8 +42,8 @@ func (Project) TableName() string {
 	return TableNameProject
 }
 
-// ProjectMetadata 项目元数据结构
-type ProjectMetadata struct {
+// ObjectMetadata 项目元数据结构
+type ObjectMetadata struct {
 	// 元数据 - 项目标签
 	Tags []string `json:"tags,omitempty"`
 	// 元数据 - 项目类型/模板标识
@@ -53,21 +53,21 @@ type ProjectMetadata struct {
 }
 
 // Scan 实现 sql.Scanner 接口
-func (pm *ProjectMetadata) Scan(value interface{}) error {
+func (pm *ObjectMetadata) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
 
 	bytes, ok := value.([]byte)
 	if !ok {
-		return fmt.Errorf("cannot scan %T into ProjectMetadata", value)
+		return fmt.Errorf("cannot scan %T into ObjectMetadata", value)
 	}
 
 	return json.Unmarshal(bytes, pm)
 }
 
 // Value 实现 driver.Valuer 接口
-func (pm ProjectMetadata) Value() (driver.Value, error) {
+func (pm ObjectMetadata) Value() (driver.Value, error) {
 	return json.Marshal(pm)
 }
 

--- a/backend/types/session.go
+++ b/backend/types/session.go
@@ -14,7 +14,6 @@ type SessionType string
 
 const (
 	SessionTypeUserChat          SessionType = "chat"
-	SessionTypeAssistantInstance SessionType = "assistant_instance"
 	SessionTypeTask              SessionType = "task"
 )
 

--- a/backend/types/session.go
+++ b/backend/types/session.go
@@ -13,8 +13,8 @@ import (
 type SessionType string
 
 const (
-	SessionTypeUserChat          SessionType = "chat"
-	SessionTypeTask              SessionType = "task"
+	SessionTypeUserChat SessionType = "chat"
+	SessionTypeTask     SessionType = "task"
 )
 
 // SessionStatus 会话状态常量
@@ -95,7 +95,7 @@ type Session struct {
 	TitleManuallySet bool `gorm:"column:title_manually_set;type:boolean;default:false;not null"`
 
 	// session - 元数据，JSON格式存储额外信息，JSONB，允许为空
-	Metadata SessionMetadata `gorm:"column:metadata;type:jsonb"`
+	Metadata ObjectMetadata `gorm:"column:metadata;type:jsonb"`
 
 	// session - 消息数量，INTEGER，DEFAULT 0
 	MessageCount int `gorm:"column:message_count;type:integer;default:0"`
@@ -110,37 +110,6 @@ type Session struct {
 // TableName 指定Session结构体对应的数据库表名
 func (Session) TableName() string {
 	return TableNameSession
-}
-
-// SessionMetadata 会话元数据结构
-type SessionMetadata struct {
-	// 元数据 - 用户代理信息
-	UserAgent string `json:"user_agent,omitempty"`
-	// 元数据 - IP地址
-	IPAddress string `json:"ip_address,omitempty"`
-	// 元数据 - 自定义标签
-	Tags []string `json:"tags,omitempty"`
-	// 元数据 - 其他扩展字段
-	Extra map[string]interface{} `json:"extra,omitempty"`
-}
-
-// Scan 实现 sql.Scanner 接口，用于从数据库中读取 JSON 数据
-func (sm *SessionMetadata) Scan(value interface{}) error {
-	if value == nil {
-		return nil
-	}
-
-	bytes, ok := value.([]byte)
-	if !ok {
-		return fmt.Errorf("cannot scan %T into SessionMetadata", value)
-	}
-
-	return json.Unmarshal(bytes, sm)
-}
-
-// Value 实现 driver.Valuer 接口，用于将元数据转换为 JSON 存储
-func (sm SessionMetadata) Value() (driver.Value, error) {
-	return json.Marshal(sm)
 }
 
 // SessionMessage 会话消息结构体
@@ -165,7 +134,7 @@ type SessionMessage struct {
 	Chunks MessageChunkSlice `gorm:"column:chunks;type:jsonb"`
 
 	// session_message - 消息元数据，JSONB，允许为空
-	Metadata MessageMetadata `gorm:"column:metadata;type:jsonb"`
+	Metadata ObjectMetadata `gorm:"column:metadata;type:jsonb"`
 
 	Usage MessageUsage `gorm:"column:usage;type:jsonb"`
 
@@ -179,16 +148,6 @@ type SessionMessage struct {
 // TableName 指定SessionMessage结构体对应的数据库表名
 func (SessionMessage) TableName() string {
 	return TableNameSessionMessage
-}
-
-// MessageMetadata 消息元数据结构
-type MessageMetadata struct {
-	// LLM 模型名称
-	Model string `json:"model,omitempty"`
-	// 延迟（毫秒）
-	Latency int `json:"latency,omitempty"`
-	// 其他扩展字段
-	Extra map[string]interface{} `json:"extra,omitempty"`
 }
 
 // MessageUsage stores model token usage for a session message.
@@ -237,25 +196,6 @@ func (m MessageChunkSlice) Value() (driver.Value, error) {
 		return nil, nil
 	}
 	return json.Marshal([]MessageChunk(m))
-}
-
-// Scan 实现 sql.Scanner 接口
-func (mm *MessageMetadata) Scan(value interface{}) error {
-	if value == nil {
-		return nil
-	}
-
-	bytes, ok := value.([]byte)
-	if !ok {
-		return fmt.Errorf("cannot scan %T into MessageMetadata", value)
-	}
-
-	return json.Unmarshal(bytes, mm)
-}
-
-// Value 实现 driver.Valuer 接口
-func (mm MessageMetadata) Value() (driver.Value, error) {
-	return json.Marshal(mm)
 }
 
 // Scan 瀹炵幇 sql.Scanner 鎺ュ彛

--- a/backend/types/session.go
+++ b/backend/types/session.go
@@ -13,8 +13,9 @@ import (
 type SessionType string
 
 const (
-	SessionTypeUserChat          SessionType = "user_chat"
+	SessionTypeUserChat          SessionType = "chat"
 	SessionTypeAssistantInstance SessionType = "assistant_instance"
+	SessionTypeTask              SessionType = "task"
 )
 
 // SessionStatus 会话状态常量
@@ -65,7 +66,7 @@ type Session struct {
 	PublicID string `gorm:"column:public_id;type:varchar(255);not null;uniqueIndex"`
 
 	// session - 会话类型，VARCHAR(50)，NOT NULL
-	Type string `gorm:"column:type;type:varchar(50);not null"`
+	Type SessionType `gorm:"column:type;type:varchar(50);not null"`
 
 	// session - 关联用户UIN，0表示不关联，BIGINT，DEFAULT 0
 	Uin uint `gorm:"column:uin;type:bigint;default:0;index"`
@@ -78,6 +79,12 @@ type Session struct {
 
 	// session - 分配的数字员工ID，0表示未分配，BIGINT，DEFAULT 0
 	AllocatedAssistantID uint `gorm:"column:allocated_assistant_id;type:bigint;default:0;index"`
+
+	// session - 关联任务ID，允许为空，BIGINT，INDEX（scope=task时绑定）
+	TaskID *uint `gorm:"column:task_id;type:bigint;index"`
+
+	// session - 关联项目ID，允许为空，BIGINT，INDEX（scope=project时绑定）
+	ProjectID *uint `gorm:"column:project_id;type:bigint;index"`
 
 	// session - 会话状态，VARCHAR(50)，NOT NULL，DEFAULT 'active'
 	Status string `gorm:"column:status;type:varchar(50);not null;default:'active'"`

--- a/backend/types/tables.go
+++ b/backend/types/tables.go
@@ -46,4 +46,7 @@ const (
 	TableNameProject = tablenamePrefix + "project"
 	// TableNameProjectMember 项目成员表名
 	TableNameProjectMember = tablenamePrefix + "project_member"
+
+	// TableNameTask 任务表名
+	TableNameTask = tablenamePrefix + "task"
 )

--- a/backend/types/task.go
+++ b/backend/types/task.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Task 表示系统中的任务
+//
+// 任务是项目中的最小执行单元，由 AI 队友（DigitalAssistant）执行，
+// 支持子任务拆分（通过 ParentTaskID 自引用）和状态生命周期管理。
+type Task struct {
+	gorm.Model
+	PublicID  string `gorm:"column:public_id;type:varchar(255);not null;uniqueIndex"`
+	OrgID     uint   `gorm:"column:org_id;type:integer;not null;index"`
+	OwnerID   uint   `gorm:"column:owner_id;type:integer;not null;index"`
+	ProjectID uint   `gorm:"column:project_id;type:bigint;not null;index"`
+	SessionID *uint  `gorm:"column:session_id;type:bigint;index"`
+
+	// TaskType 任务类型（如：general/general、cron/定时任务等），VARCHAR(16)，NOT NULL，DEFAULT 'general'
+	TaskType TaskType `gorm:"column:task_type;type:varchar(16);not null;default:'general';index"`
+
+	AssigneeID *uint `gorm:"column:assignee_id;type:bigint;index"`
+
+	Title       string     `gorm:"column:title;type:varchar(500);not null"`
+	Description string     `gorm:"column:description;type:text"`
+	Status      string     `gorm:"column:status;type:varchar(50);not null;default:'created';index"`
+	Deadline    *time.Time `gorm:"column:deadline;index"`
+
+	Metadata ObjectMetadata `gorm:"column:metadata;type:jsonb"`
+}
+
+// TableName 指定Task结构体对应的数据库表名
+func (Task) TableName() string {
+	return TableNameTask
+}


### PR DESCRIPTION
- 新增 TableNameTask 表名常量 (leros_task)
- 新增 TaskStatus 类型及8个状态常量(created/pending_assignment/in_progress/pending_approval/completed/failed/cancelled/paused)
- 新建 Task GORM模型，支持子任务自引用(ParentTaskID)、会话关联(SessionID)、AI执行者分配(AssigneeID)
- 迁移列表添加 Task 表