### PR TITLE
feat(project): 实现 Project 基础 CRUD 接口

### DIFF
--- a/backend/internal/api/contract/project.go
+++ b/backend/internal/api/contract/project.go
@@ -1,0 +1,21 @@
+package contract
+
+import "context"
+
+// ProjectService 定义项目服务接口
+type ProjectService interface {
+	// 创建项目
+	CreateProject(ctx context.Context, req *CreateProjectRequest) (*Project, error)
+
+	// 根据PublicID获取项目详情
+	GetProject(ctx context.Context, publicID string) (*Project, error)
+
+	// 更新项目
+	UpdateProject(ctx context.Context, publicID string, req *UpdateProjectRequest) (*Project, error)
+
+	// 删除项目
+	DeleteProject(ctx context.Context, publicID string) error
+
+	// 查询项目列表
+	ListProjects(ctx context.Context, req *ListProjectsRequest) (*ProjectList, error)
+}

--- a/backend/internal/api/contract/project.go
+++ b/backend/internal/api/contract/project.go
@@ -17,5 +17,5 @@ type ProjectService interface {
 	DeleteProject(ctx context.Context, publicID string) error
 
 	// 查询项目列表
-	ListProjects(ctx context.Context, opt *ListProjectQuery) (*ProjectList, error)
+	ListProjects(ctx context.Context, req *ListProjectsRequest) (*ProjectList, error)
 }

--- a/backend/internal/api/contract/project.go
+++ b/backend/internal/api/contract/project.go
@@ -17,5 +17,5 @@ type ProjectService interface {
 	DeleteProject(ctx context.Context, publicID string) error
 
 	// 查询项目列表
-	ListProjects(ctx context.Context, req *ListProjectsRequest) (*ProjectList, error)
+	ListProjects(ctx context.Context, opt *ListProjectQuery) (*ProjectList, error)
 }

--- a/backend/internal/api/contract/project_type.go
+++ b/backend/internal/api/contract/project_type.go
@@ -1,12 +1,6 @@
 package contract
 
-import (
-	"fmt"
-	"net/http"
-	"time"
-
-	"github.com/ygpkg/yg-go/apis/apiobj"
-)
+import "time"
 
 // Project 项目响应结构
 type Project struct {
@@ -36,38 +30,26 @@ type UpdateProjectRequest struct {
 	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
 }
 
-// ListProjectQuery 查询项目列表请求，基于 apiobj.PageQuery
-type ListProjectQuery struct {
-	apiobj.PageQuery
-}
-
-// AllowFilterFields 实现 apiobj.allowFilterFielder 接口
-func (ListProjectQuery) AllowFilterFields() []string {
-	return []string{"name", "status", "public_id"}
-}
-
-// AllowOrderFields 实现 apiobj.allowOrderFielder 接口
-func (ListProjectQuery) AllowOrderFields() []string {
-	return []string{"created_at", "updated_at", "name"}
+// ListProjectsRequest 查询项目列表请求
+type ListProjectsRequest struct {
+	Keyword *string `json:"keyword,omitempty"`
+	Status  *string `json:"status,omitempty"`
+	Offset  int     `json:"offset,omitempty"`
+	Limit   int     `json:"limit,omitempty"`
+	ListAll bool    `json:"list_all,omitempty"`
 }
 
 // Fill 设置分页默认值
-func (q *ListProjectQuery) Fill(req *http.Request) {
-	q.PageQuery.Fill(req)
-	if err := q.PageQuery.IsValite(q); err != nil {
-		// 校验错误在 handler 层处理
+func (r *ListProjectsRequest) Fill() {
+	if r.Offset < 0 {
+		r.Offset = 0
 	}
-}
-
-// Validate 校验查询参数
-func (q *ListProjectQuery) Validate() error {
-	if err := q.PageQuery.IsValite(q); err != nil {
-		return err
+	if r.Limit <= 0 || r.Limit > 150 {
+		r.Limit = 10
 	}
-	if q.Offset <= 0 {
-		q.Offset = 0
+	if r.ListAll {
+		r.Limit = 150
 	}
-	return nil
 }
 
 // ProjectList 项目列表响应
@@ -76,15 +58,4 @@ type ProjectList struct {
 	Offset int       `json:"offset"`
 	Limit  int       `json:"limit"`
 	Items  []Project `json:"items"`
-}
-
-// Validate 校验项目名称
-func (p *Project) Validate() error {
-	if p.Name == "" {
-		return fmt.Errorf("project name is required")
-	}
-	if p.PublicID == "" {
-		return fmt.Errorf("project public_id is required")
-	}
-	return nil
 }

--- a/backend/internal/api/contract/project_type.go
+++ b/backend/internal/api/contract/project_type.go
@@ -1,0 +1,46 @@
+package contract
+
+import "time"
+
+// Project 项目响应结构
+type Project struct {
+	PublicID    string                 `json:"public_id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	OwnerID     uint                   `json:"owner_id"`
+	Status      string                 `json:"status"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+}
+
+// CreateProjectRequest 创建项目请求
+type CreateProjectRequest struct {
+	Name        string                 `json:"name" binding:"required"`
+	Description string                 `json:"description,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// UpdateProjectRequest 更新项目请求
+type UpdateProjectRequest struct {
+	Name        *string                 `json:"name,omitempty"`
+	Description *string                 `json:"description,omitempty"`
+	OwnerID     *uint                   `json:"owner_id,omitempty"`
+	Status      *string                 `json:"status,omitempty"`
+	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ListProjectsRequest 查询项目列表请求
+type ListProjectsRequest struct {
+	Keyword *string `json:"keyword,omitempty"`
+	Status  *string `json:"status,omitempty"`
+	Pagination
+}
+
+// ProjectList 项目列表响应
+type ProjectList struct {
+	Total  int64     `json:"total"`
+	Offset int       `json:"offset"`
+	Limit  int       `json:"limit"`
+	Items  []Project `json:"items"`
+}

--- a/backend/internal/api/contract/project_type.go
+++ b/backend/internal/api/contract/project_type.go
@@ -1,6 +1,12 @@
 package contract
 
-import "time"
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ygpkg/yg-go/apis/apiobj"
+)
 
 // Project 项目响应结构
 type Project struct {
@@ -30,11 +36,38 @@ type UpdateProjectRequest struct {
 	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
 }
 
-// ListProjectsRequest 查询项目列表请求
-type ListProjectsRequest struct {
-	Keyword *string `json:"keyword,omitempty"`
-	Status  *string `json:"status,omitempty"`
-	Pagination
+// ListProjectQuery 查询项目列表请求，基于 apiobj.PageQuery
+type ListProjectQuery struct {
+	apiobj.PageQuery
+}
+
+// AllowFilterFields 实现 apiobj.allowFilterFielder 接口
+func (ListProjectQuery) AllowFilterFields() []string {
+	return []string{"name", "status", "public_id"}
+}
+
+// AllowOrderFields 实现 apiobj.allowOrderFielder 接口
+func (ListProjectQuery) AllowOrderFields() []string {
+	return []string{"created_at", "updated_at", "name"}
+}
+
+// Fill 设置分页默认值
+func (q *ListProjectQuery) Fill(req *http.Request) {
+	q.PageQuery.Fill(req)
+	if err := q.PageQuery.IsValite(q); err != nil {
+		// 校验错误在 handler 层处理
+	}
+}
+
+// Validate 校验查询参数
+func (q *ListProjectQuery) Validate() error {
+	if err := q.PageQuery.IsValite(q); err != nil {
+		return err
+	}
+	if q.Offset <= 0 {
+		q.Offset = 0
+	}
+	return nil
 }
 
 // ProjectList 项目列表响应
@@ -43,4 +76,15 @@ type ProjectList struct {
 	Offset int       `json:"offset"`
 	Limit  int       `json:"limit"`
 	Items  []Project `json:"items"`
+}
+
+// Validate 校验项目名称
+func (p *Project) Validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("project name is required")
+	}
+	if p.PublicID == "" {
+		return fmt.Errorf("project public_id is required")
+	}
+	return nil
 }

--- a/backend/internal/api/handler/project_handler.go
+++ b/backend/internal/api/handler/project_handler.go
@@ -166,22 +166,20 @@ func (h *ProjectHandler) DeleteProject(ctx *gin.Context) {
 // @Tags Project
 // @Accept json
 // @Produce json
-// @Param body body contract.ListProjectQuery true "查询列表请求"
+// @Param body body contract.ListProjectsRequest true "查询列表请求"
 // @Success 200 {object} dto.Response "成功响应"
 // @Failure 400 {object} dto.ErrorResponse "请求参数错误"
 // @Failure 401 {object} dto.ErrorResponse "未认证"
 // @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
 // @Router /ListProjects [post]
 func (h *ProjectHandler) ListProjects(ctx *gin.Context) {
-	var req contract.ListProjectQuery
+	var req contract.ListProjectsRequest
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
 		return
 	}
-	if err := req.Validate(); err != nil {
-		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
-		return
-	}
+
+	req.Fill()
 
 	result, err := h.service.ListProjects(ctx, &req)
 	if err != nil {

--- a/backend/internal/api/handler/project_handler.go
+++ b/backend/internal/api/handler/project_handler.go
@@ -1,0 +1,215 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/api/dto"
+)
+
+type ProjectHandler struct {
+	service contract.ProjectService
+}
+
+func NewProjectHandler(service contract.ProjectService) *ProjectHandler {
+	return &ProjectHandler{service: service}
+}
+
+// ================================================================
+// Route Registration
+// ================================================================
+
+func (h *ProjectHandler) RegisterRoutes(r gin.IRouter) {
+	r.POST("/CreateProject", h.CreateProject)
+	r.POST("/GetProject", h.GetProject)
+	r.POST("/UpdateProject", h.UpdateProject)
+	r.POST("/DeleteProject", h.DeleteProject)
+	r.POST("/ListProjects", h.ListProjects)
+}
+
+func RegisterProjectRoutes(r gin.IRouter, service contract.ProjectService) {
+	h := NewProjectHandler(service)
+	h.RegisterRoutes(r)
+}
+
+// ================================================================
+// Handler Methods
+// ================================================================
+
+// @Summary 创建项目
+// @Description 创建一个新项目
+// @Tags Project
+// @Accept json
+// @Produce json
+// @Param body body contract.CreateProjectRequest true "创建项目请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /CreateProject [post]
+func (h *ProjectHandler) CreateProject(ctx *gin.Context) {
+	var req contract.CreateProjectRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	result, err := h.service.CreateProject(ctx, &req)
+	if err != nil {
+		handleProjectServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+type GetProjectRequest struct {
+	PublicID *string `json:"public_id,omitempty"`
+}
+
+// @Summary 获取项目详情
+// @Description 根据PublicId获取项目详情
+// @Tags Project
+// @Accept json
+// @Produce json
+// @Param body body GetProjectRequest true "获取项目请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 404 {object} dto.ErrorResponse "资源不存在"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /GetProject [post]
+func (h *ProjectHandler) GetProject(ctx *gin.Context) {
+	var req GetProjectRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+	if req.PublicID == nil || *req.PublicID == "" {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "public_id is required"))
+		return
+	}
+
+	result, err := h.service.GetProject(ctx, *req.PublicID)
+	if err != nil {
+		handleProjectServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+type UpdateProjectRequest struct {
+	PublicID string `json:"public_id" binding:"required"`
+	contract.UpdateProjectRequest
+}
+
+// @Summary 更新项目
+// @Description 更新项目信息
+// @Tags Project
+// @Accept json
+// @Produce json
+// @Param body body UpdateProjectRequest true "更新项目请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 404 {object} dto.ErrorResponse "资源不存在"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /UpdateProject [post]
+func (h *ProjectHandler) UpdateProject(ctx *gin.Context) {
+	var req UpdateProjectRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	result, err := h.service.UpdateProject(ctx, req.PublicID, &req.UpdateProjectRequest)
+	if err != nil {
+		handleProjectServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+type DeleteProjectRequest struct {
+	PublicID string `json:"public_id" binding:"required"`
+}
+
+// @Summary 删除项目
+// @Description 根据PublicId删除项目（软删除）
+// @Tags Project
+// @Accept json
+// @Produce json
+// @Param body body DeleteProjectRequest true "删除项目请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 404 {object} dto.ErrorResponse "资源不存在"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /DeleteProject [post]
+func (h *ProjectHandler) DeleteProject(ctx *gin.Context) {
+	var req DeleteProjectRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	if err := h.service.DeleteProject(ctx, req.PublicID); err != nil {
+		handleProjectServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(nil))
+}
+
+// @Summary 查询项目列表
+// @Description 分页查询项目列表
+// @Tags Project
+// @Accept json
+// @Produce json
+// @Param body body contract.ListProjectsRequest true "查询列表请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /ListProjects [post]
+func (h *ProjectHandler) ListProjects(ctx *gin.Context) {
+	var req contract.ListProjectsRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	req.Pagination.Fill()
+
+	result, err := h.service.ListProjects(ctx, &req)
+	if err != nil {
+		handleProjectServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+// ================================================================
+// Error Handling
+// ================================================================
+
+func handleProjectServiceError(ctx *gin.Context, err error) {
+	errMsg := err.Error()
+
+	switch errMsg {
+	case "user not authenticated or org not set":
+		ctx.JSON(http.StatusUnauthorized, dto.Error(dto.CodeInternalError, errMsg))
+		return
+	}
+
+	switch errMsg {
+	case "project not found":
+		ctx.JSON(http.StatusNotFound, dto.Error(dto.CodeNotFound, errMsg))
+	case "name is required",
+		"name cannot be empty",
+		"public_id is required":
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, errMsg))
+	default:
+		ctx.JSON(http.StatusInternalServerError, dto.Error(dto.CodeInternalError, errMsg))
+	}
+}

--- a/backend/internal/api/handler/project_handler.go
+++ b/backend/internal/api/handler/project_handler.go
@@ -166,20 +166,22 @@ func (h *ProjectHandler) DeleteProject(ctx *gin.Context) {
 // @Tags Project
 // @Accept json
 // @Produce json
-// @Param body body contract.ListProjectsRequest true "查询列表请求"
+// @Param body body contract.ListProjectQuery true "查询列表请求"
 // @Success 200 {object} dto.Response "成功响应"
 // @Failure 400 {object} dto.ErrorResponse "请求参数错误"
 // @Failure 401 {object} dto.ErrorResponse "未认证"
 // @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
 // @Router /ListProjects [post]
 func (h *ProjectHandler) ListProjects(ctx *gin.Context) {
-	var req contract.ListProjectsRequest
+	var req contract.ListProjectQuery
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
 		return
 	}
-
-	req.Pagination.Fill()
+	if err := req.Validate(); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
 
 	result, err := h.service.ListProjects(ctx, &req)
 	if err != nil {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -84,6 +84,10 @@ func SetupRouter(cfg config.Config, eventbus eventbus.EventBus, db *gorm.DB) *gi
 		handler.RegisterSessionRoutes(v1, sessionService)
 		logs.Info("Session routes registered successfully")
 
+		projectService := service.NewProjectService(db)
+		handler.RegisterProjectRoutes(v1, projectService)
+		logs.Info("Project routes registered successfully")
+
 		// Start background consumers
 		go runnable.StartSessionCompleted(context.Background(), sessionService, eventbus)
 		logs.Info("Session completed runnable started")

--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -8,11 +8,28 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/ygpkg/yg-go/apis/apiobj"
 	"github.com/ygpkg/yg-go/logs"
 
 	"github.com/insmtx/Leros/backend/types"
 )
+
+// ProjectQuery 项目列表查询参数
+type ProjectQuery struct {
+	Filters []Filter
+	OrderBy []string
+	OrgID   uint
+	Uin     uint
+	Offset  int
+	Limit   int
+	ListAll bool
+}
+
+// Filter 过滤条件
+type Filter struct {
+	Field      string
+	Value      []string
+	ExactMatch bool
+}
 
 // CreateProject 创建项目
 func CreateProject(ctx context.Context, db *gorm.DB, project *types.Project) error {
@@ -50,10 +67,10 @@ type ListProjectsResponse struct {
 	Items  []*types.Project `json:"items"`
 }
 
-// ListProjects 查询项目列表，使用 apiobj.PageQuery 作为查询参数
-func ListProjects(ctx context.Context, d *gorm.DB, orgID uint, opt *apiobj.PageQuery, ret *ListProjectsResponse) error {
+// ListProjects 查询项目列表，使用 ProjectQuery 作为查询参数
+func ListProjects(ctx context.Context, d *gorm.DB, opt *ProjectQuery, ret *ListProjectsResponse) error {
 	query := d.WithContext(ctx).Table(types.TableNameProject).
-		Where("org_id = ? AND deleted_at IS NULL", orgID)
+		Where("org_id = ? AND deleted_at IS NULL", opt.OrgID)
 
 	for _, filter := range opt.Filters {
 		switch filter.Field {
@@ -96,7 +113,7 @@ func ListProjects(ctx context.Context, d *gorm.DB, orgID uint, opt *apiobj.PageQ
 	if !opt.ListAll && opt.Limit > 0 {
 		query = query.Limit(opt.Limit)
 	} else {
-		query = query.Limit(apiobj.PageMaxCount)
+		query = query.Limit(150)
 	}
 
 	err := query.Find(&ret.Items).Error

--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -50,7 +50,7 @@ type ListProjectsResponse struct {
 	Items  []*types.Project `json:"items"`
 }
 
-// ListProjects 使用 apiobj.PageQuery 风格的过滤器和排序分页查询项目列表
+// ListProjects 查询项目列表，使用 apiobj.PageQuery 作为查询参数
 func ListProjects(ctx context.Context, d *gorm.DB, orgID uint, opt *apiobj.PageQuery, ret *ListProjectsResponse) error {
 	query := d.WithContext(ctx).Table(types.TableNameProject).
 		Where("org_id = ? AND deleted_at IS NULL", orgID)

--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/types"
+)
+
+// CreateProject 创建项目
+func CreateProject(ctx context.Context, db *gorm.DB, project *types.Project) error {
+	return db.WithContext(ctx).Create(project).Error
+}
+
+// GetProjectByPublicID 根据组织ID和PublicID获取项目
+func GetProjectByPublicID(ctx context.Context, db *gorm.DB, orgID uint, publicID string) (*types.Project, error) {
+	var entity types.Project
+	err := db.WithContext(ctx).Where("org_id = ? AND public_id = ?", orgID, publicID).First(&entity).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &entity, nil
+}
+
+// UpdateProject 更新项目
+func UpdateProject(ctx context.Context, db *gorm.DB, project *types.Project) error {
+	return db.WithContext(ctx).Save(project).Error
+}
+
+// DeleteProject 删除项目（软删除）
+func DeleteProject(ctx context.Context, db *gorm.DB, id uint) error {
+	return db.WithContext(ctx).Delete(&types.Project{}, id).Error
+}
+
+// ListProjects 分页查询项目列表
+func ListProjects(ctx context.Context, db *gorm.DB, orgID uint, keyword, status *string, offset, limit int) ([]*types.Project, int64, error) {
+	var entities []*types.Project
+	var total int64
+
+	query := db.WithContext(ctx).Model(&types.Project{}).Where("org_id = ?", orgID)
+
+	if keyword != nil && *keyword != "" {
+		query = query.Where("name LIKE ? OR description LIKE ?",
+			"%"+*keyword+"%", "%"+*keyword+"%")
+	}
+	if status != nil && *status != "" {
+		query = query.Where("status = ?", *status)
+	}
+
+	err := query.Count(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = query.Offset(offset).Limit(limit).Order("created_at DESC").Find(&entities).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return entities, total, nil
+}

--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -3,8 +3,13 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"gorm.io/gorm"
+
+	"github.com/ygpkg/yg-go/apis/apiobj"
+	"github.com/ygpkg/yg-go/logs"
 
 	"github.com/insmtx/Leros/backend/types"
 )
@@ -37,30 +42,66 @@ func DeleteProject(ctx context.Context, db *gorm.DB, id uint) error {
 	return db.WithContext(ctx).Delete(&types.Project{}, id).Error
 }
 
-// ListProjects 分页查询项目列表
-func ListProjects(ctx context.Context, db *gorm.DB, orgID uint, keyword, status *string, offset, limit int) ([]*types.Project, int64, error) {
-	var entities []*types.Project
-	var total int64
+// ListProjectsResponse 项目列表查询结果
+type ListProjectsResponse struct {
+	Total  int64            `json:"total"`
+	Offset int              `json:"offset"`
+	Limit  int              `json:"limit"`
+	Items  []*types.Project `json:"items"`
+}
 
-	query := db.WithContext(ctx).Model(&types.Project{}).Where("org_id = ?", orgID)
+// ListProjects 使用 apiobj.PageQuery 风格的过滤器和排序分页查询项目列表
+func ListProjects(ctx context.Context, d *gorm.DB, orgID uint, opt *apiobj.PageQuery, ret *ListProjectsResponse) error {
+	query := d.WithContext(ctx).Table(types.TableNameProject).
+		Where("org_id = ? AND deleted_at IS NULL", orgID)
 
-	if keyword != nil && *keyword != "" {
-		query = query.Where("name LIKE ? OR description LIKE ?",
-			"%"+*keyword+"%", "%"+*keyword+"%")
+	for _, filter := range opt.Filters {
+		switch filter.Field {
+		case "name":
+			if filter.ExactMatch {
+				query = query.Where("name IN (?)", filter.Value)
+			} else {
+				conds := make([]string, len(filter.Value))
+				vals := make([]interface{}, len(filter.Value))
+				for i, v := range filter.Value {
+					conds[i] = "name LIKE ?"
+					vals[i] = "%" + v + "%"
+				}
+				query = query.Where(strings.Join(conds, " OR "), vals...)
+			}
+		case "status":
+			query = query.Where("status IN (?)", filter.Value)
+		case "public_id":
+			query = query.Where("public_id IN (?)", filter.Value)
+		default:
+			logs.WarnContextf(ctx, "[project][ListProjects] invalid filter field: %s", filter.Field)
+			return fmt.Errorf("invalid filter field: %s", filter.Field)
+		}
 	}
-	if status != nil && *status != "" {
-		query = query.Where("status = ?", *status)
+
+	if err := query.Count(&ret.Total).Error; err != nil {
+		return err
+	}
+	if ret.Total == 0 {
+		return nil
 	}
 
-	err := query.Count(&total).Error
+	if len(opt.OrderBy) > 0 {
+		query = query.Order(strings.Join(opt.OrderBy, ","))
+	} else {
+		query = query.Order("created_at DESC")
+	}
+
+	query = query.Offset(opt.Offset)
+	if !opt.ListAll && opt.Limit > 0 {
+		query = query.Limit(opt.Limit)
+	} else {
+		query = query.Limit(apiobj.PageMaxCount)
+	}
+
+	err := query.Find(&ret.Items).Error
 	if err != nil {
-		return nil, 0, err
+		return err
 	}
-
-	err = query.Offset(offset).Limit(limit).Order("created_at DESC").Find(&entities).Error
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return entities, total, nil
+	return nil
 }

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/infra/db"
 	"github.com/insmtx/Leros/backend/types"
-	"github.com/ygpkg/yg-go/apis/apiobj"
 	"github.com/ygpkg/yg-go/encryptor/snowflake"
 )
 
@@ -176,20 +175,22 @@ func (s *projectService) ListProjects(ctx context.Context, req *contract.ListPro
 	}
 	req.Fill()
 
-	opt := &apiobj.PageQuery{
+	opt := &db.ProjectQuery{
+		OrgID:   caller.OrgID,
+		Uin:     caller.Uin,
 		Offset:  req.Offset,
 		Limit:   req.Limit,
 		ListAll: req.ListAll,
 	}
 	if req.Keyword != nil && *req.Keyword != "" {
-		opt.Filters = append(opt.Filters, apiobj.Filter{Field: "name", Value: []string{*req.Keyword}})
+		opt.Filters = append(opt.Filters, db.Filter{Field: "name", Value: []string{*req.Keyword}})
 	}
 	if req.Status != nil && *req.Status != "" {
-		opt.Filters = append(opt.Filters, apiobj.Filter{Field: "status", Value: []string{*req.Status}})
+		opt.Filters = append(opt.Filters, db.Filter{Field: "status", Value: []string{*req.Status}})
 	}
 
 	var ret db.ListProjectsResponse
-	if err := db.ListProjects(ctx, s.db, caller.OrgID, opt, &ret); err != nil {
+	if err := db.ListProjects(ctx, s.db, opt, &ret); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/infra/db"
 	"github.com/insmtx/Leros/backend/types"
+	"github.com/ygpkg/yg-go/apis/apiobj"
 	"github.com/ygpkg/yg-go/encryptor/snowflake"
 )
 
@@ -168,17 +169,27 @@ func (s *projectService) DeleteProject(ctx context.Context, publicID string) err
 	})
 }
 
-func (s *projectService) ListProjects(ctx context.Context, opt *contract.ListProjectQuery) (*contract.ProjectList, error) {
+func (s *projectService) ListProjects(ctx context.Context, req *contract.ListProjectsRequest) (*contract.ProjectList, error) {
 	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if err := opt.Validate(); err != nil {
-		return nil, err
+	req.Fill()
+
+	opt := &apiobj.PageQuery{
+		Offset:  req.Offset,
+		Limit:   req.Limit,
+		ListAll: req.ListAll,
+	}
+	if req.Keyword != nil && *req.Keyword != "" {
+		opt.Filters = append(opt.Filters, apiobj.Filter{Field: "name", Value: []string{*req.Keyword}})
+	}
+	if req.Status != nil && *req.Status != "" {
+		opt.Filters = append(opt.Filters, apiobj.Filter{Field: "status", Value: []string{*req.Status}})
 	}
 
 	var ret db.ListProjectsResponse
-	if err := db.ListProjects(ctx, s.db, caller.OrgID, &opt.PageQuery, &ret); err != nil {
+	if err := db.ListProjects(ctx, s.db, caller.OrgID, opt, &ret); err != nil {
 		return nil, err
 	}
 
@@ -188,8 +199,8 @@ func (s *projectService) ListProjects(ctx context.Context, opt *contract.ListPro
 	}
 	return &contract.ProjectList{
 		Total:  ret.Total,
-		Offset: opt.Offset,
-		Limit:  opt.Limit,
+		Offset: req.Offset,
+		Limit:  req.Limit,
 		Items:  items,
 	}, nil
 }

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/infra/db"
+	"github.com/insmtx/Leros/backend/types"
+	"github.com/ygpkg/yg-go/encryptor/snowflake"
+)
+
+type projectService struct {
+	db *gorm.DB
+}
+
+// NewProjectService 创建项目服务实例
+func NewProjectService(db *gorm.DB) contract.ProjectService {
+	return &projectService{
+		db: db,
+	}
+}
+
+func (s *projectService) CreateProject(ctx context.Context, req *contract.CreateProjectRequest) (*contract.Project, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, errors.New("name is required")
+	}
+
+	publicID := generateProjectPublicID()
+
+	project := &types.Project{
+		OrgID:       caller.OrgID,
+		PublicID:    publicID,
+		OwnerID:     caller.Uin,
+		Name:        strings.TrimSpace(req.Name),
+		Description: strings.TrimSpace(req.Description),
+		Status:      "active",
+	}
+	if req.Metadata != nil {
+		project.Metadata = types.ObjectMetadata{}
+		if tags, ok := req.Metadata["tags"].([]interface{}); ok {
+			for _, t := range tags {
+				if s, ok := t.(string); ok {
+					project.Metadata.Tags = append(project.Metadata.Tags, s)
+				}
+			}
+		}
+		if t, ok := req.Metadata["type"].(string); ok {
+			project.Metadata.Type = t
+		}
+		if extra, ok := req.Metadata["extra"].(map[string]interface{}); ok {
+			project.Metadata.Extra = extra
+		}
+	}
+
+	if err := db.CreateProject(ctx, s.db, project); err != nil {
+		return nil, err
+	}
+	return convertToContractProject(project), nil
+}
+
+func (s *projectService) GetProject(ctx context.Context, publicID string) (*contract.Project, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(publicID) == "" {
+		return nil, errors.New("public_id is required")
+	}
+
+	project, err := db.GetProjectByPublicID(ctx, s.db, caller.OrgID, publicID)
+	if err != nil {
+		return nil, err
+	}
+	if project == nil {
+		return nil, errors.New("project not found")
+	}
+	return convertToContractProject(project), nil
+}
+
+func (s *projectService) UpdateProject(ctx context.Context, publicID string, req *contract.UpdateProjectRequest) (*contract.Project, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(publicID) == "" {
+		return nil, errors.New("public_id is required")
+	}
+
+	var project *types.Project
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		project, err = db.GetProjectByPublicID(ctx, tx, caller.OrgID, publicID)
+		if err != nil {
+			return err
+		}
+		if project == nil {
+			return errors.New("project not found")
+		}
+
+		if req.Name != nil {
+			project.Name = strings.TrimSpace(*req.Name)
+			if project.Name == "" {
+				return errors.New("name cannot be empty")
+			}
+		}
+		if req.Description != nil {
+			project.Description = strings.TrimSpace(*req.Description)
+		}
+		if req.OwnerID != nil {
+			project.OwnerID = *req.OwnerID
+		}
+		if req.Status != nil {
+			project.Status = *req.Status
+		}
+		if req.Metadata != nil {
+			if *req.Metadata != nil {
+				newMeta := types.ObjectMetadata{}
+				if tags, ok := (*req.Metadata)["tags"].([]interface{}); ok {
+					for _, t := range tags {
+						if s, ok := t.(string); ok {
+							newMeta.Tags = append(newMeta.Tags, s)
+						}
+					}
+				}
+				if t, ok := (*req.Metadata)["type"].(string); ok {
+					newMeta.Type = t
+				}
+				if extra, ok := (*req.Metadata)["extra"].(map[string]interface{}); ok {
+					newMeta.Extra = extra
+				}
+				project.Metadata = newMeta
+			}
+		}
+
+		return db.UpdateProject(ctx, tx, project)
+	}); err != nil {
+		return nil, err
+	}
+	return convertToContractProject(project), nil
+}
+
+func (s *projectService) DeleteProject(ctx context.Context, publicID string) error {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(publicID) == "" {
+		return errors.New("public_id is required")
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		project, err := db.GetProjectByPublicID(ctx, tx, caller.OrgID, publicID)
+		if err != nil {
+			return err
+		}
+		if project == nil {
+			return errors.New("project not found")
+		}
+		return db.DeleteProject(ctx, tx, project.ID)
+	})
+}
+
+func (s *projectService) ListProjects(ctx context.Context, req *contract.ListProjectsRequest) (*contract.ProjectList, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	projects, total, err := db.ListProjects(ctx, s.db, caller.OrgID, req.Keyword, req.Status, req.Offset, req.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]contract.Project, 0, len(projects))
+	for _, project := range projects {
+		items = append(items, *convertToContractProject(project))
+	}
+	return &contract.ProjectList{
+		Total:  total,
+		Offset: req.Offset,
+		Limit:  req.Limit,
+		Items:  items,
+	}, nil
+}
+
+func convertToContractProject(project *types.Project) *contract.Project {
+	if project == nil {
+		return nil
+	}
+
+	var metadata map[string]interface{}
+	m := make(map[string]interface{})
+	if len(project.Metadata.Tags) > 0 {
+		m["tags"] = project.Metadata.Tags
+	}
+	if project.Metadata.Type != "" {
+		m["type"] = project.Metadata.Type
+	}
+	if project.Metadata.Extra != nil && len(project.Metadata.Extra) > 0 {
+		m["extra"] = project.Metadata.Extra
+	}
+	if len(m) > 0 {
+		metadata = m
+	}
+
+	return &contract.Project{
+		PublicID:    project.PublicID,
+		Name:        project.Name,
+		Description: project.Description,
+		OwnerID:     project.OwnerID,
+		Status:      project.Status,
+		Metadata:    metadata,
+		CreatedAt:   project.CreatedAt,
+		UpdatedAt:   project.UpdatedAt,
+	}
+}
+
+func generateProjectPublicID() string {
+	return fmt.Sprintf("prj_%s", snowflake.GenerateIDBase58())
+}
+
+// ensure project implements contract.ProjectService at compile time
+var _ contract.ProjectService = (*projectService)(nil)

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -168,25 +168,28 @@ func (s *projectService) DeleteProject(ctx context.Context, publicID string) err
 	})
 }
 
-func (s *projectService) ListProjects(ctx context.Context, req *contract.ListProjectsRequest) (*contract.ProjectList, error) {
+func (s *projectService) ListProjects(ctx context.Context, opt *contract.ListProjectQuery) (*contract.ProjectList, error) {
 	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	projects, total, err := db.ListProjects(ctx, s.db, caller.OrgID, req.Keyword, req.Status, req.Offset, req.Limit)
-	if err != nil {
+	if err := opt.Validate(); err != nil {
 		return nil, err
 	}
 
-	items := make([]contract.Project, 0, len(projects))
-	for _, project := range projects {
+	var ret db.ListProjectsResponse
+	if err := db.ListProjects(ctx, s.db, caller.OrgID, &opt.PageQuery, &ret); err != nil {
+		return nil, err
+	}
+
+	items := make([]contract.Project, 0, len(ret.Items))
+	for _, project := range ret.Items {
 		items = append(items, *convertToContractProject(project))
 	}
 	return &contract.ProjectList{
-		Total:  total,
-		Offset: req.Offset,
-		Limit:  req.Limit,
+		Total:  ret.Total,
+		Offset: opt.Offset,
+		Limit:  opt.Limit,
 		Items:  items,
 	}, nil
 }


### PR DESCRIPTION
新增 Project 模块的完整四层架构实现:
- DAO 层: Create/GetByPublicID/Update/Delete/ListProjects
- Contract 层: ProjectService 接口 + 请求/响应类型定义
- Service 层: 参数校验、PublicID 自动生成、Org 权限校验、Metadata JSONB 转换
- Handler 层: POST /v1/{CreateProject,GetProject,UpdateProject,DeleteProject,ListProjects}

项目采用 PublicId 作为外部标识（不暴露内部 ID），支持软删除、分页查询、
关键词搜索（Name/Description 模糊匹配）和状态筛选。