### PR TITLE
feat(task): 新增Task CRUD完整能力

### DIFF
--- a/backend/cmd/leros/project.go
+++ b/backend/cmd/leros/project.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/ygpkg/yg-go/lifecycle"
+	"github.com/ygpkg/yg-go/logs"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/cli"
+)
+
+var (
+	projectServerAddr string
+	projectJSON       bool
+	projectKeyword    string
+	projectStatus     string
+	projectOffset     int
+	projectLimit      int
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage projects",
+	Long:  `Manage projects in the Leros platform.`,
+}
+
+var projectLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List projects",
+	Long:  `List all projects with optional filtering.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		go func() {
+			req := &contract.ListProjectsRequest{
+				Pagination: contract.ListProjectsRequest{}.Pagination,
+			}
+			req.Offset = projectOffset
+			req.Limit = projectLimit
+			req.Fill()
+
+			if projectKeyword != "" {
+				req.Keyword = &projectKeyword
+			}
+			if projectStatus != "" {
+				req.Status = &projectStatus
+			}
+
+			result, err := cli.ListProjects(lifecycle.Std().Context(), projectServerAddr, req)
+			if err != nil {
+				logs.Errorf("list projects: %v", err)
+				lifecycle.Std().Exit()
+				return
+			}
+			printProjects(result)
+			lifecycle.Std().Exit()
+		}()
+		lifecycle.Std().WaitExit()
+	},
+}
+
+func printProjects(list *contract.ProjectList) {
+	if projectJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(list.Items)
+		return
+	}
+
+	if len(list.Items) == 0 {
+		fmt.Println("No projects found.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "PUBLIC_ID\tNAME\tSTATUS\tCREATED_AT")
+	for _, p := range list.Items {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.PublicID, p.Name, p.Status, p.CreatedAt.Format("2006-01-02T15:04:05Z"))
+	}
+	w.Flush()
+
+	fmt.Fprintf(os.Stderr, "\nTotal: %d, Offset: %d, Limit: %d\n", list.Total, list.Offset, list.Limit)
+}
+
+func init() {
+	projectLsCmd.Flags().StringVar(&projectServerAddr, "server-addr", "127.0.0.1:8080", "Leros server address (host:port)")
+	projectLsCmd.Flags().BoolVar(&projectJSON, "json", false, "Output in JSON format")
+	projectLsCmd.Flags().StringVar(&projectKeyword, "keyword", "", "Filter by name keyword")
+	projectLsCmd.Flags().StringVar(&projectStatus, "status", "", "Filter by status")
+	projectLsCmd.Flags().IntVar(&projectOffset, "offset", 0, "Pagination offset")
+	projectLsCmd.Flags().IntVar(&projectLimit, "limit", 20, "Pagination limit")
+
+	projectCmd.AddCommand(projectLsCmd)
+	rootCmd.AddCommand(projectCmd)
+}

--- a/backend/cmd/leros/task.go
+++ b/backend/cmd/leros/task.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/ygpkg/yg-go/lifecycle"
+	"github.com/ygpkg/yg-go/logs"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/cli"
+)
+
+var (
+	taskServerAddr string
+	taskJSON       bool
+	taskKeyword    string
+	taskStatus     string
+	taskProjectID  uint
+	taskType       string
+	taskAssigneeID uint
+	taskOffset     int
+	taskLimit      int
+)
+
+var taskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "Manage tasks",
+	Long:  `Manage tasks in the Leros platform.`,
+}
+
+var taskLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List tasks",
+	Long:  `List all tasks with optional filtering.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		go func() {
+			req := &contract.ListTasksRequest{
+				Pagination: contract.ListTasksRequest{}.Pagination,
+			}
+			req.Offset = taskOffset
+			req.Limit = taskLimit
+			req.Fill()
+
+			if taskKeyword != "" {
+				req.Keyword = &taskKeyword
+			}
+			if taskStatus != "" {
+				req.Status = &taskStatus
+			}
+			if cmd.Flags().Changed("project-id") {
+				req.ProjectID = &taskProjectID
+			}
+			if taskType != "" {
+				req.TaskType = &taskType
+			}
+			if cmd.Flags().Changed("assignee-id") {
+				req.AssigneeID = &taskAssigneeID
+			}
+
+			result, err := cli.ListTasks(lifecycle.Std().Context(), taskServerAddr, req)
+			if err != nil {
+				logs.Errorf("list tasks: %v", err)
+				lifecycle.Std().Exit()
+				return
+			}
+			printTasks(result)
+			lifecycle.Std().Exit()
+		}()
+		lifecycle.Std().WaitExit()
+	},
+}
+
+func printTasks(list *contract.TaskList) {
+	if taskJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(list.Items)
+		return
+	}
+
+	if len(list.Items) == 0 {
+		fmt.Println("No tasks found.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "PUBLIC_ID\tTITLE\tSTATUS\tTYPE\tPROJECT_ID\tCREATED_AT")
+	for _, t := range list.Items {
+		projectID := fmt.Sprintf("%d", t.ProjectID)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			t.PublicID, t.Title, t.Status, t.TaskType, projectID,
+			t.CreatedAt.Format("2006-01-02T15:04:05Z"))
+	}
+	w.Flush()
+
+	fmt.Fprintf(os.Stderr, "\nTotal: %d, Offset: %d, Limit: %d\n", list.Total, list.Offset, list.Limit)
+}
+
+func init() {
+	taskLsCmd.Flags().StringVar(&taskServerAddr, "server-addr", "127.0.0.1:8080", "Leros server address (host:port)")
+	taskLsCmd.Flags().BoolVar(&taskJSON, "json", false, "Output in JSON format")
+	taskLsCmd.Flags().StringVar(&taskKeyword, "keyword", "", "Filter by title/description keyword")
+	taskLsCmd.Flags().StringVar(&taskStatus, "status", "", "Filter by status")
+	taskLsCmd.Flags().UintVar(&taskProjectID, "project-id", 0, "Filter by project ID")
+	taskLsCmd.Flags().StringVar(&taskType, "type", "", "Filter by task type")
+	taskLsCmd.Flags().UintVar(&taskAssigneeID, "assignee-id", 0, "Filter by assignee ID")
+	taskLsCmd.Flags().IntVar(&taskOffset, "offset", 0, "Pagination offset")
+	taskLsCmd.Flags().IntVar(&taskLimit, "limit", 20, "Pagination limit")
+
+	taskCmd.AddCommand(taskLsCmd)
+	rootCmd.AddCommand(taskCmd)
+}

--- a/backend/internal/api/contract/task.go
+++ b/backend/internal/api/contract/task.go
@@ -1,0 +1,16 @@
+package contract
+
+import "context"
+
+// TaskService 定义任务服务接口
+type TaskService interface {
+	CreateTask(ctx context.Context, req *CreateTaskRequest) (*Task, error)
+
+	GetTask(ctx context.Context, publicID string) (*Task, error)
+
+	UpdateTask(ctx context.Context, publicID string, req *UpdateTaskRequest) (*Task, error)
+
+	DeleteTask(ctx context.Context, publicID string) error
+
+	ListTasks(ctx context.Context, req *ListTasksRequest) (*TaskList, error)
+}

--- a/backend/internal/api/contract/task_type.go
+++ b/backend/internal/api/contract/task_type.go
@@ -1,0 +1,66 @@
+package contract
+
+import (
+	"time"
+
+	"github.com/insmtx/Leros/backend/types"
+)
+
+// Task 任务响应结构
+type Task struct {
+	PublicID    string                 `json:"public_id"`
+	OrgID       uint                   `json:"org_id"`
+	OwnerID     uint                   `json:"owner_id"`
+	ProjectID   uint                   `json:"project_id"`
+	SessionID   *uint                  `json:"session_id,omitempty"`
+	TaskType    string                 `json:"task_type"`
+	AssigneeID  *uint                  `json:"assignee_id,omitempty"`
+	Title       string                 `json:"title"`
+	Description string                 `json:"description"`
+	Status      string                 `json:"status"`
+	Deadline    *time.Time             `json:"deadline,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+}
+
+// CreateTaskRequest 创建任务请求
+type CreateTaskRequest struct {
+	ProjectID   uint                   `json:"project_id" binding:"required"`
+	Title       string                 `json:"title" binding:"required"`
+	Description string                 `json:"description,omitempty"`
+	TaskType    *string                `json:"task_type,omitempty"`
+	AssigneeID  *uint                  `json:"assignee_id,omitempty"`
+	Deadline    *time.Time             `json:"deadline,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// UpdateTaskRequest 更新任务请求
+type UpdateTaskRequest struct {
+	ProjectID   *uint                   `json:"project_id,omitempty"`
+	Title       *string                 `json:"title,omitempty"`
+	Description *string                 `json:"description,omitempty"`
+	TaskType    *string                 `json:"task_type,omitempty"`
+	AssigneeID  *uint                   `json:"assignee_id,omitempty"`
+	Status      *string                 `json:"status,omitempty"`
+	Deadline    *time.Time              `json:"deadline,omitempty"`
+	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ListTasksRequest 查询任务列表请求
+type ListTasksRequest struct {
+	Keyword    *string `json:"keyword,omitempty"`
+	Status     *string `json:"status,omitempty"`
+	ProjectID  *uint   `json:"project_id,omitempty"`
+	TaskType   *string `json:"task_type,omitempty"`
+	AssigneeID *uint   `json:"assignee_id,omitempty"`
+	types.Pagination
+}
+
+// TaskList 任务列表响应
+type TaskList struct {
+	Total  int64  `json:"total"`
+	Offset int    `json:"offset"`
+	Limit  int    `json:"limit"`
+	Items  []Task `json:"items"`
+}

--- a/backend/internal/api/handler/task_handler.go
+++ b/backend/internal/api/handler/task_handler.go
@@ -1,0 +1,222 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/api/dto"
+)
+
+type TaskHandler struct {
+	service contract.TaskService
+}
+
+func NewTaskHandler(service contract.TaskService) *TaskHandler {
+	return &TaskHandler{service: service}
+}
+
+// ================================================================
+// Route Registration
+// ================================================================
+
+func (h *TaskHandler) RegisterRoutes(r gin.IRouter) {
+	r.POST("/CreateTask", h.CreateTask)
+	r.POST("/GetTask", h.GetTask)
+	r.POST("/UpdateTask", h.UpdateTask)
+	r.POST("/DeleteTask", h.DeleteTask)
+	r.POST("/ListTasks", h.ListTasks)
+}
+
+func RegisterTaskRoutes(r gin.IRouter, service contract.TaskService) {
+	h := NewTaskHandler(service)
+	h.RegisterRoutes(r)
+}
+
+// ================================================================
+// Handler Methods
+// ================================================================
+
+// @Summary 创建任务
+// @Description 创建一个新任务
+// @Tags Task
+// @Accept json
+// @Produce json
+// @Param body body contract.CreateTaskRequest true "创建任务请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /CreateTask [post]
+func (h *TaskHandler) CreateTask(ctx *gin.Context) {
+	var req contract.CreateTaskRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+	if strings.TrimSpace(req.Title) == "" {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "title is required"))
+		return
+	}
+
+	result, err := h.service.CreateTask(ctx, &req)
+	if err != nil {
+		handleTaskServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+type GetTaskRequest struct {
+	PublicID *string `json:"public_id,omitempty"`
+}
+
+// @Summary 获取任务详情
+// @Description 根据PublicId获取任务详情
+// @Tags Task
+// @Accept json
+// @Produce json
+// @Param body body GetTaskRequest true "获取任务请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 404 {object} dto.ErrorResponse "资源不存在"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /GetTask [post]
+func (h *TaskHandler) GetTask(ctx *gin.Context) {
+	var req GetTaskRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+	if req.PublicID == nil || *req.PublicID == "" {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "public_id is required"))
+		return
+	}
+
+	result, err := h.service.GetTask(ctx, *req.PublicID)
+	if err != nil {
+		handleTaskServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+type UpdateTaskRequest struct {
+	PublicID string `json:"public_id" binding:"required"`
+	contract.UpdateTaskRequest
+}
+
+// @Summary 更新任务
+// @Description 更新任务信息
+// @Tags Task
+// @Accept json
+// @Produce json
+// @Param body body UpdateTaskRequest true "更新任务请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 404 {object} dto.ErrorResponse "资源不存在"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /UpdateTask [post]
+func (h *TaskHandler) UpdateTask(ctx *gin.Context) {
+	var req UpdateTaskRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	result, err := h.service.UpdateTask(ctx, req.PublicID, &req.UpdateTaskRequest)
+	if err != nil {
+		handleTaskServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+type DeleteTaskRequest struct {
+	PublicID string `json:"public_id" binding:"required"`
+}
+
+// @Summary 删除任务
+// @Description 根据PublicId删除任务（软删除）
+// @Tags Task
+// @Accept json
+// @Produce json
+// @Param body body DeleteTaskRequest true "删除任务请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 404 {object} dto.ErrorResponse "资源不存在"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /DeleteTask [post]
+func (h *TaskHandler) DeleteTask(ctx *gin.Context) {
+	var req DeleteTaskRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	if err := h.service.DeleteTask(ctx, req.PublicID); err != nil {
+		handleTaskServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(nil))
+}
+
+// @Summary 查询任务列表
+// @Description 分页查询任务列表
+// @Tags Task
+// @Accept json
+// @Produce json
+// @Param body body contract.ListTasksRequest true "查询列表请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 401 {object} dto.ErrorResponse "未认证"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /ListTasks [post]
+func (h *TaskHandler) ListTasks(ctx *gin.Context) {
+	var req contract.ListTasksRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+
+	req.Fill()
+
+	result, err := h.service.ListTasks(ctx, &req)
+	if err != nil {
+		handleTaskServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+// ================================================================
+// Error Handling
+// ================================================================
+
+func handleTaskServiceError(ctx *gin.Context, err error) {
+	errMsg := err.Error()
+
+	switch errMsg {
+	case "user not authenticated or org not set":
+		ctx.JSON(http.StatusUnauthorized, dto.Error(dto.CodeInternalError, errMsg))
+		return
+	}
+
+	switch errMsg {
+	case "task not found",
+		"project not found":
+		ctx.JSON(http.StatusNotFound, dto.Error(dto.CodeNotFound, errMsg))
+	case "title is required",
+		"title cannot be empty",
+		"public_id is required",
+		"project_id is required":
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, errMsg))
+	default:
+		ctx.JSON(http.StatusInternalServerError, dto.Error(dto.CodeInternalError, errMsg))
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -92,6 +92,10 @@ func SetupRouter(cfg config.Config, eventbus eventbus.EventBus, db *gorm.DB) *gi
 		handler.RegisterWorkRoutes(v1, workService)
 		logs.Info("Work routes registered successfully")
 
+		taskService := service.NewTaskService(db)
+		handler.RegisterTaskRoutes(v1, taskService)
+		logs.Info("Task routes registered successfully")
+
 		// Start background consumers
 		go runnable.StartSessionCompleted(context.Background(), sessionService, eventbus)
 		logs.Info("Session completed runnable started")

--- a/backend/internal/cli/lister.go
+++ b/backend/internal/cli/lister.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/api/dto"
+)
+
+// ListProjects 调用服务端 ListProjects API 并返回解析后的结果。
+func ListProjects(ctx context.Context, serverAddr string, req *contract.ListProjectsRequest) (*contract.ProjectList, error) {
+	var result contract.ProjectList
+	if err := doListRequest(ctx, serverAddr, "ListProjects", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ListTasks 调用服务端 ListTasks API 并返回解析后的结果。
+func ListTasks(ctx context.Context, serverAddr string, req *contract.ListTasksRequest) (*contract.TaskList, error) {
+	var result contract.TaskList
+	if err := doListRequest(ctx, serverAddr, "ListTasks", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// doListRequest 发送列表类 API 请求的通用封装。
+func doListRequest(ctx context.Context, serverAddr, endpoint string, reqBody, target interface{}) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	url := fmt.Sprintf("http://%s/v1/%s", serverAddr, endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp apiResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	if apiResp.Code != dto.CodeSuccess {
+		return fmt.Errorf("api error [%d]: %s", apiResp.Code, apiResp.Message)
+	}
+
+	if err := json.Unmarshal(apiResp.Data, target); err != nil {
+		return fmt.Errorf("decode data: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/infra/db/task_dao.go
+++ b/backend/internal/infra/db/task_dao.go
@@ -3,8 +3,11 @@ package db
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"gorm.io/gorm"
+
+	"github.com/ygpkg/yg-go/logs"
 
 	"github.com/insmtx/Leros/backend/types"
 )
@@ -14,10 +17,10 @@ func CreateTask(ctx context.Context, db *gorm.DB, task *types.Task) error {
 	return db.WithContext(ctx).Create(task).Error
 }
 
-// GetTaskByPublicID 根据PublicID获取任务
-func GetTaskByPublicID(ctx context.Context, db *gorm.DB, publicID string) (*types.Task, error) {
+// GetTaskByPublicID 根据组织ID和PublicID获取任务
+func GetTaskByPublicID(ctx context.Context, db *gorm.DB, orgID uint, publicID string) (*types.Task, error) {
 	var entity types.Task
-	err := db.WithContext(ctx).Where("public_id = ?", publicID).First(&entity).Error
+	err := db.WithContext(ctx).Where("org_id = ? AND public_id = ?", orgID, publicID).First(&entity).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -25,4 +28,76 @@ func GetTaskByPublicID(ctx context.Context, db *gorm.DB, publicID string) (*type
 		return nil, err
 	}
 	return &entity, nil
+}
+
+// UpdateTask 更新任务
+func UpdateTask(ctx context.Context, db *gorm.DB, task *types.Task) error {
+	return db.WithContext(ctx).Save(task).Error
+}
+
+// DeleteTask 删除任务（软删除）
+func DeleteTask(ctx context.Context, db *gorm.DB, id uint) error {
+	return db.WithContext(ctx).Delete(&types.Task{}, id).Error
+}
+
+// ListTasks 查询任务列表，使用 PageQuery 作为查询参数
+func ListTasks(ctx context.Context, d *gorm.DB, opt *types.PageQuery) ([]*types.Task, int64, error) {
+	var entities []*types.Task
+	var total int64
+
+	query := d.WithContext(ctx).Table(types.TableNameTask).
+		Where("org_id = ? AND deleted_at IS NULL", opt.OrgID)
+
+	for _, filter := range opt.Filters {
+		switch filter.Field {
+		case "keyword":
+			keyword := "%" + filter.Value[0] + "%"
+			query = query.Where("title LIKE ? OR description LIKE ?", keyword, keyword)
+		case "status":
+			query = query.Where("status IN (?)", filter.Value)
+		case "project_id":
+			if filter.ExactMatch {
+				query = query.Where("project_id IN (?)", filter.Value)
+			} else {
+				query = query.Where("project_id IN (?)", filter.Value)
+			}
+		case "task_type":
+			query = query.Where("task_type IN (?)", filter.Value)
+		case "assignee_id":
+			query = query.Where("assignee_id IN (?)", filter.Value)
+		case "title":
+			if filter.ExactMatch {
+				query = query.Where("title IN (?)", filter.Value)
+			} else {
+				query = query.Where("title LIKE ?", "%"+filter.Value[0]+"%")
+			}
+		default:
+			logs.WarnContextf(ctx, "[task][ListTasks] invalid filter field: %s", filter.Field)
+		}
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if total == 0 {
+		return nil, 0, nil
+	}
+
+	if len(opt.OrderBy) > 0 {
+		query = query.Order(strings.Join(opt.OrderBy, ","))
+	} else {
+		query = query.Order("created_at DESC")
+	}
+
+	query = query.Offset(opt.Offset)
+	if !opt.ListAll && opt.Limit > 0 {
+		query = query.Limit(opt.Limit)
+	} else {
+		query = query.Limit(150)
+	}
+
+	if err := query.Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
 }

--- a/backend/internal/service/message_poster.go
+++ b/backend/internal/service/message_poster.go
@@ -240,7 +240,7 @@ func (o *newMessageOrchestrator) ensureProjectSession() error {
 
 func (o *newMessageOrchestrator) resolveOrCreateTask() error {
 	if o.req.TaskID != "" {
-		t, err := db.GetTaskByPublicID(o.ctx, o.poster.db, o.req.TaskID)
+		t, err := db.GetTaskByPublicID(o.ctx, o.poster.db, o.caller.OrgID, o.req.TaskID)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -1,0 +1,287 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/infra/db"
+	"github.com/insmtx/Leros/backend/types"
+	"github.com/ygpkg/yg-go/encryptor/snowflake"
+)
+
+type taskService struct {
+	db *gorm.DB
+}
+
+func NewTaskService(db *gorm.DB) contract.TaskService {
+	return &taskService{
+		db: db,
+	}
+}
+
+func (s *taskService) CreateTask(ctx context.Context, req *contract.CreateTaskRequest) (*contract.Task, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.Title) == "" {
+		return nil, errors.New("title is required")
+	}
+
+	var p types.Project
+	if err := s.db.WithContext(ctx).Where("id = ? AND org_id = ?", req.ProjectID, caller.OrgID).First(&p).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("project not found")
+		}
+		return nil, err
+	}
+
+	publicID := generateTaskPublicID()
+
+	taskType := string(types.TaskTypeGeneral)
+	if req.TaskType != nil && *req.TaskType != "" {
+		taskType = *req.TaskType
+	}
+
+	task := &types.Task{
+		OrgID:       caller.OrgID,
+		PublicID:    publicID,
+		OwnerID:     caller.Uin,
+		ProjectID:   req.ProjectID,
+		TaskType:    types.TaskType(taskType),
+		AssigneeID:  req.AssigneeID,
+		Title:       strings.TrimSpace(req.Title),
+		Description: strings.TrimSpace(req.Description),
+		Status:      string(types.TaskStatusCreated),
+		Deadline:    req.Deadline,
+	}
+	if req.Metadata != nil {
+		task.Metadata = types.ObjectMetadata{}
+		if tags, ok := req.Metadata["tags"].([]interface{}); ok {
+			for _, t := range tags {
+				if s, ok := t.(string); ok {
+					task.Metadata.Tags = append(task.Metadata.Tags, s)
+				}
+			}
+		}
+		if t, ok := req.Metadata["type"].(string); ok {
+			task.Metadata.Type = t
+		}
+		if extra, ok := req.Metadata["extra"].(map[string]interface{}); ok {
+			task.Metadata.Extra = extra
+		}
+	}
+
+	if err := db.CreateTask(ctx, s.db, task); err != nil {
+		return nil, err
+	}
+	return convertToContractTask(task), nil
+}
+
+func (s *taskService) GetTask(ctx context.Context, publicID string) (*contract.Task, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(publicID) == "" {
+		return nil, errors.New("public_id is required")
+	}
+
+	task, err := db.GetTaskByPublicID(ctx, s.db, caller.OrgID, publicID)
+	if err != nil {
+		return nil, err
+	}
+	if task == nil {
+		return nil, errors.New("task not found")
+	}
+	return convertToContractTask(task), nil
+}
+
+func (s *taskService) UpdateTask(ctx context.Context, publicID string, req *contract.UpdateTaskRequest) (*contract.Task, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(publicID) == "" {
+		return nil, errors.New("public_id is required")
+	}
+
+	var task *types.Task
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		task, err = db.GetTaskByPublicID(ctx, tx, caller.OrgID, publicID)
+		if err != nil {
+			return err
+		}
+		if task == nil {
+			return errors.New("task not found")
+		}
+
+		if req.Title != nil {
+			task.Title = strings.TrimSpace(*req.Title)
+			if task.Title == "" {
+				return errors.New("title cannot be empty")
+			}
+		}
+		if req.Description != nil {
+			task.Description = strings.TrimSpace(*req.Description)
+		}
+		if req.TaskType != nil {
+			task.TaskType = types.TaskType(*req.TaskType)
+		}
+		if req.AssigneeID != nil {
+			task.AssigneeID = req.AssigneeID
+		}
+		if req.Status != nil {
+			task.Status = *req.Status
+		}
+		if req.Deadline != nil {
+			task.Deadline = req.Deadline
+		}
+		if req.ProjectID != nil {
+			var p types.Project
+			if err := tx.Where("id = ? AND org_id = ?", *req.ProjectID, caller.OrgID).First(&p).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return errors.New("project not found")
+				}
+				return err
+			}
+			task.ProjectID = *req.ProjectID
+		}
+		if req.Metadata != nil {
+			if *req.Metadata != nil {
+				newMeta := types.ObjectMetadata{}
+				if tags, ok := (*req.Metadata)["tags"].([]interface{}); ok {
+					for _, t := range tags {
+						if s, ok := t.(string); ok {
+							newMeta.Tags = append(newMeta.Tags, s)
+						}
+					}
+				}
+				if t, ok := (*req.Metadata)["type"].(string); ok {
+					newMeta.Type = t
+				}
+				if extra, ok := (*req.Metadata)["extra"].(map[string]interface{}); ok {
+					newMeta.Extra = extra
+				}
+				task.Metadata = newMeta
+			}
+		}
+
+		return db.UpdateTask(ctx, tx, task)
+	}); err != nil {
+		return nil, err
+	}
+	return convertToContractTask(task), nil
+}
+
+func (s *taskService) DeleteTask(ctx context.Context, publicID string) error {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(publicID) == "" {
+		return errors.New("public_id is required")
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		task, err := db.GetTaskByPublicID(ctx, tx, caller.OrgID, publicID)
+		if err != nil {
+			return err
+		}
+		if task == nil {
+			return errors.New("task not found")
+		}
+		return db.DeleteTask(ctx, tx, task.ID)
+	})
+}
+
+func (s *taskService) ListTasks(ctx context.Context, req *contract.ListTasksRequest) (*contract.TaskList, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	req.Fill()
+
+	opt := types.NewPageQuery(*caller, req.Offset, req.Limit)
+	opt.ListAll = req.ListAll
+	if req.Keyword != nil && *req.Keyword != "" {
+		opt.AddFilter("keyword", *req.Keyword)
+	}
+	if req.Status != nil && *req.Status != "" {
+		opt.AddFilter("status", *req.Status)
+	}
+	if req.ProjectID != nil {
+		opt.AddExactFilter("project_id", fmt.Sprintf("%d", *req.ProjectID))
+	}
+	if req.TaskType != nil && *req.TaskType != "" {
+		opt.AddFilter("task_type", *req.TaskType)
+	}
+	if req.AssigneeID != nil {
+		opt.AddExactFilter("assignee_id", fmt.Sprintf("%d", *req.AssigneeID))
+	}
+
+	tasks, total, err := db.ListTasks(ctx, s.db, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]contract.Task, 0, len(tasks))
+	for _, task := range tasks {
+		items = append(items, *convertToContractTask(task))
+	}
+	return &contract.TaskList{
+		Total:  total,
+		Offset: req.Offset,
+		Limit:  req.Limit,
+		Items:  items,
+	}, nil
+}
+
+func convertToContractTask(task *types.Task) *contract.Task {
+	if task == nil {
+		return nil
+	}
+
+	var metadata map[string]interface{}
+	m := make(map[string]interface{})
+	if len(task.Metadata.Tags) > 0 {
+		m["tags"] = task.Metadata.Tags
+	}
+	if task.Metadata.Type != "" {
+		m["type"] = task.Metadata.Type
+	}
+	if task.Metadata.Extra != nil && len(task.Metadata.Extra) > 0 {
+		m["extra"] = task.Metadata.Extra
+	}
+	if len(m) > 0 {
+		metadata = m
+	}
+
+	return &contract.Task{
+		PublicID:    task.PublicID,
+		OrgID:       task.OrgID,
+		OwnerID:     task.OwnerID,
+		ProjectID:   task.ProjectID,
+		SessionID:   task.SessionID,
+		TaskType:    string(task.TaskType),
+		AssigneeID:  task.AssigneeID,
+		Title:       task.Title,
+		Description: task.Description,
+		Status:      task.Status,
+		Deadline:    task.Deadline,
+		Metadata:    metadata,
+		CreatedAt:   task.CreatedAt,
+		UpdatedAt:   task.UpdatedAt,
+	}
+}
+
+func generateTaskPublicID() string {
+	return fmt.Sprintf("task_%s", snowflake.GenerateIDBase58())
+}
+
+var _ contract.TaskService = (*taskService)(nil)


### PR DESCRIPTION
参考Project CRUD实现模式，补充Task相关的创建、查询、更新、删除、列表能力：

- 新增 contract/task.go: TaskService 接口定义
- 新增 contract/task_type.go: 请求/响应 DTO
- 新增 handler/task_handler.go: 5个POST路由及错误映射
- 新增 service/task_service.go: 业务逻辑（多租户隔离、Project校验、snowflake ID）
- 扩展 task_dao.go: 新增 UpdateTask/DeleteTask/ListTasks，GetTaskByPublicID 增加 OrgID 参数
- router.go/message_poster.go: 路由注册及适配签名变更

API: CreateTask/GetTask/UpdateTask/DeleteTask/ListTasks