### PR TITLE
fix(task): 将Task接口的project_id从uint改为string(public_id格式)

### DIFF
--- a/backend/cmd/leros/task.go
+++ b/backend/cmd/leros/task.go
@@ -19,7 +19,7 @@ var (
 	taskJSON       bool
 	taskKeyword    string
 	taskStatus     string
-	taskProjectID  uint
+	taskProjectID  string
 	taskType       string
 	taskAssigneeID uint
 	taskOffset     int
@@ -90,9 +90,8 @@ func printTasks(list *contract.TaskList) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "PUBLIC_ID\tTITLE\tSTATUS\tTYPE\tPROJECT_ID\tCREATED_AT")
 	for _, t := range list.Items {
-		projectID := fmt.Sprintf("%d", t.ProjectID)
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			t.PublicID, t.Title, t.Status, t.TaskType, projectID,
+			t.PublicID, t.Title, t.Status, t.TaskType, t.ProjectID,
 			t.CreatedAt.Format("2006-01-02T15:04:05Z"))
 	}
 	w.Flush()
@@ -105,7 +104,7 @@ func init() {
 	taskLsCmd.Flags().BoolVar(&taskJSON, "json", false, "Output in JSON format")
 	taskLsCmd.Flags().StringVar(&taskKeyword, "keyword", "", "Filter by title/description keyword")
 	taskLsCmd.Flags().StringVar(&taskStatus, "status", "", "Filter by status")
-	taskLsCmd.Flags().UintVar(&taskProjectID, "project-id", 0, "Filter by project ID")
+	taskLsCmd.Flags().StringVar(&taskProjectID, "project-id", "", "Filter by project ID")
 	taskLsCmd.Flags().StringVar(&taskType, "type", "", "Filter by task type")
 	taskLsCmd.Flags().UintVar(&taskAssigneeID, "assignee-id", 0, "Filter by assignee ID")
 	taskLsCmd.Flags().IntVar(&taskOffset, "offset", 0, "Pagination offset")

--- a/backend/internal/api/contract/task_type.go
+++ b/backend/internal/api/contract/task_type.go
@@ -11,7 +11,7 @@ type Task struct {
 	PublicID    string                 `json:"public_id"`
 	OrgID       uint                   `json:"org_id"`
 	OwnerID     uint                   `json:"owner_id"`
-	ProjectID   uint                   `json:"project_id"`
+	ProjectID   string                 `json:"project_id"`
 	SessionID   *uint                  `json:"session_id,omitempty"`
 	TaskType    string                 `json:"task_type"`
 	AssigneeID  *uint                  `json:"assignee_id,omitempty"`
@@ -26,7 +26,7 @@ type Task struct {
 
 // CreateTaskRequest 创建任务请求
 type CreateTaskRequest struct {
-	ProjectID   uint                   `json:"project_id" binding:"required"`
+	ProjectID   string                 `json:"project_id" binding:"required"`
 	Title       string                 `json:"title" binding:"required"`
 	Description string                 `json:"description,omitempty"`
 	TaskType    *string                `json:"task_type,omitempty"`
@@ -37,7 +37,7 @@ type CreateTaskRequest struct {
 
 // UpdateTaskRequest 更新任务请求
 type UpdateTaskRequest struct {
-	ProjectID   *uint                   `json:"project_id,omitempty"`
+	ProjectID   *string                 `json:"project_id,omitempty"`
 	Title       *string                 `json:"title,omitempty"`
 	Description *string                 `json:"description,omitempty"`
 	TaskType    *string                 `json:"task_type,omitempty"`
@@ -51,7 +51,7 @@ type UpdateTaskRequest struct {
 type ListTasksRequest struct {
 	Keyword    *string `json:"keyword,omitempty"`
 	Status     *string `json:"status,omitempty"`
-	ProjectID  *uint   `json:"project_id,omitempty"`
+	ProjectID  *string `json:"project_id,omitempty"`
 	TaskType   *string `json:"task_type,omitempty"`
 	AssigneeID *uint   `json:"assignee_id,omitempty"`
 	types.Pagination

--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -40,6 +40,19 @@ func DeleteProject(ctx context.Context, db *gorm.DB, id uint) error {
 	return db.WithContext(ctx).Delete(&types.Project{}, id).Error
 }
 
+// GetProjectsByIDs 根据项目ID列表批量获取项目
+func GetProjectsByIDs(ctx context.Context, db *gorm.DB, ids []uint) ([]*types.Project, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var entities []*types.Project
+	err := db.WithContext(ctx).Where("id IN (?)", ids).Find(&entities).Error
+	if err != nil {
+		return nil, err
+	}
+	return entities, nil
+}
+
 // CreateProjectMember 创建项目成员
 func CreateProjectMember(ctx context.Context, db *gorm.DB, member *types.ProjectMember) error {
 	return db.WithContext(ctx).Create(member).Error

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -33,12 +33,12 @@ func (s *taskService) CreateTask(ctx context.Context, req *contract.CreateTaskRe
 		return nil, errors.New("title is required")
 	}
 
-	var p types.Project
-	if err := s.db.WithContext(ctx).Where("id = ? AND org_id = ?", req.ProjectID, caller.OrgID).First(&p).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errors.New("project not found")
-		}
+	project, err := db.GetProjectByPublicID(ctx, s.db, caller.OrgID, req.ProjectID)
+	if err != nil {
 		return nil, err
+	}
+	if project == nil {
+		return nil, errors.New("project not found")
 	}
 
 	publicID := generateTaskPublicID()
@@ -52,7 +52,7 @@ func (s *taskService) CreateTask(ctx context.Context, req *contract.CreateTaskRe
 		OrgID:       caller.OrgID,
 		PublicID:    publicID,
 		OwnerID:     caller.Uin,
-		ProjectID:   req.ProjectID,
+		ProjectID:   project.ID,
 		TaskType:    types.TaskType(taskType),
 		AssigneeID:  req.AssigneeID,
 		Title:       strings.TrimSpace(req.Title),
@@ -80,7 +80,7 @@ func (s *taskService) CreateTask(ctx context.Context, req *contract.CreateTaskRe
 	if err := db.CreateTask(ctx, s.db, task); err != nil {
 		return nil, err
 	}
-	return convertToContractTask(task), nil
+	return convertToContractTask(task, project.PublicID), nil
 }
 
 func (s *taskService) GetTask(ctx context.Context, publicID string) (*contract.Task, error) {
@@ -99,7 +99,12 @@ func (s *taskService) GetTask(ctx context.Context, publicID string) (*contract.T
 	if task == nil {
 		return nil, errors.New("task not found")
 	}
-	return convertToContractTask(task), nil
+
+	projectPublicID, err := s.resolveProjectPublicID(ctx, task.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return convertToContractTask(task, projectPublicID), nil
 }
 
 func (s *taskService) UpdateTask(ctx context.Context, publicID string, req *contract.UpdateTaskRequest) (*contract.Task, error) {
@@ -143,14 +148,14 @@ func (s *taskService) UpdateTask(ctx context.Context, publicID string, req *cont
 			task.Deadline = req.Deadline
 		}
 		if req.ProjectID != nil {
-			var p types.Project
-			if err := tx.Where("id = ? AND org_id = ?", *req.ProjectID, caller.OrgID).First(&p).Error; err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
-					return errors.New("project not found")
-				}
-				return err
+			project, dbErr := db.GetProjectByPublicID(ctx, tx, caller.OrgID, *req.ProjectID)
+			if dbErr != nil {
+				return dbErr
 			}
-			task.ProjectID = *req.ProjectID
+			if project == nil {
+				return errors.New("project not found")
+			}
+			task.ProjectID = project.ID
 		}
 		if req.Metadata != nil {
 			if *req.Metadata != nil {
@@ -176,7 +181,12 @@ func (s *taskService) UpdateTask(ctx context.Context, publicID string, req *cont
 	}); err != nil {
 		return nil, err
 	}
-	return convertToContractTask(task), nil
+
+	projectPublicID, err := s.resolveProjectPublicID(ctx, task.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return convertToContractTask(task, projectPublicID), nil
 }
 
 func (s *taskService) DeleteTask(ctx context.Context, publicID string) error {
@@ -215,8 +225,15 @@ func (s *taskService) ListTasks(ctx context.Context, req *contract.ListTasksRequ
 	if req.Status != nil && *req.Status != "" {
 		opt.AddFilter("status", *req.Status)
 	}
-	if req.ProjectID != nil {
-		opt.AddExactFilter("project_id", fmt.Sprintf("%d", *req.ProjectID))
+	if req.ProjectID != nil && *req.ProjectID != "" {
+		project, dbErr := db.GetProjectByPublicID(ctx, s.db, caller.OrgID, *req.ProjectID)
+		if dbErr != nil {
+			return nil, dbErr
+		}
+		if project == nil {
+			return nil, errors.New("project not found")
+		}
+		opt.AddExactFilter("project_id", fmt.Sprintf("%d", project.ID))
 	}
 	if req.TaskType != nil && *req.TaskType != "" {
 		opt.AddFilter("task_type", *req.TaskType)
@@ -230,9 +247,22 @@ func (s *taskService) ListTasks(ctx context.Context, req *contract.ListTasksRequ
 		return nil, err
 	}
 
+	projectIDs := make([]uint, 0, len(tasks))
+	projectIDSet := make(map[uint]struct{})
+	for _, t := range tasks {
+		if _, ok := projectIDSet[t.ProjectID]; !ok {
+			projectIDSet[t.ProjectID] = struct{}{}
+			projectIDs = append(projectIDs, t.ProjectID)
+		}
+	}
+	projectPublicIDMap, err := s.resolveProjectPublicIDs(ctx, projectIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	items := make([]contract.Task, 0, len(tasks))
 	for _, task := range tasks {
-		items = append(items, *convertToContractTask(task))
+		items = append(items, *convertToContractTask(task, projectPublicIDMap[task.ProjectID]))
 	}
 	return &contract.TaskList{
 		Total:  total,
@@ -242,7 +272,7 @@ func (s *taskService) ListTasks(ctx context.Context, req *contract.ListTasksRequ
 	}, nil
 }
 
-func convertToContractTask(task *types.Task) *contract.Task {
+func convertToContractTask(task *types.Task, projectPublicID string) *contract.Task {
 	if task == nil {
 		return nil
 	}
@@ -266,7 +296,7 @@ func convertToContractTask(task *types.Task) *contract.Task {
 		PublicID:    task.PublicID,
 		OrgID:       task.OrgID,
 		OwnerID:     task.OwnerID,
-		ProjectID:   task.ProjectID,
+		ProjectID:   projectPublicID,
 		SessionID:   task.SessionID,
 		TaskType:    string(task.TaskType),
 		AssigneeID:  task.AssigneeID,
@@ -282,6 +312,30 @@ func convertToContractTask(task *types.Task) *contract.Task {
 
 func generateTaskPublicID() string {
 	return fmt.Sprintf("task_%s", snowflake.GenerateIDBase58())
+}
+
+func (s *taskService) resolveProjectPublicID(ctx context.Context, projectID uint) (string, error) {
+	projectIDs := []uint{projectID}
+	publicIDs, err := s.resolveProjectPublicIDs(ctx, projectIDs)
+	if err != nil {
+		return "", err
+	}
+	return publicIDs[projectID], nil
+}
+
+func (s *taskService) resolveProjectPublicIDs(ctx context.Context, projectIDs []uint) (map[uint]string, error) {
+	result := make(map[uint]string)
+	if len(projectIDs) == 0 {
+		return result, nil
+	}
+	projects, err := db.GetProjectsByIDs(ctx, s.db, projectIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projects {
+		result[p.ID] = p.PublicID
+	}
+	return result, nil
 }
 
 var _ contract.TaskService = (*taskService)(nil)


### PR DESCRIPTION
- ListTasks/CreateTask/UpdateTask 的 project_id 字段从 uint 改为 string
- 服务层通过 public_id 解析项目，统一使用 GetProjectByPublicID/GetProjectsByIDs
- 响应中的 ProjectID 返回项目的 public_id 而非内部数字ID
- CLI task ls 命令适配 string 类型 project-id