### PR TITLE
feat(session): 添加 (project_id, task_id) 复合唯一索引并实现 upsert

### DIFF
--- a/backend/internal/infra/db/session_dao.go
+++ b/backend/internal/infra/db/session_dao.go
@@ -7,15 +7,33 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/ygpkg/yg-go/logs"
 
 	"github.com/insmtx/Leros/backend/types"
 )
 
-// CreateSession 创建会话
+// CreateSession 创建会话（冲突时更新）
 func CreateSession(ctx context.Context, db *gorm.DB, session *types.Session) error {
-	return db.WithContext(ctx).Create(session).Error
+	return db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "project_id"}, {Name: "task_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"updated_at",
+			"type",
+			"uin",
+			"org_id",
+			"assistant_id",
+			"allocated_assistant_id",
+			"status",
+			"title",
+			"title_manually_set",
+			"metadata",
+			"message_count",
+			"last_message_at",
+			"expired_at",
+		}),
+	}).Create(session).Error
 }
 
 // GetSessionByID 根据ID获取会话
@@ -44,9 +62,27 @@ func GetSessionByPublicID(ctx context.Context, db *gorm.DB, publicID string) (*t
 	return &entity, nil
 }
 
-// UpdateSession 更新会话
+// UpdateSession 更新会话（冲突时更新）
 func UpdateSession(ctx context.Context, db *gorm.DB, session *types.Session) error {
-	return db.WithContext(ctx).Save(session).Error
+	return db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "task_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"public_id",
+			"updated_at",
+			"type",
+			"uin",
+			"org_id",
+			"assistant_id",
+			"allocated_assistant_id",
+			"status",
+			"title",
+			"title_manually_set",
+			"metadata",
+			"message_count",
+			"last_message_at",
+			"expired_at",
+		}),
+	}).Save(session).Error
 }
 
 // DeleteSession 删除会话（软删除）

--- a/backend/types/session.go
+++ b/backend/types/session.go
@@ -81,10 +81,10 @@ type Session struct {
 	AllocatedAssistantID uint `gorm:"column:allocated_assistant_id;type:bigint;default:0;index"`
 
 	// session - 关联任务ID，允许为空，BIGINT，INDEX（scope=task时绑定）
-	TaskID *uint `gorm:"column:task_id;type:bigint;index"`
+	TaskID *uint `gorm:"column:task_id;type:bigint;uniqueIndex:uni_session_project_task"`
 
 	// session - 关联项目ID，允许为空，BIGINT，INDEX（scope=project时绑定）
-	ProjectID *uint `gorm:"column:project_id;type:bigint;index"`
+	ProjectID *uint `gorm:"column:project_id;type:bigint;uniqueIndex:uni_session_project_task"`
 
 	// session - 会话状态，VARCHAR(50)，NOT NULL，DEFAULT 'active'
 	Status string `gorm:"column:status;type:varchar(50);not null;default:'active'"`


### PR DESCRIPTION
- Session.TaskID + ProjectID 共用 uniqueIndex:uni_session_project_task
- CreateSession/UpdateSession 使用 ON CONFLICT DO UPDATE 实现 upsert
- 冲突时更新除 id/created_at/deleted_at 外的全部字段