### PR TITLE
fix(chat): 修复 clearMessages 方法名冲突导致 unmount 时误调后端 API

### DIFF
--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -33,7 +33,7 @@ export function ProjectPage() {
 	const { projects, activeProjectId, activeProjectTab, projectDetailLoading, projectDetailError, activeProjectSessionId, projectSessionId, switchView, setActiveProjectTab, fetchProjectDetail } =
 		useLayoutStore((s) => s);
 
-	const { setActiveSession, loadConversationMessages, clearMessages } = useChatStore((s) => s);
+	const { setActiveSession, loadConversationMessages, resetLocalMessages } = useChatStore((s) => s);
 
 	const project = projects.find((item) => item.id === activeProjectId) ?? projects[0];
 
@@ -57,9 +57,9 @@ export function ProjectPage() {
 
 	useEffect(() => {
 		return () => {
-			clearMessages();
+			resetLocalMessages();
 		};
-	}, [clearMessages]);
+	}, [resetLocalMessages]);
 
 	if (!project) {
 		return (

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -33,7 +33,7 @@ export function TaskDetailPage() {
 		switchProject,
 	} = useLayoutStore((s) => s);
 
-	const { setActiveSession, loadConversationMessages, clearMessages } = useChatStore((s) => s);
+	const { setActiveSession, loadConversationMessages, resetLocalMessages } = useChatStore((s) => s);
 
 	const [task, setTask] = useState<ProjectTask | null>(null);
 
@@ -69,9 +69,9 @@ export function TaskDetailPage() {
 
 	useEffect(() => {
 		return () => {
-			clearMessages();
+			resetLocalMessages();
 		};
-	}, [clearMessages]);
+	}, [resetLocalMessages]);
 
 	if (!activeTaskDetailProjectId || !activeTaskDetailTaskId || !activeTaskDetailSessionId) {
 		return (

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -571,7 +571,7 @@ export class ChatActionImpl {
 		}
 	};
 
-	clearMessages = () => {
+	resetLocalMessages = () => {
 		this.#set({ messagesMap: {}, messageIds: [], activeSessionId: null });
 	};
 


### PR DESCRIPTION
chatSlice.ts 中定义了两个同名 clearMessages 方法，JS 类字段中后者覆盖前者， 导致 ProjectPage/TaskDetailPage unmount cleanup 中本意本地清空消息的调用 实际触发了 POST /ClearSessionMessages 请求。

- 将本地清空方法重命名为 resetLocalMessages
- ProjectPage / TaskDetailPage 改用 resetLocalMessages