### PR TITLE
fix(desktop): 修复 Windows 桌面端打包与产物渲染问题

### DIFF
--- a/frontend/apps/desktop/electron-builder.yml
+++ b/frontend/apps/desktop/electron-builder.yml
@@ -21,6 +21,7 @@ mac:
     - target: zip
   artifactName: ${productName}-${version}-mac-${arch}.${ext}
 win:
+  signAndEditExecutable: false
   target:
     - target: nsis
       arch:

--- a/frontend/apps/desktop/electron.vite.config.ts
+++ b/frontend/apps/desktop/electron.vite.config.ts
@@ -1,14 +1,14 @@
 import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import { defineConfig } from "electron-vite";
 
 export default defineConfig({
 	main: {
-		plugins: [externalizeDepsPlugin()],
+		// 主进程依赖直接打进产物，避免 electron-builder 在打包时沿着 workspace 依赖树继续扫描 node_modules。
 	},
 	preload: {
-		plugins: [externalizeDepsPlugin()],
+		// preload 同样内联依赖，减少 Windows 下 pnpm monorepo 的依赖收集开销。
 	},
 	renderer: {
 		server: {

--- a/frontend/apps/desktop/package.json
+++ b/frontend/apps/desktop/package.json
@@ -29,19 +29,18 @@
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
+    "react-router-dom": "^7.6.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "lucide-react": "catalog:"
+  },
+  "devDependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@leros/ui": "workspace:*",
     "@leros/store": "workspace:*",
     "@leros/app-ui": "workspace:*",
     "@leros/styles": "workspace:*",
-    "react-router-dom": "^7.6.0",
-    "react": "catalog:",
-    "react-dom": "catalog:",
-    "lucide-react": "catalog:",
-    "sonner": "^2.0.7"
-  },
-  "devDependencies": {
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@leros/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4",

--- a/frontend/apps/desktop/src/renderer/src/App.tsx
+++ b/frontend/apps/desktop/src/renderer/src/App.tsx
@@ -1,15 +1,15 @@
 import { ThemeProvider } from "@leros/ui/components/common/theme-provider";
 import { Toaster } from "@leros/ui/components/ui/sonner";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import { AppRoutes } from "./routes";
 
 export default function App() {
 	return (
-		<BrowserRouter>
+		<HashRouter>
 			<ThemeProvider defaultTheme="system">
 				<AppRoutes />
 				<Toaster />
 			</ThemeProvider>
-		</BrowserRouter>
+		</HashRouter>
 	);
 }


### PR DESCRIPTION
- 收紧 desktop 打包依赖范围，避免 Windows 下 pnpm monorepo 依赖扫描过慢
- 关闭 Windows 本地 signAndEditExecutable，绕过 winCodeSign 符号链接权限问题
- 去除本地打包多余 publish 配置，避免 channel 元数据报错
- 桌面端改用 HashRouter，修复打包产物在 file 协议下右侧内容区空白