### PR TITLE
fix(styles): 启用 typography 插件修复 AI 消息 Markdown 排版

### DIFF
--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -189,6 +189,13 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 			adjustHeight();
 		}, [value, adjustHeight]);
 
+		const validTokens = useMemo(
+			() => tokens.filter((token) => value.slice(token.start, token.end) === token.label),
+			[tokens, value],
+		);
+
+		const shouldUseHighlightLayer = validTokens.length > 0;
+
 		const focusAt = useCallback((cursor: number) => {
 			requestAnimationFrame(() => {
 				const textarea = textareaRef.current;
@@ -313,9 +320,6 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		);
 
 		const renderHighlightedValue = () => {
-			const validTokens = tokens.filter(
-				(token) => value.slice(token.start, token.end) === token.label,
-			);
 			if (validTokens.length === 0) return value;
 
 			const parts: React.ReactNode[] = [];
@@ -343,8 +347,8 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		};
 
 		const inputSpacingClass = isProjectVariant
-			? "min-h-[92px] rounded-none px-0 py-0 text-base"
-			: "min-h-[116px] rounded-2xl px-5 py-4 text-sm";
+			? "min-h-[92px] rounded-none px-0 py-0 text-base leading-7"
+			: "min-h-[116px] rounded-2xl px-5 py-4 text-sm leading-6";
 
 		return (
 			<div className="relative">
@@ -352,15 +356,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					<div className="absolute bottom-full left-0 z-30 mb-2 w-full max-w-[360px] overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-1.5 shadow-[0_12px_36px_rgba(15,23,42,0.12)] backdrop-blur">
 						<Command shouldFilter={false} className="rounded-xl! bg-transparent p-0">
 							<div className="flex items-center gap-2 px-2.5 pb-1.5 pt-1 text-xs font-medium text-slate-400">
-								{trigger.kind === "assistant" ? (
-									<>
-										AI 队友
-									</>
-								) : (
-									<>
-										命令
-									</>
-								)}
+								{trigger.kind === "assistant" ? <>AI 队友</> : <>命令</>}
 								{trigger.query && <span className="truncate text-slate-400">{trigger.query}</span>}
 							</div>
 							<CommandList className="max-h-60">
@@ -419,15 +415,20 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					</div>
 				)}
 
-				<div
-					aria-hidden="true"
-					className={cn(
-						"pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words text-slate-700",
-						inputSpacingClass,
-					)}
-				>
-					<div style={{ transform: `translateY(-${scrollTop}px)` }}>{renderHighlightedValue()}</div>
-				</div>
+				{shouldUseHighlightLayer && (
+					<div
+						aria-hidden="true"
+						className={cn(
+							"pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words text-slate-700",
+							inputSpacingClass,
+						)}
+					>
+						{/* 只有真正需要高亮 token 时才启用镜像层，避免长文本粘贴时双层排版产生重影。 */}
+						<div style={{ transform: `translateY(-${scrollTop}px)` }}>
+							{renderHighlightedValue()}
+						</div>
+					</div>
+				)}
 				<textarea
 					ref={textareaRef}
 					value={value}
@@ -450,7 +451,8 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					}}
 					placeholder={placeholder}
 					className={cn(
-						"relative z-10 max-h-[220px] w-full resize-none bg-transparent text-transparent caret-slate-700 focus:outline-none placeholder:text-slate-400",
+						"relative z-10 max-h-[220px] w-full resize-none bg-transparent caret-slate-700 focus:outline-none placeholder:text-slate-400",
+						shouldUseHighlightLayer ? "text-transparent" : "text-slate-700",
 						inputSpacingClass,
 					)}
 					rows={1}

--- a/frontend/packages/styles/globals.css
+++ b/frontend/packages/styles/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@eigenpal/docx-editor-react/styles.css";

--- a/frontend/packages/styles/package.json
+++ b/frontend/packages/styles/package.json
@@ -3,7 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
-	"sideEffects": ["*.css"],
+	"sideEffects": [
+		"*.css"
+	],
 	"exports": {
 		"./globals.css": {
 			"style": "./globals.css",
@@ -18,5 +20,8 @@
 	},
 	"peerDependencies": {
 		"tailwindcss": "^4"
+	},
+	"devDependencies": {
+		"@tailwindcss/typography": "^0.5.20"
 	}
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -293,6 +293,10 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+    devDependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.20
+        version: 0.5.20
 
   packages/tsconfig: {}
 
@@ -1818,6 +1822,11 @@ packages:
 
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
   '@tailwindcss/vite@4.3.0':
     resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
@@ -3853,6 +3862,10 @@ packages:
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -6122,6 +6135,10 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       postcss: 8.5.15
       tailwindcss: 4.3.0
+
+  '@tailwindcss/typography@0.5.20':
+    dependencies:
+      postcss-selector-parser: 6.0.10
 
   '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
@@ -8424,6 +8441,11 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
     optional: true
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:


### PR DESCRIPTION
添加 @tailwindcss/typography 并在 globals.css 注册，使 AIMessageBubble 中的 prose 类生效，修复标题、表格、代码块等样式缺失问题。