### PR TITLE
fix(worker): 修复重建流后 worker 恢复点失效问题

### DIFF
--- a/backend/internal/infra/mq/nats.go
+++ b/backend/internal/infra/mq/nats.go
@@ -272,6 +272,22 @@ func (p *natsBus) SubscribeFrom(ctx context.Context, topic string, startSeq int6
 	if startSeq <= 0 {
 		return p.subscribeNewOnly(ctx, topic, handler)
 	}
+	streamName := dm.StreamNameFromTopic(topic)
+	if streamName != "" {
+		info, err := p.js.StreamInfo(streamName)
+		if err != nil {
+			logs.WarnContextf(ctx, "Failed to inspect stream %s before subscribing to %s from seq %d: %v", streamName, topic, startSeq, err)
+		} else if uint64(startSeq) > info.State.LastSeq+1 {
+			logs.WarnContextf(ctx,
+				"Local recovery seq %d for topic %s is beyond stream %s last seq %d; subscribing to new messages only",
+				startSeq,
+				topic,
+				streamName,
+				info.State.LastSeq,
+			)
+			return p.subscribeNewOnly(ctx, topic, handler)
+		}
+	}
 	sub, err := p.js.Subscribe(topic, handler,
 		nats.StartSequence(uint64(startSeq)),
 		nats.Context(ctx),


### PR DESCRIPTION
worker 会将已消费的 JetStream seq 记录到本地 leros.db 中，
但当远端 TASK_STREAM 被重建或清空后，stream seq 会重新从较小值开始。
此时本地恢复点可能大于当前 stream 最新 seq，导致 worker 从未来序号订阅，
无法收到后续新消息。

本次在 SubscribeFrom 中增加 stream 最新 seq 检查：
当本地恢复 seq 超过 stream last seq + 1 时，自动退回为仅订阅新消息，
避免重新部署或重建 NATS stream 后 worker 卡在过期恢复点。