### PR TITLE
fix(auth): 按用户隔离业务数据查询

### DIFF
--- a/backend/internal/infra/db/digital_assistant_dao.go
+++ b/backend/internal/infra/db/digital_assistant_dao.go
@@ -77,6 +77,9 @@ func ListDigitalAssistant(ctx context.Context, db *gorm.DB, opt *types.PageQuery
 	if opt.OrgID > 0 {
 		query = query.Where("org_id = ?", opt.OrgID)
 	}
+	if opt.Uin > 0 {
+		query = query.Where("owner_id = ?", opt.Uin)
+	}
 
 	for _, filter := range opt.Filters {
 		switch filter.Field {

--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -93,6 +93,9 @@ func ListProjects(ctx context.Context, d *gorm.DB, opt *types.PageQuery) ([]*typ
 
 	query := d.WithContext(ctx).Table(types.TableNameProject).
 		Where("org_id = ? AND deleted_at IS NULL", opt.OrgID)
+	if opt.Uin > 0 {
+		query = query.Where("owner_id = ?", opt.Uin)
+	}
 
 	for _, filter := range opt.Filters {
 		switch filter.Field {

--- a/backend/internal/infra/db/task_dao.go
+++ b/backend/internal/infra/db/task_dao.go
@@ -47,6 +47,9 @@ func ListTasks(ctx context.Context, d *gorm.DB, opt *types.PageQuery) ([]*types.
 
 	query := d.WithContext(ctx).Table(types.TableNameTask).
 		Where("org_id = ? AND deleted_at IS NULL", opt.OrgID)
+	if opt.Uin > 0 {
+		query = query.Where("owner_id = ?", opt.Uin)
+	}
 
 	for _, filter := range opt.Filters {
 		switch filter.Field {

--- a/backend/internal/service/artifact_service.go
+++ b/backend/internal/service/artifact_service.go
@@ -41,6 +41,9 @@ func (s *artifactService) ListTaskArtifacts(ctx context.Context, taskPublicID st
 	if task == nil {
 		return nil, errors.New("task not found")
 	}
+	if err := verifyUserPermission(task.OwnerID, caller.Uin); err != nil {
+		return nil, err
+	}
 	artifacts, err := db.ListTaskArtifacts(ctx, s.db, caller.OrgID, task.ID)
 	if err != nil {
 		return nil, err
@@ -66,6 +69,9 @@ func (s *artifactService) GetArtifactDownload(ctx context.Context, artifactPubli
 	}
 	if artifact == nil {
 		return nil, errors.New("artifact not found")
+	}
+	if err := verifyUserPermission(artifact.OwnerID, caller.Uin); err != nil {
+		return nil, err
 	}
 	file, err := agentworkspace.OpenArtifactStorageFile(artifact.OrgID, artifactWorkerID(artifact), artifact.StorageKey)
 	if err != nil {

--- a/backend/internal/service/digital_assistant_service.go
+++ b/backend/internal/service/digital_assistant_service.go
@@ -81,7 +81,7 @@ func (s *digitalAssistantService) CreateDigitalAssistant(ctx context.Context, re
 }
 
 func (s *digitalAssistantService) GetDigitalAssistantByID(ctx context.Context, id uint) (*contract.DigitalAssistantDetail, error) {
-	orgID, err := getOrgIDFromContext(ctx)
+	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,10 @@ func (s *digitalAssistantService) GetDigitalAssistantByID(ctx context.Context, i
 		return nil, errors.New("digital assistant not found")
 	}
 
-	if err := verifyOrgPermission(da.OrgID, orgID); err != nil {
+	if err := verifyOrgPermission(da.OrgID, caller.OrgID); err != nil {
+		return nil, err
+	}
+	if err := verifyUserPermission(da.OwnerID, caller.Uin); err != nil {
 		return nil, err
 	}
 
@@ -104,7 +107,7 @@ func (s *digitalAssistantService) GetDigitalAssistantByID(ctx context.Context, i
 }
 
 func (s *digitalAssistantService) GetDigitalAssistantByCode(ctx context.Context, code string) (*contract.DigitalAssistantDetail, error) {
-	orgID, err := getOrgIDFromContext(ctx)
+	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +120,10 @@ func (s *digitalAssistantService) GetDigitalAssistantByCode(ctx context.Context,
 		return nil, errors.New("digital assistant not found")
 	}
 
-	if err := verifyOrgPermission(da.OrgID, orgID); err != nil {
+	if err := verifyOrgPermission(da.OrgID, caller.OrgID); err != nil {
+		return nil, err
+	}
+	if err := verifyUserPermission(da.OwnerID, caller.Uin); err != nil {
 		return nil, err
 	}
 
@@ -127,7 +133,7 @@ func (s *digitalAssistantService) GetDigitalAssistantByCode(ctx context.Context,
 }
 
 func (s *digitalAssistantService) UpdateDigitalAssistant(ctx context.Context, id uint, req *contract.UpdateDigitalAssistantRequest) (*contract.DigitalAssistant, error) {
-	orgID, err := getOrgIDFromContext(ctx)
+	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +146,10 @@ func (s *digitalAssistantService) UpdateDigitalAssistant(ctx context.Context, id
 		return nil, errors.New("digital assistant not found")
 	}
 
-	if err := verifyOrgPermission(da.OrgID, orgID); err != nil {
+	if err := verifyOrgPermission(da.OrgID, caller.OrgID); err != nil {
+		return nil, err
+	}
+	if err := verifyUserPermission(da.OwnerID, caller.Uin); err != nil {
 		return nil, err
 	}
 
@@ -166,7 +175,7 @@ func (s *digitalAssistantService) UpdateDigitalAssistant(ctx context.Context, id
 }
 
 func (s *digitalAssistantService) DeleteDigitalAssistant(ctx context.Context, id uint) error {
-	orgID, err := getOrgIDFromContext(ctx)
+	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return err
 	}
@@ -179,7 +188,10 @@ func (s *digitalAssistantService) DeleteDigitalAssistant(ctx context.Context, id
 		return errors.New("digital assistant not found")
 	}
 
-	if err := verifyOrgPermission(da.OrgID, orgID); err != nil {
+	if err := verifyOrgPermission(da.OrgID, caller.OrgID); err != nil {
+		return err
+	}
+	if err := verifyUserPermission(da.OwnerID, caller.Uin); err != nil {
 		return err
 	}
 
@@ -220,7 +232,7 @@ func (s *digitalAssistantService) ListDigitalAssistant(ctx context.Context, req 
 }
 
 func (s *digitalAssistantService) UpdateDigitalAssistantStatus(ctx context.Context, id uint, req *contract.UpdateDigitalAssistantStatusRequest) error {
-	orgID, err := getOrgIDFromContext(ctx)
+	caller, err := requireCallerOrg(ctx)
 	if err != nil {
 		return err
 	}
@@ -233,7 +245,10 @@ func (s *digitalAssistantService) UpdateDigitalAssistantStatus(ctx context.Conte
 		return errors.New("digital assistant not found")
 	}
 
-	if err := verifyOrgPermission(da.OrgID, orgID); err != nil {
+	if err := verifyOrgPermission(da.OrgID, caller.OrgID); err != nil {
+		return err
+	}
+	if err := verifyUserPermission(da.OwnerID, caller.Uin); err != nil {
 		return err
 	}
 

--- a/backend/internal/service/message_poster.go
+++ b/backend/internal/service/message_poster.go
@@ -173,6 +173,9 @@ func (o *newMessageOrchestrator) resolveOrCreateProject() error {
 		if proj == nil {
 			return errors.New("project not found")
 		}
+		if err := verifyUserPermission(proj.OwnerID, o.caller.Uin); err != nil {
+			return err
+		}
 		o.project = proj
 		return nil
 	}
@@ -248,6 +251,9 @@ func (o *newMessageOrchestrator) resolveOrCreateTask() error {
 		}
 		if t == nil {
 			return errors.New("task not found")
+		}
+		if err := verifyUserPermission(t.OwnerID, o.caller.Uin); err != nil {
+			return err
 		}
 		o.task = t
 		return nil

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -16,8 +16,8 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/insmtx/Leros/backend/internal/api/contract"
-	localmemory "github.com/insmtx/Leros/backend/internal/memory/local"
 	"github.com/insmtx/Leros/backend/internal/infra/db"
+	localmemory "github.com/insmtx/Leros/backend/internal/memory/local"
 	"github.com/insmtx/Leros/backend/internal/workspace"
 	"github.com/insmtx/Leros/backend/types"
 	"github.com/ygpkg/yg-go/encryptor/snowflake"
@@ -108,6 +108,9 @@ func (s *projectService) GetProject(ctx context.Context, publicID string) (*cont
 	if project == nil {
 		return nil, errors.New("project not found")
 	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, err
+	}
 	return convertToContractProject(project), nil
 }
 
@@ -128,6 +131,9 @@ func (s *projectService) UpdateProject(ctx context.Context, publicID string, req
 		}
 		if project == nil {
 			return errors.New("project not found")
+		}
+		if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+			return err
 		}
 
 		if req.Name != nil {
@@ -191,6 +197,9 @@ func (s *projectService) DeleteProject(ctx context.Context, publicID string) err
 		}
 		if project == nil {
 			return errors.New("project not found")
+		}
+		if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+			return err
 		}
 		return db.DeleteProject(ctx, tx, project.ID)
 	})
@@ -277,6 +286,9 @@ func (s *projectService) DetailProject(ctx context.Context, publicID string) (*c
 	}
 	if project == nil {
 		return nil, errors.New("project not found")
+	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, err
 	}
 
 	result := &contract.ProjectDetail{
@@ -408,6 +420,9 @@ func (s *projectService) GetProjectMemory(ctx context.Context, publicID string) 
 	if project == nil {
 		return nil, errors.New("project not found")
 	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, err
+	}
 
 	// 3. 拼 repo 路径: {workspaceRoot}/projects/{orgID}/{publicID}/repo/
 	workerID := getWorkerIDByProjectID(publicID)
@@ -438,7 +453,7 @@ func (s *projectService) GetProjectMemory(ctx context.Context, publicID string) 
 		Entries: entries,
 		Total:   len(entries),
 	}, nil
-	}
+}
 
 func (s *projectService) GetProjectFileTree(ctx context.Context, publicID string, parentPath string, depth int) ([]*contract.FileTreeNode, error) {
 	// 1. 鉴权
@@ -457,6 +472,9 @@ func (s *projectService) GetProjectFileTree(ctx context.Context, publicID string
 	}
 	if project == nil {
 		return nil, errors.New("project not found")
+	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, err
 	}
 
 	// 3. 解析 repo 路径
@@ -645,6 +663,9 @@ func (s *projectService) DownloadProjectFile(ctx context.Context, publicID strin
 	if project == nil {
 		return nil, "", 0, errors.New("project not found")
 	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, "", 0, err
+	}
 
 	// 3. 解析 repo 路径
 	workerID := getWorkerIDByProjectID(publicID)
@@ -718,6 +739,9 @@ func (s *projectService) UploadProjectFile(ctx context.Context, publicID string,
 	}
 	if project == nil {
 		return nil, errors.New("project not found")
+	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, err
 	}
 
 	// 3. 解析 repo 路径

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -41,6 +41,27 @@ func NewSessionService(db *gorm.DB, eventbus eventbus.EventBus, inferrer Assista
 	}
 }
 
+func (s *sessionService) getSessionForCaller(ctx context.Context, sessionID string) (*types.Session, *types.Caller, error) {
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if session == nil {
+		return nil, nil, errors.New("session not found")
+	}
+	if session.OrgID != caller.OrgID {
+		return nil, nil, errors.New("permission denied")
+	}
+	if err := verifyUserPermission(session.Uin, caller.Uin); err != nil {
+		return nil, nil, err
+	}
+	return session, caller, nil
+}
+
 func (s *sessionService) CreateSession(ctx context.Context, req *contract.CreateSessionRequest) (*contract.Session, error) {
 	if req.Type == "" {
 		return nil, errors.New("type is required")
@@ -93,24 +114,18 @@ func (s *sessionService) GetSession(ctx context.Context, sessionID string) (*con
 		return nil, errors.New("session_id is required")
 	}
 
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return nil, err
-	}
-	if session == nil {
-		return nil, errors.New("session not found")
 	}
 
 	return convertToContractSession(session), nil
 }
 
 func (s *sessionService) UpdateSession(ctx context.Context, sessionID string, req *contract.UpdateSessionRequest) (*contract.Session, error) {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return nil, err
-	}
-	if session == nil {
-		return nil, errors.New("session not found")
 	}
 
 	if req.Title != "" {
@@ -134,12 +149,9 @@ func (s *sessionService) UpdateSession(ctx context.Context, sessionID string, re
 }
 
 func (s *sessionService) DeleteSession(ctx context.Context, sessionID string) error {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return err
-	}
-	if session == nil {
-		return errors.New("session not found")
 	}
 
 	return db.DeleteSession(ctx, s.db, session.ID)
@@ -190,12 +202,9 @@ func (s *sessionService) ListSessions(ctx context.Context, req *contract.ListSes
 }
 
 func (s *sessionService) ActivateSession(ctx context.Context, sessionID string) error {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return err
-	}
-	if session == nil {
-		return errors.New("session not found")
 	}
 
 	if session.Status == string(types.SessionStatusEnded) {
@@ -206,12 +215,9 @@ func (s *sessionService) ActivateSession(ctx context.Context, sessionID string) 
 }
 
 func (s *sessionService) PauseSession(ctx context.Context, sessionID string) error {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return err
-	}
-	if session == nil {
-		return errors.New("session not found")
 	}
 
 	if session.Status == string(types.SessionStatusEnded) || session.Status == string(types.SessionStatusExpired) {
@@ -222,12 +228,9 @@ func (s *sessionService) PauseSession(ctx context.Context, sessionID string) err
 }
 
 func (s *sessionService) EndSession(ctx context.Context, sessionID string) error {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return err
-	}
-	if session == nil {
-		return errors.New("session not found")
 	}
 
 	if session.Status == string(types.SessionStatusEnded) {
@@ -238,12 +241,9 @@ func (s *sessionService) EndSession(ctx context.Context, sessionID string) error
 }
 
 func (s *sessionService) ResumeSession(ctx context.Context, sessionID string) error {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return err
-	}
-	if session == nil {
-		return errors.New("session not found")
 	}
 
 	if session.Status != string(types.SessionStatusPaused) {
@@ -261,12 +261,9 @@ func (s *sessionService) AddMessage(ctx context.Context, sessionID string, req *
 		return nil, errors.New("content is required")
 	}
 
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return nil, err
-	}
-	if session == nil {
-		return nil, errors.New("session not found")
 	}
 
 	mp := NewMessagePoster(s.db, s.eventbus, s.inferrer)
@@ -385,10 +382,17 @@ func (s *sessionService) HandleSessionTitleRequest(ctx context.Context, sessionI
 	return nil
 }
 
-
 func (s *sessionService) SubmitApproval(ctx context.Context, req *contract.SubmitApprovalRequest) error {
+	session, caller, err := s.getSessionForCaller(ctx, req.SessionID)
+	if err != nil {
+		return err
+	}
+	req.OrgID = caller.OrgID
 	if req.WorkerID == 0 {
-		req.WorkerID = 1 // TODO: 由 session 关联的运行时动态获取
+		req.WorkerID = session.AllocatedAssistantID
+	}
+	if req.WorkerID == 0 {
+		req.WorkerID = 1
 	}
 	topic, err := dm.WorkerApprovalSubject(req.OrgID, req.WorkerID)
 	if err != nil {
@@ -397,12 +401,9 @@ func (s *sessionService) SubmitApproval(ctx context.Context, req *contract.Submi
 	return s.eventbus.Publish(ctx, topic, req)
 }
 func (s *sessionService) GetSessionMessages(ctx context.Context, sessionID string, page, perPage int) (*contract.MessageList, error) {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return nil, err
-	}
-	if session == nil {
-		return nil, errors.New("session not found")
 	}
 
 	messages, total, err := db.GetSessionMessages(ctx, s.db, session.ID, page, perPage)
@@ -430,6 +431,23 @@ func (s *sessionService) DeleteMessage(ctx context.Context, messageID uint) erro
 	if message == nil {
 		return errors.New("message not found")
 	}
+	session, err := db.GetSessionByID(ctx, s.db, message.SessionID)
+	if err != nil {
+		return err
+	}
+	if session == nil {
+		return errors.New("session not found")
+	}
+	caller, err := requireCallerOrg(ctx)
+	if err != nil {
+		return err
+	}
+	if session.OrgID != caller.OrgID {
+		return errors.New("permission denied")
+	}
+	if err := verifyUserPermission(session.Uin, caller.Uin); err != nil {
+		return err
+	}
 
 	if err := db.DeleteMessage(ctx, s.db, messageID); err != nil {
 		return err
@@ -439,12 +457,9 @@ func (s *sessionService) DeleteMessage(ctx context.Context, messageID uint) erro
 }
 
 func (s *sessionService) ClearSessionMessages(ctx context.Context, sessionID string) error {
-	session, err := db.GetSessionByPublicID(ctx, s.db, sessionID)
+	session, _, err := s.getSessionForCaller(ctx, sessionID)
 	if err != nil {
 		return err
-	}
-	if session == nil {
-		return errors.New("session not found")
 	}
 
 	if err := db.ClearSessionMessages(ctx, s.db, session.ID); err != nil {
@@ -464,9 +479,9 @@ func toJSONString(v interface{}) string {
 }
 
 func (s *sessionService) StreamSessionEvents(ctx context.Context, sessionPID string, lastSequence int64, sink events.Sink) error {
-	caller, _ := auth.FromContext(ctx)
-	if caller == nil || caller.OrgID == 0 {
-		return errors.New("user not authenticated or org not set")
+	_, caller, err := s.getSessionForCaller(ctx, sessionPID)
+	if err != nil {
+		return err
 	}
 
 	topic, err := dm.SessionResultStreamSubject(caller.OrgID, sessionPID)

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -40,6 +40,9 @@ func (s *taskService) CreateTask(ctx context.Context, req *contract.CreateTaskRe
 	if project == nil {
 		return nil, errors.New("project not found")
 	}
+	if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+		return nil, err
+	}
 
 	publicID := generateTaskPublicID()
 
@@ -99,6 +102,9 @@ func (s *taskService) GetTask(ctx context.Context, publicID string) (*contract.T
 	if task == nil {
 		return nil, errors.New("task not found")
 	}
+	if err := verifyUserPermission(task.OwnerID, caller.Uin); err != nil {
+		return nil, err
+	}
 
 	projectPublicID, err := s.resolveProjectPublicID(ctx, task.ProjectID)
 	if err != nil {
@@ -124,6 +130,9 @@ func (s *taskService) UpdateTask(ctx context.Context, publicID string, req *cont
 		}
 		if task == nil {
 			return errors.New("task not found")
+		}
+		if err := verifyUserPermission(task.OwnerID, caller.Uin); err != nil {
+			return err
 		}
 
 		if req.Title != nil {
@@ -154,6 +163,9 @@ func (s *taskService) UpdateTask(ctx context.Context, publicID string, req *cont
 			}
 			if project == nil {
 				return errors.New("project not found")
+			}
+			if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+				return err
 			}
 			task.ProjectID = project.ID
 		}
@@ -206,6 +218,9 @@ func (s *taskService) DeleteTask(ctx context.Context, publicID string) error {
 		if task == nil {
 			return errors.New("task not found")
 		}
+		if err := verifyUserPermission(task.OwnerID, caller.Uin); err != nil {
+			return err
+		}
 		return db.DeleteTask(ctx, tx, task.ID)
 	})
 }
@@ -232,6 +247,9 @@ func (s *taskService) ListTasks(ctx context.Context, req *contract.ListTasksRequ
 		}
 		if project == nil {
 			return nil, errors.New("project not found")
+		}
+		if err := verifyUserPermission(project.OwnerID, caller.Uin); err != nil {
+			return nil, err
 		}
 		opt.AddExactFilter("project_id", fmt.Sprintf("%d", project.ID))
 	}

--- a/backend/internal/service/utils.go
+++ b/backend/internal/service/utils.go
@@ -23,6 +23,13 @@ func verifyOrgPermission(daOrgID, orgID uint) error {
 	return nil
 }
 
+func verifyUserPermission(ownerID, uin uint) error {
+	if ownerID != uin {
+		return errors.New("permission denied")
+	}
+	return nil
+}
+
 func getCallerFromContext(ctx context.Context) (*types.Caller, error) {
 	caller, _ := auth.FromContext(ctx)
 	if caller == nil || caller.Uin == 0 {

--- a/deployments/dev/dev-server.sh
+++ b/deployments/dev/dev-server.sh
@@ -52,4 +52,4 @@ fi
 echo -e "${BLUE}Starting server (port 8080)...${NC}"
 
 cd "$ROOT_DIR"
-LEROS_DEV=true ./bundles/leros server --config "$CONFIG_FILE"
+./bundles/leros server --config "$CONFIG_FILE"


### PR DESCRIPTION
将项目、任务、会话、产物和数字员工的数据访问权限由组织级收窄为用户级，
默认组织内不同用户只能查询和操作自己创建的数据。

同时调整开发环境启动脚本，移除 dev-server.sh 中默认注入的 LEROS_DEV=true， 避免开发模式强制使用默认用户导致权限验证不生效。