### PR TITLE
fix(frontend): 统一文件下载与产物展示链路

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -3,6 +3,8 @@
 import {
 	formatTime,
 	mapBackendArtifactToProjectArtifact,
+	mergeProjectArtifacts,
+	messageArtifactToProjectArtifact,
 	type ProjectArtifact,
 	useChatStore,
 	useLayoutStore,
@@ -207,8 +209,10 @@ function MessageArtifactList({ artifacts }: { artifacts: MessageArtifact[] }) {
 		[artifacts],
 	);
 	const visibleArtifacts = useMemo(() => {
-		const artifactIds = new Set(artifacts.map((artifact) => artifact.id));
-		return taskArtifacts.filter((artifact) => artifactIds.has(artifact.id));
+		const sessionArtifacts = artifacts.map(messageArtifactToProjectArtifact);
+		const artifactIds = new Set(sessionArtifacts.map((artifact) => artifact.id));
+		const enrichedTaskArtifacts = taskArtifacts.filter((artifact) => artifactIds.has(artifact.id));
+		return mergeProjectArtifacts(enrichedTaskArtifacts, sessionArtifacts);
 	}, [artifacts, taskArtifacts]);
 
 	useEffect(() => {
@@ -239,7 +243,7 @@ function MessageArtifactList({ artifacts }: { artifacts: MessageArtifact[] }) {
 		};
 	}, [activeTaskDetailTaskId, artifactKey]);
 
-	if (!activeTaskDetailTaskId || visibleArtifacts.length === 0) return null;
+	if (visibleArtifacts.length === 0) return null;
 
 	return (
 		<>

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -93,10 +93,12 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 			for (const file of files) {
 				if (isProjectVariant && projectId) {
 					try {
-						await addUploadedAttachment(projectId, file);
-						toast.success("文件上传成功");
+						const { message } = await addUploadedAttachment(projectId, file);
+						toast.success(message || "文件上传成功");
 					} catch (err) {
+						const message = err instanceof Error ? err.message : "文件上传失败";
 						console.error("ChatInput upload project attachment error:", err);
+						toast.error(message);
 					}
 					continue;
 				}

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -2,7 +2,7 @@
 
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import {
-	fetchProjectFileDownload,
+	fetchFileDownload,
 	mapBackendArtifactToProjectArtifact,
 	projectFileApi,
 	useChatStore,
@@ -617,9 +617,14 @@ function ProjectFiles({
 		const controller = new AbortController();
 
 		async function loadPreview() {
+			if (!currentFile.publicId) {
+				setPreviewState({ status: "error", message: "文件缺少 public_id，无法预览" });
+				return;
+			}
+
 			setPreviewState({ status: "loading" });
 			try {
-				const response = await fetchProjectFileDownload(projectId, currentFile.path, {
+				const response = await fetchFileDownload(currentFile.publicId, {
 					signal: controller.signal,
 				});
 				const mimeType =
@@ -657,7 +662,7 @@ function ProjectFiles({
 				URL.revokeObjectURL(objectUrl);
 			}
 		};
-	}, [projectId, previewFile]);
+	}, [previewFile]);
 
 	useEffect(() => {
 		if (!previewFile) return;
@@ -682,9 +687,9 @@ function ProjectFiles({
 		setUploading(true);
 		setUploadError(null);
 		try {
-			await projectFileApi.upload({ projectId, file });
+			const response = await projectFileApi.upload({ projectId, file });
 			await onRefresh();
-			toast.success("文件上传成功");
+			toast.success(response.message || "文件上传成功");
 		} catch (err) {
 			setUploadError(err instanceof Error ? err.message : "上传文件失败");
 		} finally {
@@ -693,8 +698,13 @@ function ProjectFiles({
 	};
 
 	const handleDownload = async (file: ProjectFileNode) => {
+		if (!file.publicId) {
+			console.error("ProjectFiles download error: missing public_id");
+			return;
+		}
+
 		try {
-			const response = await fetchProjectFileDownload(projectId, file.path);
+			const response = await fetchFileDownload(file.publicId);
 			const blob = await response.blob();
 			const objectUrl = URL.createObjectURL(blob);
 			const link = document.createElement("a");

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -2,8 +2,10 @@
 
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import {
+	collectSessionArtifacts,
 	formatTokenCount,
 	mapBackendArtifactToProjectArtifact,
+	mergeProjectArtifacts,
 	useChatStore,
 	useLayoutStore,
 } from "@leros/store";
@@ -72,7 +74,7 @@ export function TaskDetailPage({
 	} = useChatStore((s) => s);
 
 	const [task, setTask] = useState<ProjectTask | null>(null);
-	const [artifacts, setArtifacts] = useState<ProjectArtifact[]>([]);
+	const [taskApiArtifacts, setTaskApiArtifacts] = useState<ProjectArtifact[]>([]);
 	const [previewArtifact, setPreviewArtifact] = useState<ProjectArtifact | null>(null);
 
 	const resolvedProjectId = projectId ?? activeTaskDetailProjectId;
@@ -116,13 +118,23 @@ export function TaskDetailPage({
 		}, initialSummary);
 	}, [resolvedSessionId, messageIds, messagesMap]);
 
+	const sessionArtifacts = useMemo(
+		() => collectSessionArtifacts(messagesMap, messageIds, resolvedSessionId),
+		[messagesMap, messageIds, resolvedSessionId],
+	);
+
+	const artifacts = useMemo(
+		() => mergeProjectArtifacts(taskApiArtifacts, sessionArtifacts),
+		[taskApiArtifacts, sessionArtifacts],
+	);
+
 	const fetchArtifacts = useCallback(async (taskId: string) => {
 		try {
 			const res = await artifactApi.listTaskArtifacts(taskId);
-			setArtifacts((res.data.data ?? []).map(mapBackendArtifactToProjectArtifact));
+			setTaskApiArtifacts((res.data.data ?? []).map(mapBackendArtifactToProjectArtifact));
 		} catch (err) {
 			console.error("TaskDetailPage fetch artifacts error:", err);
-			setArtifacts([]);
+			setTaskApiArtifacts([]);
 		}
 	}, []);
 

--- a/frontend/packages/app-ui/components/layout/project-files.ts
+++ b/frontend/packages/app-ui/components/layout/project-files.ts
@@ -6,6 +6,7 @@ export type BackendProjectFileNodeLike = {
 	size?: number;
 	mime_type?: string;
 	mod_time?: number;
+	public_id?: string;
 };
 
 export type ProjectFileNode = {
@@ -16,6 +17,7 @@ export type ProjectFileNode = {
 	size: number;
 	mimeType: string;
 	modTime: number;
+	publicId: string;
 };
 
 // 统一清洗后端文件树结构，避免页面层到处处理空值和字段名差异。
@@ -31,6 +33,7 @@ export function normalizeProjectFileTree(
 		size: typeof node.size === "number" ? node.size : 0,
 		mimeType: typeof node.mime_type === "string" ? node.mime_type : "",
 		modTime: typeof node.mod_time === "number" ? node.mod_time : 0,
+		publicId: typeof node.public_id === "string" ? node.public_id : "",
 		children: normalizeProjectFileTree(node.children),
 	}));
 }

--- a/frontend/packages/store/api/artifactApi.ts
+++ b/frontend/packages/store/api/artifactApi.ts
@@ -1,30 +1,49 @@
-import { readStoredJwtToken } from "../utils/authStorage";
 import { apiClient } from "./client";
-import { API_BASE_URL } from "./config";
-import type { BackendArtifact, BackendDataResponse } from "./types";
+import { fetchFileDownload } from "./fileApi";
+import type { BackendArtifact, BackendArtifactDetail, BackendDataResponse } from "./types";
 
-export function getArtifactDownloadUrl(artifactId: string): string {
-	return `${API_BASE_URL}/artifacts/${encodeURIComponent(artifactId)}/download`;
+const publishFileIdCache = new Map<string, string>();
+
+function readPublishFileId(detail: BackendArtifactDetail): string {
+	const publishFileId = detail.publish_file_id?.trim() ?? detail["publish-file_id"]?.trim() ?? "";
+	return publishFileId;
+}
+
+async function resolveArtifactPublishFileId(
+	artifactId: string,
+	options?: { signal?: AbortSignal },
+): Promise<string> {
+	const normalizedArtifactId = artifactId.trim();
+	if (!normalizedArtifactId) {
+		throw new Error("artifact_id is required");
+	}
+
+	const cached = publishFileIdCache.get(normalizedArtifactId);
+	if (cached) return cached;
+
+	const response = await apiClient.post<BackendDataResponse<BackendArtifactDetail>>(
+		"/GetArtifact",
+		{ artifact_id: normalizedArtifactId },
+		{ signal: options?.signal },
+	);
+	const publishFileId = readPublishFileId(response.data.data ?? {});
+	if (!publishFileId) {
+		throw new Error("GetArtifact 未返回 publish_file_id");
+	}
+
+	publishFileIdCache.set(normalizedArtifactId, publishFileId);
+	return publishFileId;
 }
 
 export async function fetchArtifactDownload(
 	artifactId: string,
 	options?: { signal?: AbortSignal },
 ): Promise<Response> {
-	const token = readStoredJwtToken();
-	const response = await fetch(getArtifactDownloadUrl(artifactId), {
-		method: "GET",
-		signal: options?.signal,
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-	});
-	if (!response.ok) {
-		throw new Error(`HTTP ${response.status}`);
-	}
-	return response;
+	const publishFileId = await resolveArtifactPublishFileId(artifactId, options);
+	return fetchFileDownload(publishFileId, options);
 }
 
 export const artifactApi = {
-	getDownloadUrl: getArtifactDownloadUrl,
 	fetchDownload: fetchArtifactDownload,
 	listTaskArtifacts: (taskId: string) =>
 		apiClient.get<BackendDataResponse<BackendArtifact[]>>(

--- a/frontend/packages/store/api/artifactApi.ts
+++ b/frontend/packages/store/api/artifactApi.ts
@@ -1,6 +1,35 @@
+import type { ApiError } from "@leros/ui/lib/request";
 import { apiClient } from "./client";
 import { fetchFileDownload } from "./fileApi";
 import type { BackendArtifact, BackendArtifactDetail, BackendDataResponse } from "./types";
+
+function isNotFoundError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"status" in error &&
+		(error as ApiError).status === 404
+	);
+}
+
+/** Lists task artifacts; prefers deployed RPC route, falls back to REST GET for local dev. */
+async function listTaskArtifacts(taskId: string) {
+	const normalizedTaskId = taskId.trim();
+	if (!normalizedTaskId) {
+		throw new Error("task_id is required");
+	}
+
+	try {
+		return await apiClient.post<BackendDataResponse<BackendArtifact[]>>("/ListTaskArtifacts", {
+			task_id: normalizedTaskId,
+		});
+	} catch (error) {
+		if (!isNotFoundError(error)) throw error;
+		return apiClient.get<BackendDataResponse<BackendArtifact[]>>(
+			`/tasks/${encodeURIComponent(normalizedTaskId)}/artifacts`,
+		);
+	}
+}
 
 const publishFileIdCache = new Map<string, string>();
 
@@ -45,8 +74,5 @@ export async function fetchArtifactDownload(
 
 export const artifactApi = {
 	fetchDownload: fetchArtifactDownload,
-	listTaskArtifacts: (taskId: string) =>
-		apiClient.get<BackendDataResponse<BackendArtifact[]>>(
-			`/tasks/${encodeURIComponent(taskId)}/artifacts`,
-		),
+	listTaskArtifacts,
 };

--- a/frontend/packages/store/api/fileApi.ts
+++ b/frontend/packages/store/api/fileApi.ts
@@ -1,0 +1,27 @@
+import { readStoredJwtToken } from "../utils/authStorage";
+import { API_BASE_URL } from "./config";
+
+export function getFileDownloadUrl(publicId: string): string {
+	return `${API_BASE_URL}/files/${encodeURIComponent(publicId)}/download`;
+}
+
+export async function fetchFileDownload(
+	publicId: string,
+	options?: { signal?: AbortSignal },
+): Promise<Response> {
+	const token = readStoredJwtToken();
+	const response = await fetch(getFileDownloadUrl(publicId), {
+		method: "GET",
+		signal: options?.signal,
+		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+	});
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}`);
+	}
+	return response;
+}
+
+export const fileApi = {
+	getDownloadUrl: getFileDownloadUrl,
+	fetchDownload: fetchFileDownload,
+};

--- a/frontend/packages/store/api/index.ts
+++ b/frontend/packages/store/api/index.ts
@@ -1,4 +1,4 @@
-export { artifactApi, fetchArtifactDownload, getArtifactDownloadUrl } from "./artifactApi";
+export { artifactApi, fetchArtifactDownload } from "./artifactApi";
 export type {
 	AuthOrgInfo,
 	AuthTokenResponse,

--- a/frontend/packages/store/api/projectFileApi.ts
+++ b/frontend/packages/store/api/projectFileApi.ts
@@ -18,29 +18,88 @@ export type UploadProjectFileParams = {
 	file: File;
 };
 
-export function getProjectFileDownloadUrl(projectId: string, filepath: string): string {
-	const normalizedPath = filepath.replace(/^\/+/, "");
-	return `${API_BASE_URL}/projects/${encodeURIComponent(projectId)}/files/${normalizedPath
-		.split("/")
-		.map((segment) => encodeURIComponent(segment))
-		.join("/")}`;
+type BackendUploadFilePayload = {
+	public_id: string;
+	file_upload_id?: string;
+	filename?: string;
+	original_name?: string;
+	mime_type?: string;
+	file_size?: number;
+	sha256?: string;
+	storage_path?: string;
+	url?: string;
+};
+
+type AddProjectFileParams = {
+	projectId: string;
+	publicId: string;
+};
+
+async function parseErrorMessage(response: Response): Promise<string> {
+	let message = `HTTP ${response.status}`;
+	try {
+		const payload = (await response.json()) as { message?: string };
+		if (typeof payload.message === "string" && payload.message) {
+			message = payload.message;
+		}
+	} catch {
+		// 保持默认错误信息即可
+	}
+	return message;
 }
 
-export async function fetchProjectFileDownload(
-	projectId: string,
-	filepath: string,
-	options?: { signal?: AbortSignal },
-): Promise<Response> {
-	const token = readStoredJwtToken();
-	const response = await fetch(getProjectFileDownloadUrl(projectId, filepath), {
-		method: "GET",
-		signal: options?.signal,
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-	});
-	if (!response.ok) {
-		throw new Error(`HTTP ${response.status}`);
+function assertBackendSuccess<T>(
+	response: BackendDataResponse<T>,
+	fallbackMessage: string,
+): BackendDataResponse<T> {
+	if (response.code !== 0) {
+		throw new Error(response.message || fallbackMessage);
 	}
 	return response;
+}
+
+async function uploadFile(
+	file: File,
+	token?: string | null,
+): Promise<BackendDataResponse<BackendUploadFilePayload>> {
+	const formData = new FormData();
+	formData.append("file", file);
+	formData.append("purpose", "project");
+
+	const response = await fetch(`${API_BASE_URL}/files/upload`, {
+		method: "POST",
+		body: formData,
+		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+	});
+
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+
+	return (await response.json()) as BackendDataResponse<BackendUploadFilePayload>;
+}
+
+async function addFileToProject(
+	{ projectId, publicId }: AddProjectFileParams,
+	token?: string | null,
+): Promise<BackendDataResponse<null>> {
+	const response = await fetch(
+		`${API_BASE_URL}/projects/${encodeURIComponent(projectId)}/AddFile`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				...(token ? { Authorization: `Bearer ${token}` } : {}),
+			},
+			body: JSON.stringify({ public_id: publicId }),
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+
+	return (await response.json()) as BackendDataResponse<null>;
 }
 
 export const projectFileApi = {
@@ -57,34 +116,33 @@ export const projectFileApi = {
 
 	upload: async ({ projectId, file }: UploadProjectFileParams) => {
 		const token = readStoredJwtToken();
-		const formData = new FormData();
-		formData.append("file", file);
-
-		const response = await fetch(
-			`${API_BASE_URL}/projects/${encodeURIComponent(projectId)}/files/upload`,
-			{
-				method: "POST",
-				body: formData,
-				headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-			},
-		);
-
-		if (!response.ok) {
-			let message = `HTTP ${response.status}`;
-			try {
-				const payload = (await response.json()) as { message?: string };
-				if (typeof payload.message === "string" && payload.message) {
-					message = payload.message;
-				}
-			} catch {
-				// 保持默认错误信息即可
-			}
-			throw new Error(message);
+		const uploadResponse = assertBackendSuccess(await uploadFile(file, token), "文件上传失败");
+		const uploaded = uploadResponse.data;
+		if (!uploaded?.public_id) {
+			throw new Error("上传接口未返回 public_id");
 		}
 
-		return (await response.json()) as BackendDataResponse<BackendProjectFileUploadResult | string>;
-	},
+		const addResponse = assertBackendSuccess(
+			await addFileToProject({ projectId, publicId: uploaded.public_id }, token),
+			"添加文件到项目失败",
+		);
 
-	getDownloadUrl: getProjectFileDownloadUrl,
-	fetchDownload: fetchProjectFileDownload,
+		return {
+			code: addResponse.code,
+			message: addResponse.message,
+			data: {
+				path: uploaded.storage_path || uploaded.url || uploaded.public_id,
+				filename: uploaded.original_name || uploaded.filename || file.name,
+				size: uploaded.file_size ?? file.size,
+				public_id: uploaded.public_id,
+				file_upload_id: uploaded.file_upload_id,
+				original_name: uploaded.original_name,
+				mime_type: uploaded.mime_type || file.type,
+				file_size: uploaded.file_size ?? file.size,
+				sha256: uploaded.sha256,
+				storage_path: uploaded.storage_path,
+				url: uploaded.url,
+			} satisfies BackendProjectFileUploadResult,
+		} as BackendDataResponse<BackendProjectFileUploadResult>;
+	},
 };

--- a/frontend/packages/store/api/types.ts
+++ b/frontend/packages/store/api/types.ts
@@ -58,6 +58,7 @@ export type BackendMessage = {
 		total_tokens?: number;
 	};
 	chunks?: BackendMessageChunk[];
+	artifacts?: BackendSessionArtifactPayload[];
 	created_at: string;
 };
 
@@ -285,6 +286,24 @@ export type BackendArtifact = {
 	sha256?: string;
 };
 
+export type BackendArtifactDetail = {
+	artifact_id: string;
+	title: string;
+	filename?: string;
+	description?: string;
+	artifact_type: string;
+	mime_type?: string;
+	file_size?: number;
+	sha256?: string;
+	relative_path?: string;
+	source?: string;
+	export_format?: string;
+	version?: number;
+	status?: string;
+	publish_file_id?: string;
+	"publish-file_id"?: string;
+};
+
 export type BackendProjectMemberItem = {
 	member_id: number;
 	member_type: string;
@@ -313,12 +332,21 @@ export type BackendProjectFileNode = {
 	size?: number;
 	mime_type?: string;
 	mod_time?: number;
+	public_id?: string;
 };
 
 export type BackendProjectFileUploadResult = {
 	path: string;
 	filename: string;
 	size: number;
+	public_id?: string;
+	file_upload_id?: string;
+	original_name?: string;
+	mime_type?: string;
+	file_size?: number;
+	sha256?: string;
+	storage_path?: string;
+	url?: string;
 };
 
 export type BackendNewMessageData = {

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -1,4 +1,4 @@
-export { artifactApi, fetchArtifactDownload, getArtifactDownloadUrl } from "./api/artifactApi";
+export { artifactApi, fetchArtifactDownload } from "./api/artifactApi";
 export type {
 	AuthOrgInfo,
 	AuthTokenResponse,
@@ -9,11 +9,8 @@ export type {
 export { authApi } from "./api/authApi";
 export { API_BASE_URL } from "./api/config";
 export { digitalAssistantApi } from "./api/digitalAssistantApi";
-export {
-	fetchProjectFileDownload,
-	getProjectFileDownloadUrl,
-	projectFileApi,
-} from "./api/projectFileApi";
+export { fetchFileDownload, fileApi, getFileDownloadUrl } from "./api/fileApi";
+export { projectFileApi } from "./api/projectFileApi";
 export { sessionApi } from "./api/sessionApi";
 export type { AppAction, AppStore } from "./appStore";
 export {
@@ -79,4 +76,9 @@ export type {
 	ToolCallStatus,
 } from "./types/chat";
 export { flattenActions } from "./utils";
+export {
+	collectSessionArtifacts,
+	mergeProjectArtifacts,
+	messageArtifactToProjectArtifact,
+} from "./utils/artifacts";
 export { formatDate, formatFileSize, formatTime, formatTokenCount } from "./utils/format";

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -1,5 +1,4 @@
 import { FetchSSEClient } from "@leros/ui/lib/fetch-sse";
-import { getArtifactDownloadUrl } from "../api/artifactApi";
 import { API_BASE_URL } from "../api/config";
 import { projectFileApi } from "../api/projectFileApi";
 import { sessionApi } from "../api/sessionApi";
@@ -92,7 +91,18 @@ function mapBackendMessage(msg: BackendMessage): Message {
 		usage: mapUsage(msg.usage),
 	};
 
-	return applySessionEventsToMessage(message, msg.chunks, { appendContent: !message.content });
+	let mapped = applySessionEventsToMessage(message, msg.chunks, {
+		appendContent: !message.content,
+	});
+	if (msg.artifacts?.length) {
+		const artifacts = msg.artifacts
+			.map(mapArtifactPayload)
+			.filter((artifact): artifact is MessageArtifact => artifact !== undefined);
+		if (artifacts.length) {
+			mapped = { ...mapped, artifacts: mergeArtifacts(mapped.artifacts, artifacts) };
+		}
+	}
+	return mapped;
 }
 
 function mapToolCalls(tcList?: BackendToolCall[]): ToolCall[] | undefined {
@@ -281,7 +291,7 @@ function mapArtifactPayload(payload: BackendSessionArtifactPayload): MessageArti
 		mimeType,
 		size: formatFileSize(payload.file_size ?? 0),
 		updatedAt: "",
-		downloadUrl: getArtifactDownloadUrl(artifactID),
+		downloadUrl: "",
 		sha256: payload.sha256,
 	};
 }
@@ -1038,33 +1048,31 @@ export class ChatActionImpl {
 	addUploadedAttachment = async (projectId: string, file: File) => {
 		const response = await projectFileApi.upload({ projectId, file });
 		const payload = response.data;
-		const uploadedPath =
-			typeof payload === "string" ? payload : typeof payload?.path === "string" ? payload.path : "";
 		const attachmentId = `att-${Date.now()}`;
 		const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined;
 
 		const attachment: Attachment = {
 			id: attachmentId,
 			type: file.type.startsWith("image/") ? "image" : "file",
-			name: file.name,
-			size: file.size,
+			name: payload.original_name || payload.filename || file.name,
+			size: payload.file_size ?? payload.size ?? file.size,
 			url: previewUrl,
 			file,
-			path: uploadedPath,
-			mimeType: file.type,
+			path: payload.public_id || payload.storage_path || payload.path,
+			mimeType: payload.mime_type || file.type,
 		};
 
 		this.#set((state) => ({
 			inputAttachments: [...state.inputAttachments, attachment],
 		}));
 
-		return attachment;
+		return { attachment, message: response.message };
 	};
 
 	removeAttachment = (id: string) => {
 		const state = this.#get();
 		const att = state.inputAttachments.find((a) => a.id === id);
-		if (att?.url) URL.revokeObjectURL(att.url);
+		if (att?.url?.startsWith("blob:")) URL.revokeObjectURL(att.url);
 		this.#set((state) => ({
 			inputAttachments: state.inputAttachments.filter((a) => a.id !== id),
 		}));

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -1,4 +1,3 @@
-import { getArtifactDownloadUrl } from "../api/artifactApi";
 import { projectApi } from "../api/projectApi";
 import { sessionApi } from "../api/sessionApi";
 import { taskApi } from "../api/taskApi";
@@ -182,7 +181,7 @@ export function mapBackendArtifactToProjectArtifact(ba: BackendArtifact): Projec
 		mimeType: ba.mime_type,
 		size: formatFileSize(ba.file_size ?? 0),
 		updatedAt: "",
-		downloadUrl: getArtifactDownloadUrl(ba.artifact_id),
+		downloadUrl: "",
 		sha256: ba.sha256,
 	};
 }

--- a/frontend/packages/store/utils/artifacts.ts
+++ b/frontend/packages/store/utils/artifacts.ts
@@ -1,0 +1,64 @@
+import type { ProjectArtifact } from "../slices/layoutSlice";
+import type { Message, MessageArtifact } from "../types/chat";
+
+/** Converts a message-scoped artifact into the project artifact shape used by UI panels. */
+export function messageArtifactToProjectArtifact(artifact: MessageArtifact): ProjectArtifact {
+	return {
+		id: artifact.id,
+		name: artifact.name,
+		title: artifact.title,
+		description: artifact.description,
+		type: artifact.type,
+		artifactType: artifact.artifactType,
+		mimeType: artifact.mimeType,
+		size: artifact.size,
+		updatedAt: artifact.updatedAt,
+		downloadUrl: artifact.downloadUrl,
+		sha256: artifact.sha256,
+	};
+}
+
+/**
+ * Merges session message artifacts with task API artifacts.
+ * Task API records enrich message artifacts when both exist for the same id.
+ */
+export function mergeProjectArtifacts(
+	taskArtifacts: ProjectArtifact[],
+	sessionArtifacts: ProjectArtifact[],
+): ProjectArtifact[] {
+	const merged = new Map<string, ProjectArtifact>();
+	for (const artifact of sessionArtifacts) {
+		merged.set(artifact.id, artifact);
+	}
+	for (const artifact of taskArtifacts) {
+		const existing = merged.get(artifact.id);
+		merged.set(artifact.id, existing ? { ...existing, ...artifact } : artifact);
+	}
+	return [...merged.values()];
+}
+
+/** Collects declared artifacts from assistant messages in one session. */
+export function collectSessionArtifacts(
+	messagesMap: Record<string, Message>,
+	messageIds: string[],
+	sessionId: string | null | undefined,
+): ProjectArtifact[] {
+	if (!sessionId) return [];
+
+	const merged = new Map<string, ProjectArtifact>();
+	for (const id of messageIds) {
+		const message = messagesMap[id];
+		if (
+			!message ||
+			message.conversationId !== sessionId ||
+			message.role !== "assistant" ||
+			!message.artifacts?.length
+		) {
+			continue;
+		}
+		for (const artifact of message.artifacts) {
+			merged.set(artifact.id, messageArtifactToProjectArtifact(artifact));
+		}
+	}
+	return [...merged.values()];
+}


### PR DESCRIPTION
## Summary

- 修复项目文件与任务产物在预览/下载时依赖旧字段导致的链路不一致问题
- 拆分并收敛文件上传流程，统一上传返回结构，补齐前端成功/失败提示
- 合并会话内 artifacts 与任务侧 artifacts 的展示数据，避免同一产物在不同面板里信息不一致
- 清理无用中间层与空转封装，减少非必要导出和重复转换逻辑

## Changes

- 新增通用文件下载能力 `fileApi`
- 项目文件预览/下载改为直接走文件下载接口，不再依赖旧的路径下载方式
- artifact 预览下载前先解析 `publish_file_id`，再获取实际文件
- 项目上传接口改为“先上传文件，再关联到项目”，并统一返回结构化元数据
- 会话消息中的 artifact 数据补充进任务详情和消息气泡展示，并与任务接口返回结果合并
- 清理死代码、重复包装和无关样式噪音，收敛 diff 范围

## Verification

- `pnpm exec biome check packages/app-ui/components/chat/AIMessageBubble.tsx packages/app-ui/components/input/ChatInput.tsx packages/app-ui/components/layout/ProjectPage.tsx packages/app-ui/components/layout/TaskDetailPage.tsx packages/app-ui/components/layout/project-files.ts packages/store/api/artifactApi.ts packages/store/api/fileApi.ts packages/store/api/index.ts packages/store/api/projectFileApi.ts packages/store/api/types.ts packages/store/index.ts packages/store/slices/chatSlice.ts packages/store/slices/layoutSlice.ts packages/store/utils/artifacts.ts`
- `pnpm run typecheck`

## Issue

- Closes #<issue-number>