### PR TITLE
fix: 内置agent修复对话历史上下文

### DIFF
--- a/backend/cmd/leros/main.go
+++ b/backend/cmd/leros/main.go
@@ -1,9 +1,79 @@
 package main
 
-import "os"
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
 
 func main() {
+	redirectLogsToStderr()
 	if err := newRootCommand().Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// redirectLogsToStderr ensures that structured zap log lines emitted by the
+// yg-go/logs package are written to stderr instead of stdout. This keeps
+// machine-readable --json output on stdout clean for pipes and subprocess
+// callers.
+//
+// The redirect only activates when a --json flag is present in the command
+// arguments (e.g. session messages, session ls). Server, worker, chat and
+// other interactive commands are left untouched.
+func redirectLogsToStderr() {
+	if !hasJSONFlag() {
+		return
+	}
+
+	realStdout := os.Stdout
+	realStderr := os.Stderr
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return
+	}
+
+	os.Stdout = w
+
+	go func() {
+		defer r.Close()
+		defer w.Close()
+
+		scanner := bufio.NewScanner(r)
+		// Large JSON payloads may exceed the default 64 KiB buffer.
+		scanner.Buffer(make([]byte, 0, 256*1024), 16*1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if isZapLogLine(line) {
+				realStderr.Write(line)
+				realStderr.Write([]byte{'\n'})
+			} else {
+				realStdout.Write(line)
+				realStdout.Write([]byte{'\n'})
+			}
+		}
+		_ = scanner.Err()
+	}()
+}
+
+// hasJSONFlag reports whether the --json flag is present in the command
+// line arguments.
+func hasJSONFlag() bool {
+	for _, arg := range os.Args {
+		if arg == "--json" {
+			return true
+		}
+	}
+	return false
+}
+
+// isZapLogLine reports whether b is a structured zap JSON log entry by
+// probing for the "lvl" key that the zapcore.JSONEncoder always emits.
+func isZapLogLine(b []byte) bool {
+	var probe struct {
+		Level string `json:"lvl"`
+	}
+	return json.Unmarshal(b, &probe) == nil && probe.Level != ""
 }

--- a/backend/cmd/leros/session.go
+++ b/backend/cmd/leros/session.go
@@ -12,16 +12,19 @@ import (
 
 	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/cli"
+	"github.com/insmtx/Leros/backend/types"
 )
 
 var (
-	sessionJSON        bool
-	sessionKeyword     string
-	sessionStatus      string
-	sessionType        string
-	sessionAssistantID uint
-	sessionOffset      int
-	sessionLimit       int
+	sessionJSON           bool
+	sessionKeyword        string
+	sessionStatus         string
+	sessionType           string
+	sessionAssistantID    uint
+	sessionOffset         int
+	sessionLimit          int
+	sessionMessagesPage   int
+	sessionMessagesPerPage int
 )
 
 type sessionDetailOutput struct {
@@ -134,6 +137,38 @@ func newSessionCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&sessionJSON, "json", false, "Output in JSON format")
 
+	messagesCmd := &cobra.Command{
+		Use:   "messages <session_id>",
+		Short: "List session messages",
+		Long: `List persisted messages for a session in page-delimited batches.
+
+Requires a session ID argument:
+  leros session messages <session_id> --json --page 1 --per-page 20`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			go func() {
+				ctx := lifecycle.Std().Context()
+				sessionID := args[0]
+
+				result, err := cli.GetSessionMessages(
+					ctx, cliServerAddr(), cliAuthToken(),
+					sessionID, sessionMessagesPage, sessionMessagesPerPage,
+				)
+				if err != nil {
+					logs.Errorf("list session messages: %v", err)
+					lifecycle.Std().Exit()
+					return
+				}
+				printSessionMessages(result)
+				lifecycle.Std().Exit()
+			}()
+			lifecycle.Std().WaitExit()
+		},
+	}
+
+	messagesCmd.Flags().IntVar(&sessionMessagesPage, "page", 1, "Page number (1-based)")
+	messagesCmd.Flags().IntVar(&sessionMessagesPerPage, "per-page", 20, "Items per page")
+
 	lsCmd.Flags().StringVar(&sessionKeyword, "keyword", "", "Filter by title or public_id keyword")
 	lsCmd.Flags().StringVar(&sessionStatus, "status", "", "Filter by status")
 	lsCmd.Flags().StringVar(&sessionType, "type", "", "Filter by session type")
@@ -143,6 +178,7 @@ func newSessionCommand() *cobra.Command {
 
 	cmd.AddCommand(lsCmd)
 	cmd.AddCommand(getCmd)
+	cmd.AddCommand(messagesCmd)
 	return cmd
 }
 
@@ -232,4 +268,55 @@ func truncateContent(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+type sessionMessageItem struct {
+	Role        string                    `json:"role"`
+	Content     string                    `json:"content"`
+	MessageType string                    `json:"message_type,omitempty"`
+	Attachments []types.MessageAttachment `json:"attachments,omitempty"`
+}
+
+type sessionMessagesOutput struct {
+	Total int64                 `json:"total"`
+	Page  int                   `json:"page"`
+	Items []sessionMessageItem  `json:"items"`
+}
+
+func printSessionMessages(list *contract.MessageList) {
+	if sessionJSON {
+		out := sessionMessagesOutput{
+			Total: list.Total,
+			Page:  list.Page,
+			Items: make([]sessionMessageItem, len(list.Items)),
+		}
+		for i, m := range list.Items {
+			out.Items[i] = sessionMessageItem{
+				Role:        m.Role,
+				Content:     m.Content,
+				MessageType: m.MessageType,
+				Attachments: m.Attachments,
+			}
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(out)
+		return
+	}
+
+	if len(list.Items) == 0 {
+		fmt.Println("No messages found.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "SEQ\tROLE\tCONTENT\tCREATED")
+	for _, m := range list.Items {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\n",
+			m.Sequence, m.Role,
+			truncateContent(m.Content, 120),
+			m.CreatedAt.Format("2006-01-02T15:04:05Z"))
+	}
+	w.Flush()
+	fmt.Fprintf(os.Stderr, "\nTotal: %d, Page: %d\n", list.Total, list.Page)
 }

--- a/backend/engines/claude/invoker.go
+++ b/backend/engines/claude/invoker.go
@@ -29,9 +29,6 @@ func NewInvoker(binary string, extraEnv map[string]string) *Invoker {
 
 // Run 启动 CLI 进程并将 stdout/stderr 转换为引擎事件。
 func (inv *Invoker) Run(ctx context.Context, req engines.RunRequest) (*engines.RunHandle, error) {
-	// TODO: 测试用强制改写，测试完毕后移除
-	req.PermissionMode = engines.PermissionModeOnRequest
-
 	args := buildArgs(req)
 
 	// 写入 settings.leros.{sessionId}.json，通过 --settings 覆盖用户级 ~/.claude/settings.json

--- a/backend/engines/native/runner.go
+++ b/backend/engines/native/runner.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/cloudwego/eino/adk"
 	einotool "github.com/cloudwego/eino/components/tool"
 	"github.com/insmtx/Leros/backend/engines"
+	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/runtime/deps"
 	"github.com/insmtx/Leros/backend/internal/runtime/events"
 	runtimetodo "github.com/insmtx/Leros/backend/internal/runtime/todo"
@@ -136,12 +139,24 @@ func (r *Runner) runWithState(ctx context.Context, req engines.RunRequest, sink 
 	}
 	einoBaseTools := buildEinoTools(toolSpecs, toolInvoker)
 
+	// Load persisted session messages as conversation history.
+	var historyMessages []adk.Message
+	if req.SessionID != "" {
+		msgList, loadErr := loadSessionContext(ctx, req.SessionID, 1, 20)
+		if loadErr != nil {
+			return "", nil, fmt.Errorf("load session context: %w", loadErr)
+		}
+		if msgList != nil && len(msgList.Items) > 0 {
+			historyMessages = buildHistoryMessages(msgList.Items, 20)
+		}
+	}
+
 	flow, err := pkgeino.NewFlow(ctx, &pkgeino.FlowConfig{
 		Model:        chatModel,
 		Tools:        einoBaseTools,
 		SystemPrompt: systemPrompt,
 		MaxStep:      90,
-		Messages:     nil,
+		Messages:     historyMessages,
 	})
 	if err != nil {
 		return "", nil, err
@@ -180,6 +195,41 @@ func (r *Runner) runWithState(ctx context.Context, req engines.RunRequest, sink 
 		req.ExecutionID, formatLLMResultForLog(message))
 
 	return resultMessage, usage, nil
+}
+
+// buildHistoryMessages converts persisted session messages into Eino ADK
+// history messages. It sorts by sequence, skips empty content, and limits
+// to the most recent maxMessages entries.
+func buildHistoryMessages(messages []contract.SessionMessage, maxMessages int) []adk.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	// Sort by sequence number ascending.
+	sorted := make([]contract.SessionMessage, len(messages))
+	copy(sorted, messages)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Sequence < sorted[j].Sequence
+	})
+
+	// Filter empty and build eino.Message slice.
+	einoMessages := make([]pkgeino.Message, 0, len(sorted))
+	for _, msg := range sorted {
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+		einoMessages = append(einoMessages, pkgeino.Message{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+
+	// Limit to most recent maxMessages.
+	if maxMessages > 0 && len(einoMessages) > maxMessages {
+		einoMessages = einoMessages[len(einoMessages)-maxMessages:]
+	}
+
+	return pkgeino.BuildMessages(einoMessages)
 }
 
 func (r *Runner) buildToolBinding(req engines.RunRequest, sink events.Sink) toolBinding {

--- a/backend/engines/native/session_context.go
+++ b/backend/engines/native/session_context.go
@@ -1,0 +1,47 @@
+package native
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+)
+
+// loadSessionContext shells out to the leros CLI to fetch persisted session
+// messages from the server. Returns nil if sessionID is empty.
+func loadSessionContext(ctx context.Context, sessionID string, page, perPage int) (*contract.MessageList, error) {
+	if sessionID == "" {
+		return nil, nil
+	}
+
+	lerosBin, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("find leros binary: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, lerosBin,
+		"session", "messages", sessionID,
+		"--page", fmt.Sprintf("%d", page),
+		"--per-page", fmt.Sprintf("%d", perPage),
+		"--json",
+	)
+
+	// Inherit worker process environment so CLI resolves
+	// server_addr and auth_token from config/env.
+	cmd.Env = os.Environ()
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("leros session messages: %w", err)
+	}
+
+	var msgList contract.MessageList
+	if err := json.Unmarshal(stdout, &msgList); err != nil {
+		return nil, fmt.Errorf("parse session messages JSON: %w", err)
+	}
+
+	return &msgList, nil
+}

--- a/backend/internal/api/contract/session_type.go
+++ b/backend/internal/api/contract/session_type.go
@@ -116,6 +116,13 @@ type MessageList struct {
 	Items []SessionMessage `json:"items"`
 }
 
+// GetSessionMessagesRequest queries paged session messages.
+type GetSessionMessagesRequest struct {
+	SessionID string `json:"session_id"`
+	Page      int    `json:"page,omitempty"`
+	PerPage   int    `json:"per_page,omitempty"`
+}
+
 // CompleteSessionMessageRequest persists a completed assistant message.
 type CompleteSessionMessageRequest struct {
 	SessionID string                  `json:"session_id"`

--- a/backend/internal/cli/getter.go
+++ b/backend/internal/cli/getter.go
@@ -56,10 +56,10 @@ func DetailProject(ctx context.Context, serverAddr, authToken, publicID string) 
 func GetSessionMessages(ctx context.Context, serverAddr, authToken, sessionID string, page, perPage int) (*contract.MessageList, error) {
 	var result contract.MessageList
 	if err := doPostRequest(ctx, serverAddr, authToken, "GetSessionMessages",
-		map[string]interface{}{
-			"session_id": sessionID,
-			"page":       page,
-			"per_page":   perPage,
+		&contract.GetSessionMessagesRequest{
+			SessionID: sessionID,
+			Page:      page,
+			PerPage:   perPage,
 		}, &result); err != nil {
 		return nil, err
 	}

--- a/backend/internal/runtime/drivers/externalcli/runner.go
+++ b/backend/internal/runtime/drivers/externalcli/runner.go
@@ -324,6 +324,12 @@ func (r *Runner) resolveProviderSession(ctx context.Context, req *agent.RequestC
 			AssistantID:       req.Assistant.ID,
 		},
 	}
+		// Native 引擎不使用外部 CLI 会话，直接使用 Leros 内部 session ID。
+		if r.name == engines.EngineNative {
+			plan.ProviderSessionID = internalSessionID
+			return plan
+		}
+
 	if internalSessionID == "" || r.sessionStore == nil {
 		return plan
 	}

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -631,8 +631,8 @@ func convertToContractSessionMessage(message *types.SessionMessage, publicID str
 
 func isHiddenSessionHistoryChunk(eventType string) bool {
 	switch events.EventType(eventType) {
-	case events.EventTodoSnapshot, events.EventTodoUpdated:
-		return true
+	// case events.EventTodoSnapshot, events.EventTodoUpdated:
+	// 	return true
 	default:
 		return false
 	}


### PR DESCRIPTION
add session message history and CLI messages command
- Add  subcommand with JSON output and pagination
- Native engine loads persisted session messages as conversation context
- Redirect zap structured logs to stderr when --json flag is used
- Add GetSessionMessagesRequest contract type
- Refactor CLI getter to use typed request struct
- Native engine uses internal session ID directly (skip external CLI session)
- Expose all message types in session history (unhide todo events)