### PR TITLE
fix(ui): 增强产物卡片预览悬停提示

### DIFF
--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -1088,11 +1088,17 @@ function ProjectArtifactList({
 						key={artifact.id}
 						onClick={() => setPreviewArtifact(artifact)}
 						className={cn(
-							"flex w-full items-center border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
+							"group relative flex w-full cursor-pointer items-center overflow-hidden border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
 							compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
 						)}
 						title="预览产物"
 					>
+						{/* hover 时补一个轻量蒙层，明确提示当前整卡可点击预览 */}
+						<div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+							<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
+								点击预览
+							</span>
+						</div>
 						<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-text)]">
 							<ArtifactIcon type={artifact.type} />
 						</div>

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -517,9 +517,15 @@ function TaskArtifactList({
 					type="button"
 					key={artifact.id}
 					onClick={() => onPreview(artifact)}
-					className="flex w-full items-center gap-3 rounded-lg border border-[var(--leros-control-border)] bg-[var(--leros-surface)] px-3.5 py-3 text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35"
+					className="group relative flex w-full cursor-pointer items-center gap-3 overflow-hidden rounded-lg border border-[var(--leros-control-border)] bg-[var(--leros-surface)] px-3.5 py-3 text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35"
 					title="预览产物"
 				>
+					{/* hover 时补一个轻量蒙层，明确提示当前整卡可点击预览 */}
+					<div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+						<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
+							点击预览
+						</span>
+					</div>
 					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-text)]">
 						<TaskArtifactIcon type={artifact.type} />
 					</div>


### PR DESCRIPTION
## 变更说明
- 为任务会话页的产物卡片补充 hover 蒙层提示
- 为项目页的产物卡片补充 hover 蒙层提示
- 悬停时展示“点击预览”文案，并统一鼠标指针样式为可点击态
- 保持原有点击热区不变，仍然是整个产物容器可点击预览

## 验证
- 已检查任务会话页产物卡片 hover 提示样式
- 已同步项目页产物卡片 hover 提示样式
- 已执行文件级 Biome 检查：
  - `pnpm exec biome check packages/app-ui/components/layout/TaskDetailPage.tsx`
  - `pnpm exec biome check packages/app-ui/components/layout/ProjectPage.tsx`
