### PR TITLE
fix(frontend): 减少项目切换重复请求

### DIFF
--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -81,6 +81,7 @@ export function ProjectPage({
 		projectDetailLoading,
 		projectDetailError,
 		projectSessionId,
+		projectSessionProjectId,
 		activeWorkbenchProjectId,
 		activeWorkbenchTaskId,
 		activeTaskDetailProjectId,
@@ -126,9 +127,14 @@ export function ProjectPage({
 		activeTaskDetailSessionId === activeSessionId
 			? activeTaskDetailSessionId
 			: null;
+	const currentProjectSessionId =
+		projectSessionProjectId === resolvedProjectId ? projectSessionId : null;
 
 	const resolvedSessionId =
-		streamingTaskSessionId ?? currentTaskSessionId ?? selectedTaskSessionId ?? projectSessionId;
+		streamingTaskSessionId ??
+		currentTaskSessionId ??
+		selectedTaskSessionId ??
+		currentProjectSessionId;
 
 	const handleOpenTask = (task: ProjectTask) => {
 		if (!resolvedProjectId) return;

--- a/frontend/packages/store/api/artifactApi.ts
+++ b/frontend/packages/store/api/artifactApi.ts
@@ -3,6 +3,8 @@ import { apiClient } from "./client";
 import { fetchFileDownload } from "./fileApi";
 import type { BackendArtifact, BackendArtifactDetail, BackendDataResponse } from "./types";
 
+type ListTaskArtifactsResponse = Awaited<ReturnType<typeof requestTaskArtifacts>>;
+
 function isNotFoundError(error: unknown): boolean {
 	return (
 		typeof error === "object" &&
@@ -12,6 +14,21 @@ function isNotFoundError(error: unknown): boolean {
 	);
 }
 
+const listTaskArtifactsRequests = new Map<string, Promise<ListTaskArtifactsResponse>>();
+
+async function requestTaskArtifacts(taskId: string) {
+	try {
+		return await apiClient.post<BackendDataResponse<BackendArtifact[]>>("/ListTaskArtifacts", {
+			task_id: taskId,
+		});
+	} catch (error) {
+		if (!isNotFoundError(error)) throw error;
+		return apiClient.get<BackendDataResponse<BackendArtifact[]>>(
+			`/tasks/${encodeURIComponent(taskId)}/artifacts`,
+		);
+	}
+}
+
 /** Lists task artifacts; prefers deployed RPC route, falls back to REST GET for local dev. */
 async function listTaskArtifacts(taskId: string) {
 	const normalizedTaskId = taskId.trim();
@@ -19,16 +36,14 @@ async function listTaskArtifacts(taskId: string) {
 		throw new Error("task_id is required");
 	}
 
-	try {
-		return await apiClient.post<BackendDataResponse<BackendArtifact[]>>("/ListTaskArtifacts", {
-			task_id: normalizedTaskId,
-		});
-	} catch (error) {
-		if (!isNotFoundError(error)) throw error;
-		return apiClient.get<BackendDataResponse<BackendArtifact[]>>(
-			`/tasks/${encodeURIComponent(normalizedTaskId)}/artifacts`,
-		);
-	}
+	const existingRequest = listTaskArtifactsRequests.get(normalizedTaskId);
+	if (existingRequest) return existingRequest;
+
+	const request = requestTaskArtifacts(normalizedTaskId).finally(() => {
+		listTaskArtifactsRequests.delete(normalizedTaskId);
+	});
+	listTaskArtifactsRequests.set(normalizedTaskId, request);
+	return request;
 }
 
 async function resolveArtifactFileID(

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -682,6 +682,7 @@ export class ChatActionImpl {
 	readonly #get: () => ChatStore;
 	readonly #fullGet: FullStoreGet;
 	#sseClient: FetchSSEClient | null = null;
+	#messageLoadPromises = new Map<string, Promise<void>>();
 
 	constructor(set: SetState, get: () => ChatStore, fullGet: FullStoreGet) {
 		this.#set = set;
@@ -968,6 +969,17 @@ export class ChatActionImpl {
 	};
 
 	loadConversationMessages = async (sessionId: string) => {
+		const loading = this.#messageLoadPromises.get(sessionId);
+		if (loading) return loading;
+
+		const loadPromise = this.#loadConversationMessages(sessionId).finally(() => {
+			this.#messageLoadPromises.delete(sessionId);
+		});
+		this.#messageLoadPromises.set(sessionId, loadPromise);
+		return loadPromise;
+	};
+
+	#loadConversationMessages = async (sessionId: string) => {
 		try {
 			const res = await sessionApi.getMessages(sessionId, 1, 100);
 			const items = res.data.data?.items ?? [];

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -123,6 +123,7 @@ export type LayoutState = {
 	projectDetailError: string | null;
 	activeProjectSessionId: string | null;
 	projectSessionId: string | null;
+	projectSessionProjectId: string | null;
 };
 
 export type LayoutAction = Pick<LayoutActionImpl, keyof LayoutActionImpl>;
@@ -242,6 +243,7 @@ const _initialState: LayoutState = {
 	projectDetailError: null,
 	activeProjectSessionId: null,
 	projectSessionId: null,
+	projectSessionProjectId: null,
 };
 
 type SetState = (
@@ -380,6 +382,9 @@ export class LayoutActionImpl {
 									: p,
 							),
 							projectSessionId: detail.session?.session_id ?? s.projectSessionId,
+							projectSessionProjectId: detail.session?.session_id
+								? workbenchProjectId
+								: s.projectSessionProjectId,
 						}));
 						project = { ...(project ?? mapBackendProject(detail)), tasks };
 						selectedTask = tasks.find((task) => task.id === selectedTaskId);
@@ -571,6 +576,7 @@ export class LayoutActionImpl {
 						: p,
 				),
 				projectSessionId: detail.session?.session_id ?? s.projectSessionId,
+				projectSessionProjectId: detail.session?.session_id ? projectId : s.projectSessionProjectId,
 			}));
 		} catch (err) {
 			console.error("fetchTasks error:", err);
@@ -681,6 +687,7 @@ export class LayoutActionImpl {
 				),
 				projectDetailLoading: false,
 				projectSessionId: detail.session?.session_id ?? null,
+				projectSessionProjectId: detail.session?.session_id ? projectId : null,
 			}));
 		} catch (err) {
 			console.error("fetchProjectDetail error:", err);
@@ -815,6 +822,7 @@ export class LayoutActionImpl {
 			projectDetailError: null,
 			activeProjectSessionId: null,
 			projectSessionId: null,
+			projectSessionProjectId: null,
 		});
 	};
 }


### PR DESCRIPTION
## 变更说明

修复左侧菜单切换项目时，项目会话消息和任务产物接口重复请求的问题。

## 问题原因

- 项目页使用全局 `projectSessionId` 时缺少项目归属信息，切换项目时可能误用上一个项目的 session。
- 同一个 session 的消息加载在短时间内可能被多个 effect 触发，导致 `/GetSessionMessages` 重复请求。
- 左侧项目切换时，同一个 task 的产物查询可能因组件重新挂载或并发触发而重复调用 `/ListTaskArtifacts`。

## 解决方案

- 为项目 session 增加 `projectSessionProjectId`，确保项目页只使用当前项目自己的 session。
- 在 `loadConversationMessages` 内部增加同 session 的 in-flight 请求复用。
- 在 `artifactApi.listTaskArtifacts` 内部增加同 taskId 的 in-flight 请求复用，只合并未完成请求，不缓存结果。

## 验证

- `pnpm exec biome check packages/store/api/artifactApi.ts packages/app-ui/components/layout/ProjectPage.tsx packages/store/slices/layoutSlice.ts packages/store/slices/chatSlice.ts`
- `pnpm --filter @leros/store typecheck`
- `pnpm --filter @leros/app-ui typecheck`