### PR TITLE
fix(auth): 修复登录态失效后请求无法正常响应

### DIFF
--- a/frontend/packages/app-ui/components/auth/AuthDialog.tsx
+++ b/frontend/packages/app-ui/components/auth/AuthDialog.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import {
+	AUTH_SESSION_EXPIRED_EVENT,
 	type AuthTokenResponse,
 	type AuthUser,
 	authApi,
+	getValidJwtToken,
 	useAuthStore,
 	useChatStore,
 	useLayoutStore,
@@ -60,7 +62,26 @@ export function AuthProvider({
 	const [mode, setMode] = useState<AuthMode>("login");
 	const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
 
-	useEffect(() => { setHydrated(true); }, []);
+	useEffect(() => {
+		setHydrated(true);
+	}, []);
+
+	useEffect(() => {
+		const handleExpiredSession = () => {
+			logoutAuth();
+			resetAuthScopedData();
+			resetLocalMessages();
+			setPendingAction(null);
+			setMode("login");
+			setDialogOpen(true);
+		};
+		window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, handleExpiredSession);
+		return () => window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, handleExpiredSession);
+	}, [logoutAuth, resetAuthScopedData, resetLocalMessages]);
+
+	useEffect(() => {
+		if (authUser) void getValidJwtToken();
+	}, [authUser]);
 
 	const openAuthDialog = useCallback((nextMode: AuthMode = "login") => {
 		setMode(nextMode);

--- a/frontend/packages/store/api/client.ts
+++ b/frontend/packages/store/api/client.ts
@@ -1,22 +1,27 @@
 import type { HttpClient } from "@leros/ui/lib/request";
 import { createHttpClient } from "@leros/ui/lib/request";
-import { readStoredJwtToken } from "../utils/authStorage";
+import { getValidJwtToken, readStoredAuthUser } from "../utils/authStorage";
 import { API_BASE_URL } from "./config";
 
 export const apiClient: HttpClient = createHttpClient(API_BASE_URL);
 
 // biome-ignore lint/correctness/useHookAtTopLevel: this is an HTTP client interceptor API, not a React hook.
-apiClient.useRequestInterceptor((config) => {
-	const token = readStoredJwtToken();
+apiClient.useRequestInterceptor(async (config) => {
+	const token = await getValidJwtToken();
 	if (!token) return config;
 
-	return {
-		...config,
-		headers: {
-			...headersToRecord(config.headers),
-			Authorization: `Bearer ${token}`,
-		},
-	};
+	return withAuthorization(config, token);
+});
+
+// biome-ignore lint/correctness/useHookAtTopLevel: this is an HTTP client interceptor API, not a React hook.
+apiClient.useResponseInterceptor(async (response, context) => {
+	if (response.status !== 401 || isAuthEndpoint(context.url) || !readStoredAuthUser()) {
+		return response;
+	}
+
+	const token = await getValidJwtToken(true);
+	if (!token) return response;
+	return fetch(context.url, withAuthorization(context.config, token));
 });
 
 function headersToRecord(headers: HeadersInit | undefined): Record<string, string> {
@@ -24,4 +29,18 @@ function headersToRecord(headers: HeadersInit | undefined): Record<string, strin
 	if (headers instanceof Headers) return Object.fromEntries(headers.entries());
 	if (Array.isArray(headers)) return Object.fromEntries(headers);
 	return headers;
+}
+
+function withAuthorization(config: RequestInit, token: string): RequestInit {
+	return {
+		...config,
+		headers: {
+			...headersToRecord(config.headers),
+			Authorization: `Bearer ${token}`,
+		},
+	};
+}
+
+function isAuthEndpoint(url: string): boolean {
+	return ["/LoginByEmail", "/RegisterByEmail", "/RefreshToken"].some((path) => url.endsWith(path));
 }

--- a/frontend/packages/store/api/fileApi.ts
+++ b/frontend/packages/store/api/fileApi.ts
@@ -1,4 +1,4 @@
-import { readStoredJwtToken } from "../utils/authStorage";
+import { authenticatedFetch } from "../utils/authStorage";
 import { API_BASE_URL } from "./config";
 
 export function getFileDownloadUrl(publicId: string): string {
@@ -9,11 +9,9 @@ export async function fetchFileDownload(
 	publicId: string,
 	options?: { signal?: AbortSignal },
 ): Promise<Response> {
-	const token = readStoredJwtToken();
-	const response = await fetch(getFileDownloadUrl(publicId), {
+	const response = await authenticatedFetch(getFileDownloadUrl(publicId), {
 		method: "GET",
 		signal: options?.signal,
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
 	});
 	if (!response.ok) {
 		throw new Error(`HTTP ${response.status}`);

--- a/frontend/packages/store/api/projectFileApi.ts
+++ b/frontend/packages/store/api/projectFileApi.ts
@@ -1,4 +1,4 @@
-import { readStoredJwtToken } from "../utils/authStorage";
+import { authenticatedFetch } from "../utils/authStorage";
 import { apiClient } from "./client";
 import { API_BASE_URL } from "./config";
 import type {
@@ -58,18 +58,14 @@ function assertBackendSuccess<T>(
 	return response;
 }
 
-async function uploadFile(
-	file: File,
-	token?: string | null,
-): Promise<BackendDataResponse<BackendUploadFilePayload>> {
+async function uploadFile(file: File): Promise<BackendDataResponse<BackendUploadFilePayload>> {
 	const formData = new FormData();
 	formData.append("file", file);
 	formData.append("purpose", "project");
 
-	const response = await fetch(`${API_BASE_URL}/files/upload`, {
+	const response = await authenticatedFetch(`${API_BASE_URL}/files/upload`, {
 		method: "POST",
 		body: formData,
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
 	});
 
 	if (!response.ok) {
@@ -79,17 +75,16 @@ async function uploadFile(
 	return (await response.json()) as BackendDataResponse<BackendUploadFilePayload>;
 }
 
-async function addFileToProject(
-	{ projectId, publicId }: AddProjectFileParams,
-	token?: string | null,
-): Promise<BackendDataResponse<null>> {
-	const response = await fetch(
+async function addFileToProject({
+	projectId,
+	publicId,
+}: AddProjectFileParams): Promise<BackendDataResponse<null>> {
+	const response = await authenticatedFetch(
 		`${API_BASE_URL}/projects/${encodeURIComponent(projectId)}/AddFile`,
 		{
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				...(token ? { Authorization: `Bearer ${token}` } : {}),
 			},
 			body: JSON.stringify({ public_id: publicId }),
 		},
@@ -115,15 +110,14 @@ export const projectFileApi = {
 		),
 
 	upload: async ({ projectId, file }: UploadProjectFileParams) => {
-		const token = readStoredJwtToken();
-		const uploadResponse = assertBackendSuccess(await uploadFile(file, token), "文件上传失败");
+		const uploadResponse = assertBackendSuccess(await uploadFile(file), "文件上传失败");
 		const uploaded = uploadResponse.data;
 		if (!uploaded?.public_id) {
 			throw new Error("上传接口未返回 public_id");
 		}
 
 		const addResponse = assertBackendSuccess(
-			await addFileToProject({ projectId, publicId: uploaded.public_id }, token),
+			await addFileToProject({ projectId, publicId: uploaded.public_id }),
 			"添加文件到项目失败",
 		);
 

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -87,4 +87,5 @@ export {
 	mergeProjectArtifacts,
 	messageArtifactToProjectArtifact,
 } from "./utils/artifacts";
+export { AUTH_SESSION_EXPIRED_EVENT, getValidJwtToken } from "./utils/authStorage";
 export { formatDate, formatFileSize, formatTime, formatTokenCount } from "./utils/format";

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -32,7 +32,7 @@ import type {
 	ToolCallStatus,
 } from "../types/chat";
 import { flattenActions } from "../utils";
-import { readStoredJwtToken } from "../utils/authStorage";
+import { getValidJwtToken } from "../utils/authStorage";
 import { formatFileSize } from "../utils/format";
 
 export type ChatState = {
@@ -879,17 +879,21 @@ export class ChatActionImpl {
 		this.#startSSE(sessionId, assistantMsg.id);
 	};
 
-	#startSSE = (sessionId: string, assistantMsgId: string) => {
+	#startSSE = async (sessionId: string, assistantMsgId: string) => {
 		if (this.#sseClient) {
 			this.#sseClient.close();
 			this.#sseClient = null;
 		}
 
 		const url = `${API_BASE_URL}/SessionEvents`;
-		const token = readStoredJwtToken();
+		const token = await getValidJwtToken();
+		if (!token) {
+			this.#finishStream();
+			return;
+		}
 		const client = new FetchSSEClient(url, {
 			method: "POST",
-			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			headers: { Authorization: `Bearer ${token}` },
 			body: { session_id: sessionId },
 			onMessage: (event) => {
 				try {
@@ -935,7 +939,7 @@ export class ChatActionImpl {
 		});
 
 		this.#set({ streamCancelRef: () => client.close() });
-		client.connect();
+		void client.connect();
 		this.#sseClient = client;
 	};
 

--- a/frontend/packages/store/utils/authStorage.ts
+++ b/frontend/packages/store/utils/authStorage.ts
@@ -1,3 +1,5 @@
+import { API_BASE_URL } from "../api/config";
+
 export type StoredAuthUser = {
 	name: string;
 	email: string;
@@ -5,9 +7,14 @@ export type StoredAuthUser = {
 	refreshToken?: string;
 	expiredAt?: number;
 	uin?: number;
+	apiBaseUrl?: string;
 };
 
 export const AUTH_STORAGE_KEY = "leros-auth-user";
+export const AUTH_SESSION_EXPIRED_EVENT = "leros-auth-session-expired";
+
+const TOKEN_REFRESH_BUFFER_SECONDS = 60;
+let refreshPromise: Promise<string | null> | null = null;
 
 export function readStoredAuthUser(): StoredAuthUser | null {
 	if (typeof window === "undefined") return null;
@@ -15,7 +22,12 @@ export function readStoredAuthUser(): StoredAuthUser | null {
 	try {
 		const stored = window.localStorage.getItem(AUTH_STORAGE_KEY);
 		if (!stored) return null;
-		return JSON.parse(stored) as StoredAuthUser;
+		const user = JSON.parse(stored) as StoredAuthUser;
+		if (user.apiBaseUrl && user.apiBaseUrl !== API_BASE_URL) {
+			clearStoredAuthUser();
+			return null;
+		}
+		return user;
 	} catch (err) {
 		console.error("read auth user error:", err);
 		return null;
@@ -26,7 +38,10 @@ export function writeStoredAuthUser(user: StoredAuthUser) {
 	if (typeof window === "undefined") return;
 
 	try {
-		window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+		window.localStorage.setItem(
+			AUTH_STORAGE_KEY,
+			JSON.stringify({ ...user, apiBaseUrl: API_BASE_URL }),
+		);
 	} catch (err) {
 		console.error("save auth user error:", err);
 	}
@@ -45,4 +60,109 @@ export function clearStoredAuthUser() {
 export function readStoredJwtToken(): string | null {
 	const user = readStoredAuthUser();
 	return user?.jwtToken ?? null;
+}
+
+export async function getValidJwtToken(forceRefresh = false): Promise<string | null> {
+	const user = readStoredAuthUser();
+	if (!user?.jwtToken) return null;
+
+	const now = Math.floor(Date.now() / 1000);
+	if (!forceRefresh && (!user.expiredAt || user.expiredAt > now + TOKEN_REFRESH_BUFFER_SECONDS)) {
+		return user.jwtToken;
+	}
+	if (!user.refreshToken) {
+		expireStoredAuthSession();
+		return null;
+	}
+
+	if (!refreshPromise) {
+		refreshPromise = refreshStoredAuthToken(user).finally(() => {
+			refreshPromise = null;
+		});
+	}
+	return refreshPromise;
+}
+
+export async function authenticatedFetch(
+	input: RequestInfo | URL,
+	init: RequestInit = {},
+): Promise<Response> {
+	const token = await getValidJwtToken();
+	const response = await fetch(input, withAuthorization(init, token));
+	if (response.status !== 401 || !token) return response;
+
+	const refreshedToken = await getValidJwtToken(true);
+	if (!refreshedToken) return response;
+	return fetch(input, withAuthorization(init, refreshedToken));
+}
+
+async function refreshStoredAuthToken(user: StoredAuthUser): Promise<string | null> {
+	try {
+		const response = await fetch(`${API_BASE_URL}/RefreshToken`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ refresh_token: user.refreshToken }),
+		});
+		if (!response.ok) {
+			if (response.status === 400 || response.status === 401) {
+				expireStoredAuthSession();
+			}
+			return null;
+		}
+
+		const payload = (await response.json()) as {
+			data?: {
+				jwt_token?: string;
+				refresh_token?: string;
+				expired_at?: number;
+				uin?: number;
+				user_info?: { name?: string; email?: string };
+			};
+		};
+		const token = payload.data;
+		if (!token?.jwt_token || !token.refresh_token) {
+			expireStoredAuthSession();
+			return null;
+		}
+
+		writeStoredAuthUser({
+			...user,
+			name: token.user_info?.name || user.name,
+			email: token.user_info?.email || user.email,
+			jwtToken: token.jwt_token,
+			refreshToken: token.refresh_token,
+			expiredAt: token.expired_at,
+			uin: token.uin ?? user.uin,
+		});
+		return token.jwt_token;
+	} catch (err) {
+		console.error("refresh auth token error:", err);
+		return null;
+	}
+}
+
+function expireStoredAuthSession() {
+	const hadSession = Boolean(readStoredAuthUser());
+	clearStoredAuthUser();
+	if (hadSession && typeof window !== "undefined") {
+		window.dispatchEvent(new Event(AUTH_SESSION_EXPIRED_EVENT));
+	}
+}
+
+function withAuthorization(init: RequestInit, token: string | null): RequestInit {
+	if (!token) return init;
+	return {
+		...init,
+		headers: {
+			...headersToRecord(init.headers),
+			Authorization: `Bearer ${token}`,
+		},
+	};
+}
+
+function headersToRecord(headers: HeadersInit | undefined): Record<string, string> {
+	if (!headers) return {};
+	if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+	if (Array.isArray(headers)) return Object.fromEntries(headers);
+	return headers;
 }

--- a/frontend/packages/ui/lib/request.ts
+++ b/frontend/packages/ui/lib/request.ts
@@ -2,9 +2,12 @@ class HttpClient {
 	private baseURL: string;
 	private defaultHeaders: Record<string, string>;
 	private interceptors: {
-		request: Array<(config: RequestInit) => RequestInit>;
+		request: Array<(config: RequestInit) => RequestInit | Promise<RequestInit>>;
 		response: Array<
-			(response: globalThis.Response) => globalThis.Response | Promise<globalThis.Response>
+			(
+				response: globalThis.Response,
+				context: { url: string; config: RequestInit },
+			) => globalThis.Response | Promise<globalThis.Response>
 		>;
 	};
 
@@ -20,7 +23,9 @@ class HttpClient {
 		};
 	}
 
-	useRequestInterceptor(interceptor: (config: RequestInit) => RequestInit): () => void {
+	useRequestInterceptor(
+		interceptor: (config: RequestInit) => RequestInit | Promise<RequestInit>,
+	): () => void {
 		this.interceptors.request.push(interceptor);
 		return () => {
 			const index = this.interceptors.request.indexOf(interceptor);
@@ -31,6 +36,7 @@ class HttpClient {
 	useResponseInterceptor(
 		interceptor: (
 			response: globalThis.Response,
+			context: { url: string; config: RequestInit },
 		) => globalThis.Response | Promise<globalThis.Response>,
 	): () => void {
 		this.interceptors.response.push(interceptor);
@@ -40,7 +46,10 @@ class HttpClient {
 		};
 	}
 
-	private buildURL(url: string, params?: Record<string, string | number | boolean | string[]>): string {
+	private buildURL(
+		url: string,
+		params?: Record<string, string | number | boolean | string[]>,
+	): string {
 		const fullURL = this.baseURL ? `${this.baseURL}${url}` : url;
 		if (!params) return fullURL;
 
@@ -48,7 +57,9 @@ class HttpClient {
 		Object.keys(params).forEach((key) => {
 			const value = params[key];
 			if (Array.isArray(value)) {
-				value.forEach((v) => urlObj.searchParams.append(key, v));
+				value.forEach((v) => {
+					urlObj.searchParams.append(key, v);
+				});
 			} else {
 				urlObj.searchParams.append(key, String(value));
 			}
@@ -94,7 +105,7 @@ class HttpClient {
 		};
 
 		for (const interceptor of this.interceptors.request) {
-			config = interceptor(config);
+			config = await interceptor(config);
 		}
 
 		const fullURL = this.buildURL(url, params);
@@ -107,7 +118,7 @@ class HttpClient {
 				let response = await this.requestWithTimeout(fullURL, config, timeout);
 
 				for (const interceptor of this.interceptors.response) {
-					response = await interceptor(response);
+					response = await interceptor(response, { url: fullURL, config });
 				}
 
 				if (!response.ok) {


### PR DESCRIPTION
- 增加访问令牌过期检查与自动刷新机制
- 支持并发请求共享刷新任务，避免重复刷新
- 普通 API 返回 401 后自动刷新并重试
- 登录失效后清理账号数据并弹出登录窗口
- 修复问答 SSE、文件上传及下载的鉴权刷新
- 保持首次匿名访问时不主动弹出登录窗口
- API 环境变化时自动清理旧登录态