### PR TITLE
feat(frontend): 支持 Excel 和 CSV 文件在线预览

### DIFF
--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -22,8 +22,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { StructuredComposer, type StructuredComposerHandle } from "./StructuredComposer";
 
-// .csv 暂不支持预览，上传后体验异常，待预览能力就绪后再开放
-export const PROJECT_ATTACHMENT_ACCEPT = "image/*,.pdf,.txt,.md,.json"; // ,.csv
+export const PROJECT_ATTACHMENT_ACCEPT = "image/*,.pdf,.txt,.md,.json,.xlsx,.xls,.csv";
 
 export function ChatInput({ variant = "default" }: { variant?: "default" | "project" }) {
 	const {

--- a/frontend/packages/app-ui/components/layout/ArtifactPreviewDialog.tsx
+++ b/frontend/packages/app-ui/components/layout/ArtifactPreviewDialog.tsx
@@ -14,8 +14,9 @@ import { cn } from "@leros/ui/lib/utils";
 import { Download, FileText, ImageIcon, LoaderCircle, Table2, X } from "lucide-react";
 import { type ComponentType, type CSSProperties, useEffect, useMemo, useState } from "react";
 import { MarkdownRenderer } from "../common/MarkdownRenderer";
+import { SpreadsheetPreview } from "./SpreadsheetPreview";
 
-type PreviewKind = "docx" | "markdown" | "text" | "image" | "pdf" | "unsupported";
+type PreviewKind = "docx" | "spreadsheet" | "markdown" | "text" | "image" | "pdf" | "unsupported";
 
 export type ArtifactPreviewItem = {
 	id: string;
@@ -109,7 +110,7 @@ export function ArtifactPreviewDialog({
 					return;
 				}
 
-				if (previewKind === "docx") {
+				if (previewKind === "docx" || previewKind === "spreadsheet") {
 					const buffer = await response.arrayBuffer();
 					if (!cancelled) setPreview({ status: "ready", buffer });
 					return;
@@ -243,6 +244,10 @@ function ArtifactPreviewBody({
 
 	if (previewKind === "docx" && preview.buffer) {
 		return <DocxPreview artifact={artifact} buffer={preview.buffer} />;
+	}
+
+	if (previewKind === "spreadsheet" && preview.buffer) {
+		return <SpreadsheetPreview buffer={preview.buffer} fileName={artifact.name} />;
 	}
 
 	if (previewKind === "markdown") {
@@ -379,6 +384,16 @@ function detectPreviewKind(artifact: ArtifactPreviewItem | null): PreviewKind {
 	) {
 		return "docx";
 	}
+	if (
+		mimeType.includes("spreadsheet") ||
+		mimeType.includes("excel") ||
+		mimeType === "text/csv" ||
+		name.endsWith(".xlsx") ||
+		name.endsWith(".xls") ||
+		name.endsWith(".csv")
+	) {
+		return "spreadsheet";
+	}
 	if (mimeType.includes("markdown") || name.endsWith(".md") || name.endsWith(".markdown")) {
 		return "markdown";
 	}
@@ -392,7 +407,6 @@ function detectPreviewKind(artifact: ArtifactPreviewItem | null): PreviewKind {
 		mimeType.startsWith("text/") ||
 		name.endsWith(".txt") ||
 		name.endsWith(".json") ||
-		name.endsWith(".csv") ||
 		name.endsWith(".yaml") ||
 		name.endsWith(".yml") ||
 		name.endsWith(".log")

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -41,6 +41,7 @@ import {
 	type ProjectFileNode,
 	sortProjectFilesByUploadedTimeDesc,
 } from "./project-files";
+import { SpreadsheetPreview } from "./SpreadsheetPreview";
 import { TaskDeleteDialog } from "./TaskDeleteDialog";
 
 const projectTabs = [
@@ -60,6 +61,7 @@ type FilePreviewState =
 	| { status: "loading" }
 	| { status: "error"; message: string }
 	| { status: "text"; content: string }
+	| { status: "spreadsheet"; buffer: ArrayBuffer }
 	| { status: "blob"; url: string; mimeType: string };
 
 export function ProjectPage({
@@ -638,6 +640,14 @@ function ProjectFiles({
 					currentFile.mimeType ??
 					"application/octet-stream";
 
+				if (isSpreadsheetPreviewable(currentFile.path, mimeType)) {
+					const buffer = await response.arrayBuffer();
+					if (!cancelled) {
+						setPreviewState({ status: "spreadsheet", buffer });
+					}
+					return;
+				}
+
 				if (isTextPreviewable(currentFile.path, mimeType)) {
 					const content = await response.text();
 					if (!cancelled) {
@@ -981,6 +991,14 @@ function ProjectFilePreviewBody({
 		);
 	}
 
+	if (previewState.status === "spreadsheet") {
+		return (
+			<div className="h-[calc(100vh-150px)] min-h-[520px] overflow-hidden rounded-xl bg-white shadow-sm">
+				<SpreadsheetPreview buffer={previewState.buffer} fileName={file.name} />
+			</div>
+		);
+	}
+
 	if (previewState.mimeType.startsWith("image/")) {
 		return (
 			<div className="flex min-h-[320px] items-center justify-center rounded-xl bg-white p-4 shadow-sm">
@@ -1045,6 +1063,18 @@ function isTextPreviewable(path: string, mimeType: string): boolean {
 		".sh",
 		".sql",
 	].some((suffix) => normalizedPath.endsWith(suffix));
+}
+
+function isSpreadsheetPreviewable(path: string, mimeType: string): boolean {
+	const normalizedPath = path.toLowerCase();
+	const normalizedMimeType = mimeType.toLowerCase();
+
+	return (
+		normalizedMimeType.includes("spreadsheet") ||
+		normalizedMimeType.includes("excel") ||
+		normalizedMimeType === "text/csv" ||
+		[".xlsx", ".xls", ".csv"].some((suffix) => normalizedPath.endsWith(suffix))
+	);
 }
 
 function formatBytes(size: number): string {

--- a/frontend/packages/app-ui/components/layout/SpreadsheetPreview.tsx
+++ b/frontend/packages/app-ui/components/layout/SpreadsheetPreview.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { AlertCircle, Table2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { read, utils, type WorkBook } from "xlsx";
+
+const MAX_PREVIEW_ROWS = 200;
+const MAX_PREVIEW_COLUMNS = 50;
+
+type SheetPreview = {
+	name: string;
+	rows: string[][];
+	totalRows: number;
+	totalColumns: number;
+};
+
+export function SpreadsheetPreview({
+	buffer,
+	fileName,
+}: {
+	buffer: ArrayBuffer;
+	fileName: string;
+}) {
+	const result = useMemo(() => parseWorkbook(buffer), [buffer]);
+	const [selectedSheet, setSelectedSheet] = useState(0);
+
+	if (result.error) {
+		return (
+			<div className="flex h-full min-h-[320px] items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
+				<div>
+					<AlertCircle className="mx-auto mb-3 size-8 text-[var(--leros-danger)]" />
+					<p>无法解析表格文件</p>
+					<p className="mt-1 text-xs">{result.error}</p>
+				</div>
+			</div>
+		);
+	}
+
+	const activeSheetIndex = result.sheets[selectedSheet] ? selectedSheet : 0;
+	const sheet = result.sheets[activeSheetIndex];
+	if (!sheet) {
+		return (
+			<div className="flex h-full min-h-[320px] items-center justify-center text-sm text-[var(--leros-text-muted)]">
+				文件中没有可预览的工作表
+			</div>
+		);
+	}
+
+	const truncated = sheet.totalRows > MAX_PREVIEW_ROWS || sheet.totalColumns > MAX_PREVIEW_COLUMNS;
+	const visibleColumns = Math.min(sheet.totalColumns, MAX_PREVIEW_COLUMNS);
+
+	return (
+		<div className="flex h-full min-h-[320px] flex-col overflow-hidden bg-white">
+			<div className="flex shrink-0 items-center gap-2 border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-3 py-2">
+				<Table2 className="size-4 shrink-0 text-emerald-600" />
+				<div className="min-w-0 flex-1 truncate text-xs text-[var(--leros-text-muted)]">
+					{fileName} · {sheet.totalRows.toLocaleString()} 行 × {sheet.totalColumns.toLocaleString()}{" "}
+					列
+				</div>
+				{truncated && (
+					<div className="shrink-0 text-xs text-amber-700">
+						仅展示前 {MAX_PREVIEW_ROWS} 行、{MAX_PREVIEW_COLUMNS} 列
+					</div>
+				)}
+			</div>
+
+			<div className="min-h-0 flex-1 overflow-auto">
+				<table className="border-separate border-spacing-0 text-xs text-[var(--leros-text)]">
+					<thead>
+						<tr>
+							<th className="sticky left-0 top-0 z-30 min-w-12 border-b border-r border-[var(--leros-control-border)] bg-slate-200" />
+							{Array.from({ length: visibleColumns }, (_, columnIndex) => (
+								<th
+									key={columnIndex}
+									className="sticky top-0 z-10 min-w-28 border-b border-r border-[var(--leros-control-border)] bg-slate-100 px-2.5 py-1.5 text-center font-medium text-slate-500"
+								>
+									{columnName(columnIndex)}
+								</th>
+							))}
+						</tr>
+					</thead>
+					<tbody>
+						{sheet.rows.map((row, rowIndex) => (
+							<tr key={`${sheet.name}-${rowIndex}`}>
+								<th className="sticky left-0 z-20 min-w-12 border-b border-r border-[var(--leros-control-border)] bg-slate-100 px-2 py-1.5 text-center font-normal text-slate-500">
+									{rowIndex + 1}
+								</th>
+								{row.map((cell, columnIndex) => (
+									<td
+										key={`${sheet.name}-${rowIndex}-${columnIndex}`}
+										title={cell}
+										className="max-w-64 min-w-28 truncate whitespace-nowrap border-b border-r border-[var(--leros-control-border)] bg-white px-2.5 py-1.5"
+									>
+										{cell}
+									</td>
+								))}
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+
+			{result.sheets.length > 1 && (
+				<div className="flex shrink-0 gap-1 overflow-x-auto border-t border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-2 py-1.5">
+					{result.sheets.map((item, index) => (
+						<button
+							key={item.name}
+							type="button"
+							onClick={() => setSelectedSheet(index)}
+							className={`shrink-0 rounded-md px-3 py-1.5 text-xs transition-colors ${
+								index === activeSheetIndex
+									? "bg-white font-medium text-emerald-700 shadow-sm ring-1 ring-[var(--leros-control-border)]"
+									: "text-[var(--leros-text-muted)] hover:bg-white/70"
+							}`}
+						>
+							{item.name}
+						</button>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function columnName(columnIndex: number): string {
+	let value = columnIndex + 1;
+	let name = "";
+	while (value > 0) {
+		value -= 1;
+		name = String.fromCharCode(65 + (value % 26)) + name;
+		value = Math.floor(value / 26);
+	}
+	return name;
+}
+
+function parseWorkbook(buffer: ArrayBuffer):
+	| { sheets: SheetPreview[]; error?: undefined }
+	| {
+			sheets: [];
+			error: string;
+	  } {
+	try {
+		const workbook = read(buffer, { type: "array", cellDates: true });
+		return { sheets: workbook.SheetNames.map((name) => parseSheet(workbook, name)) };
+	} catch (err) {
+		return {
+			sheets: [],
+			error: err instanceof Error ? err.message : "表格格式不正确或文件已损坏",
+		};
+	}
+}
+
+function parseSheet(workbook: WorkBook, name: string): SheetPreview {
+	const worksheet = workbook.Sheets[name];
+	if (!worksheet?.["!ref"]) {
+		return { name, rows: [], totalRows: 0, totalColumns: 0 };
+	}
+
+	const range = utils.decode_range(worksheet["!ref"]);
+	const totalRows = range.e.r - range.s.r + 1;
+	const totalColumns = range.e.c - range.s.c + 1;
+	const rows = utils.sheet_to_json<string[]>(worksheet, {
+		header: 1,
+		raw: false,
+		defval: "",
+		range: {
+			s: range.s,
+			e: {
+				r: Math.min(range.e.r, range.s.r + MAX_PREVIEW_ROWS - 1),
+				c: Math.min(range.e.c, range.s.c + MAX_PREVIEW_COLUMNS - 1),
+			},
+		},
+	});
+
+	return {
+		name,
+		rows: rows.map((row) => row.map((cell) => String(cell))),
+		totalRows,
+		totalColumns,
+	};
+}

--- a/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
@@ -194,7 +194,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 					<div className="max-w-3xl mx-auto">
 						<div className="mb-6 flex flex-col items-start gap-4 text-left">
 							<h2 className="text-4xl font-bold tracking-tight text-[var(--leros-text-strong)] md:text-5xl">
-								Hi, <span className="text-[var(--leros-primary)]">Mia</span>
+								Hi, <span className="text-[var(--leros-primary)]">Leros</span>
 							</h2>
 							<p className="text-lg font-medium uppercase tracking-widest text-[var(--leros-text-subtle)]">
 								以 Leros 智能赋能您的工作流。

--- a/frontend/packages/app-ui/package.json
+++ b/frontend/packages/app-ui/package.json
@@ -19,7 +19,8 @@
 		"react-markdown": "^10.1.0",
 		"rehype-katex": "^7.0.1",
 		"remark-gfm": "^4.0.1",
-		"remark-math": "^6.0.0"
+		"remark-math": "^6.0.0",
+		"xlsx": "^0.18.5"
 	},
 	"peerDependencies": {
 		"react": "catalog:",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
     devDependencies:
       '@leros/tsconfig':
         specifier: workspace:*
@@ -1987,6 +1990,10 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2168,6 +2175,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2240,6 +2251,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2324,6 +2339,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -2779,6 +2799,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -4228,6 +4252,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4683,6 +4711,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -4693,6 +4729,11 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
@@ -6208,6 +6249,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  adler-32@1.3.1: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -6433,6 +6476,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -6496,6 +6544,8 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6552,6 +6602,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  crc-32@1.2.2: {}
 
   cross-dirname@0.1.0:
     optional: true
@@ -7082,6 +7134,8 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
+
+  frac@1.1.2: {}
 
   fresh@2.0.0: {}
 
@@ -8910,6 +8964,10 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stackback@0.0.2: {}
 
   stat-mode@1.0.0: {}
@@ -9328,6 +9386,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -9340,6 +9402,16 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-js@1.6.11:
     dependencies:


### PR DESCRIPTION
- 支持 xlsx、xls、csv 文件解析与表格预览
- 支持多工作表切换和固定行列标头
- 限制预览前 200 行、50 列，避免大文件影响页面性能
- 在项目文件和产物预览中接入表格预览
- 开放 Excel 和 CSV 文件上传