### PR TITLE
fix(frontend): 修复会话流式结束后 AI 回复重复渲染

### DIFF
--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -989,11 +989,13 @@ export class ChatActionImpl {
 			const items = res.data.data?.items ?? [];
 			const persistedMessages = items.map(mapBackendMessage);
 			const state = this.#get();
+			// 仅在流式生成进行中才合并本地 optimistic 消息；结束后应完全信任后端持久化结果，
+			// 否则 msg-assistant-* 占位消息会与已落库的 assistant 同时保留，造成重复渲染。
 			const shouldPreserveLocalMessages =
-				state.activeSessionId === sessionId ||
-				(state.isGenerating &&
-					state.streamingMessageId !== null &&
-					state.messagesMap[state.streamingMessageId]?.conversationId === sessionId);
+				state.isGenerating &&
+				state.activeSessionId === sessionId &&
+				state.streamingMessageId !== null &&
+				state.messagesMap[state.streamingMessageId]?.conversationId === sessionId;
 			const localSessionMessages = shouldPreserveLocalMessages
 				? state.messageIds
 						.map((id) => state.messagesMap[id])


### PR DESCRIPTION
## Summary

- 修复项目/任务会话中 AI 回复完成后出现两条相同 assistant 消息的问题
- 调整 `loadConversationMessages` 中 `shouldPreserveLocalMessages` 的判断：仅在流式生成进行中才合并本地 optimistic 占位消息
- 流式结束后直接使用 `GetSessionMessages` 返回的持久化结果，避免 `msg-assistant-*` 与后端落库消息并存

## 根因

`run.completed` 会先调用 `#finishStream()` 将 `isGenerating` 设为 `false`，随后回拉历史消息。原逻辑在 `activeSessionId === sessionId` 时仍会保留 optimistic 占位消息并与持久化 assistant 合并，因 message id 不同导致 dedupe 失败，出现重复渲染。刷新页面后只加载持久化消息，因此显示正常。

## Test plan

- [ ] 在项目会话页发送消息，等待 AI 流式回复完成，确认只显示一条 assistant 消息
- [ ] 刷新页面后消息列表仍正常，无重复
- [ ] 流式生成过程中消息仍能正常增量更新
- [ ] 普通会话（非项目）发送消息行为不受影响

<!-- 如有对应 Issue，请补充：Fixes #xxx -->