### PR TITLE
fix(desktop): 完善 macOS DMG 签名公证配置

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -101,6 +101,26 @@ jobs:
         working-directory: frontend
         run: pnpm --filter @leros/desktop typecheck
 
+      - name: Prepare macOS signing credentials
+        if: startsWith(matrix.name, 'mac-')
+        shell: bash
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          for variable in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER CSC_LINK CSC_KEY_PASSWORD; do
+            if [ -z "${!variable}" ]; then
+              echo "::error::Required macOS signing secret is missing: ${variable}"
+              exit 1
+            fi
+          done
+
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/AuthKey.p8"
+
       - name: Build desktop package
         working-directory: frontend
         shell: bash
@@ -123,6 +143,40 @@ jobs:
           ELECTRON_CACHE: ${{ runner.temp }}/electron-cache
           electron_config_cache: ${{ runner.temp }}/electron-cache
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/electron-builder-cache
+          CSC_LINK: ${{ startsWith(matrix.name, 'mac-') && secrets.MACOS_CERTIFICATE_P12_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ startsWith(matrix.name, 'mac-') && secrets.MACOS_CERTIFICATE_PASSWORD || '' }}
+          APPLE_API_KEY: ${{ startsWith(matrix.name, 'mac-') && format('{0}/AuthKey.p8', runner.temp) || '' }}
+          APPLE_API_KEY_ID: ${{ startsWith(matrix.name, 'mac-') && secrets.APPLE_API_KEY_ID || '' }}
+          APPLE_API_ISSUER: ${{ startsWith(matrix.name, 'mac-') && secrets.APPLE_API_ISSUER || '' }}
+
+      - name: Verify macOS signature and notarization
+        if: startsWith(matrix.name, 'mac-')
+        working-directory: frontend/apps/desktop
+        shell: bash
+        run: |
+          dmg_path="$(find dist -maxdepth 1 -name '*.dmg' -print -quit)"
+          if [ -z "$dmg_path" ]; then
+            echo "::error::No DMG package found"
+            exit 1
+          fi
+
+          mount_dir="$(mktemp -d)"
+          cleanup() {
+            hdiutil detach "$mount_dir" -quiet || true
+            rmdir "$mount_dir" || true
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_dir"
+          app_path="$(find "$mount_dir" -maxdepth 1 -name '*.app' -print -quit)"
+          if [ -z "$app_path" ]; then
+            echo "::error::No application bundle found in DMG"
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          spctl --assess --type execute --verbose=2 "$app_path"
+          xcrun stapler validate "$app_path"
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4

--- a/frontend/apps/desktop/electron-builder.yml
+++ b/frontend/apps/desktop/electron-builder.yml
@@ -17,6 +17,8 @@ asarUnpack:
   - resources/**
 mac:
   category: public.app-category.developer-tools
+  hardenedRuntime: true
+  notarize: true
   target:
     - target: dmg
   artifactName: ${productName}-${version}-mac-${arch}.${ext}


### PR DESCRIPTION
- 为 electron-builder 启用 hardened runtime 与 notarize
- 在 desktop-release 工作流中注入 macOS 签名和 Apple 公证凭据
- 构建后验证 DMG 内应用的 codesign、Gatekeeper 与 stapler 状态