### PR TITLE
feat(chat): 完善 AI 消息 footer 的单条 model/tokens/latency 展示

### DIFF
--- a/backend/internal/runnable/session_completed.go
+++ b/backend/internal/runnable/session_completed.go
@@ -258,36 +258,102 @@ func messageMetadataFromRunCompleted(completed *events.RunCompletedPayload) *typ
 	if completed == nil {
 		return nil
 	}
-	src := completed.Metadata
-	if src == nil {
-		return nil
-	}
-
-	data, err := json.Marshal(src)
-	if err != nil {
-		return nil
-	}
 
 	msgMetadata := &types.ObjectMetadata{}
-	if err := json.Unmarshal(data, msgMetadata); err != nil {
-		return nil
-	}
+	extra := map[string]any{}
 
-	var flat map[string]any
-	if err := json.Unmarshal(data, &flat); err != nil {
-		return nil
-	}
-
-	knownKeys := map[string]bool{"tags": true, "type": true, "bucket": true, "key": true}
-	extra := make(map[string]any, len(flat))
-	for k, v := range flat {
-		if knownKeys[k] {
-			continue
+	if completed.Metadata != nil {
+		data, err := json.Marshal(completed.Metadata)
+		if err != nil {
+			return nil
 		}
-		extra[k] = v
+		if err := json.Unmarshal(data, msgMetadata); err != nil {
+			return nil
+		}
+
+		var flat map[string]any
+		if err := json.Unmarshal(data, &flat); err != nil {
+			return nil
+		}
+
+		knownKeys := map[string]bool{"tags": true, "type": true, "bucket": true, "key": true}
+		for k, v := range flat {
+			if knownKeys[k] {
+				continue
+			}
+			extra[k] = v
+		}
 	}
+
+	// 写入前端消息 footer 使用的标准展示字段（model / tokens / latency）。
+	enrichMessageDisplayMetadata(extra, completed)
 	if len(extra) > 0 {
 		msgMetadata.Extra = extra
 	}
+
+	if isEmptyObjectMetadata(msgMetadata) {
+		return nil
+	}
 	return msgMetadata
+}
+
+// enrichMessageDisplayMetadata 将单次 run 的模型、token 与耗时写入 metadata.extra，供前端按消息展示。
+func enrichMessageDisplayMetadata(extra map[string]any, completed *events.RunCompletedPayload) {
+	if extra == nil || completed == nil {
+		return
+	}
+	if model := messageDisplayModel(extra, completed.Metadata); model != "" {
+		extra["model"] = model
+	}
+	if completed.Usage != nil && completed.Usage.TotalTokens > 0 {
+		extra["tokens"] = completed.Usage.TotalTokens
+	}
+	if latencyMS := runCompletedLatencyMS(completed); latencyMS > 0 {
+		extra["latency"] = latencyMS
+	}
+}
+
+func messageDisplayModel(extra map[string]any, src map[string]any) string {
+	if model := metadataStringValue(extra["model"]); model != "" {
+		return model
+	}
+	if model := metadataStringValue(extra["model_name"]); model != "" {
+		return model
+	}
+	if src == nil {
+		return ""
+	}
+	if model := metadataStringValue(src["model"]); model != "" {
+		return model
+	}
+	return metadataStringValue(src["model_name"])
+}
+
+func runCompletedLatencyMS(completed *events.RunCompletedPayload) int64 {
+	if completed == nil || completed.StartedAt.IsZero() || completed.CompletedAt.IsZero() {
+		return 0
+	}
+	if completed.CompletedAt.Before(completed.StartedAt) {
+		return 0
+	}
+	return completed.CompletedAt.Sub(completed.StartedAt).Milliseconds()
+}
+
+func metadataStringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return ""
+	}
+}
+
+func isEmptyObjectMetadata(metadata *types.ObjectMetadata) bool {
+	if metadata == nil {
+		return true
+	}
+	if len(metadata.Tags) > 0 || metadata.Type != "" || metadata.Bucket != "" || metadata.Key != "" {
+		return false
+	}
+	return len(metadata.Extra) == 0
 }

--- a/backend/internal/runnable/session_completed_test.go
+++ b/backend/internal/runnable/session_completed_test.go
@@ -307,6 +307,60 @@ func TestHandleSessionCompletedMessageUsesFailedRunCompletedPayload(t *testing.T
 	}
 }
 
+func TestMessageMetadataFromRunCompletedEnrichesDisplayFields(t *testing.T) {
+	startedAt := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(1500 * time.Millisecond)
+
+	metadata := messageMetadataFromRunCompleted(&events.RunCompletedPayload{
+		Metadata: map[string]any{
+			"model_name":         "gpt-4o",
+			"run_started_at_ms":  startedAt.UnixMilli(),
+			"runtime":            "external_cli",
+		},
+		Usage: &events.UsagePayload{
+			InputTokens:  100,
+			OutputTokens: 20,
+			TotalTokens:  120,
+		},
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+	})
+	if metadata == nil || metadata.Extra == nil {
+		t.Fatal("expected metadata extra to be populated")
+	}
+	if metadata.Extra["model"] != "gpt-4o" {
+		t.Fatalf("expected model gpt-4o, got %#v", metadata.Extra["model"])
+	}
+	if metadata.Extra["tokens"] != 120 {
+		t.Fatalf("expected tokens 120, got %#v", metadata.Extra["tokens"])
+	}
+	if metadata.Extra["latency"] != int64(1500) {
+		t.Fatalf("expected latency 1500, got %#v", metadata.Extra["latency"])
+	}
+}
+
+func TestMessageMetadataFromRunCompletedWithoutRuntimeMetadata(t *testing.T) {
+	startedAt := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(800 * time.Millisecond)
+
+	metadata := messageMetadataFromRunCompleted(&events.RunCompletedPayload{
+		Usage: &events.UsagePayload{
+			TotalTokens: 42,
+		},
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+	})
+	if metadata == nil || metadata.Extra == nil {
+		t.Fatal("expected metadata extra to be populated from usage and timing")
+	}
+	if metadata.Extra["tokens"] != 42 {
+		t.Fatalf("expected tokens 42, got %#v", metadata.Extra["tokens"])
+	}
+	if metadata.Extra["latency"] != int64(800) {
+		t.Fatalf("expected latency 800, got %#v", metadata.Extra["latency"])
+	}
+}
+
 type recordingSessionService struct {
 	completeReq *contract.CompleteSessionMessageRequest
 	failedReq   *contract.FailedSessionMessageRequest

--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -2,6 +2,7 @@
 
 import {
 	formatTime,
+	getAssistantMessageMetrics,
 	mapBackendArtifactToProjectArtifact,
 	mergeProjectArtifacts,
 	messageArtifactToProjectArtifact,
@@ -62,6 +63,12 @@ export function AIMessageBubble({
 	const hasThinking = (message.thinking ?? "").trim().length > 0;
 	const hasToolCalls = message.toolCalls && message.toolCalls.length > 0;
 	const hasArtifacts = message.artifacts && message.artifacts.length > 0;
+	const metrics = getAssistantMessageMetrics(message);
+	const metricSegments = [
+		metrics?.model,
+		metrics?.tokens !== undefined ? `${metrics.tokens} tokens` : undefined,
+		metrics?.latency !== undefined ? `${metrics.latency}ms` : undefined,
+	].filter((segment): segment is string => Boolean(segment));
 
 	return (
 		<div data-slot="ai-message" className="group flex items-start gap-3">
@@ -119,14 +126,8 @@ export function AIMessageBubble({
 
 				{!isStreaming && (
 					<div className="mt-2 flex items-center gap-3">
-						{message.metadata && (
-							<div className="flex items-center gap-1.5 text-xs text-slate-400">
-								<span>{message.metadata.model}</span>
-								<span>·</span>
-								<span>{message.metadata.tokens} tokens</span>
-								<span>·</span>
-								<span>{message.metadata.latency}ms</span>
-							</div>
+						{metricSegments.length > 0 && (
+							<div className="text-xs text-slate-400">{metricSegments.join(" · ")}</div>
 						)}
 						<div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
 							<CopyButton text={content} />

--- a/frontend/packages/store/api/types.ts
+++ b/frontend/packages/store/api/types.ts
@@ -241,6 +241,8 @@ export type BackendSessionEventPayload = {
 	output_tokens?: number;
 	total_tokens?: number;
 	model?: string;
+	started_at?: string;
+	completed_at?: string;
 };
 
 export type BackendSessionEventPayloadLike = BackendSessionEventPayload | BackendRuntimeTodoItem[];

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -89,3 +89,8 @@ export {
 } from "./utils/artifacts";
 export { AUTH_SESSION_EXPIRED_EVENT, getValidJwtToken } from "./utils/authStorage";
 export { formatDate, formatFileSize, formatTime, formatTokenCount } from "./utils/format";
+export {
+	buildMessageMetadata,
+	getAssistantMessageMetrics,
+	latencyFromRunCompletedTimes,
+} from "./utils/messageMetrics";

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -34,6 +34,11 @@ import type {
 import { flattenActions } from "../utils";
 import { getValidJwtToken } from "../utils/authStorage";
 import { formatFileSize } from "../utils/format";
+import {
+	buildMessageMetadata,
+	enrichAssistantMessageMetrics,
+	latencyFromRunCompletedTimes,
+} from "../utils/messageMetrics";
 
 export type ChatState = {
 	messagesMap: Record<string, Message>;
@@ -102,7 +107,7 @@ function mapBackendMessage(msg: BackendMessage): Message {
 			mapped = { ...mapped, artifacts: mergeArtifacts(mapped.artifacts, artifacts) };
 		}
 	}
-	return mapped;
+	return enrichAssistantMessageMetrics(mapped);
 }
 
 function mapToolCalls(tcList?: BackendToolCall[]): ToolCall[] | undefined {
@@ -124,13 +129,9 @@ function mapMetadata(metadata?: {
 	model?: string;
 	tokens?: number;
 	latency?: number;
+	extra?: Record<string, unknown>;
 }): MessageMetadata | undefined {
-	if (!metadata) return undefined;
-	return {
-		model: metadata.model,
-		tokens: metadata.tokens,
-		latency: metadata.latency,
-	};
+	return buildMessageMetadata(metadata);
 }
 
 function mapUsage(usage?: {
@@ -236,15 +237,16 @@ function getRunResultMessage(payload: BackendSessionEventPayload): string | unde
 }
 
 function metadataFromPayload(payload: BackendSessionEventPayload): MessageMetadata | undefined {
-	const metadata = mapMetadata(payload.metadata);
-	const tokens = metadata?.tokens ?? payload.usage?.total_tokens ?? payload.total_tokens;
-	const model = metadata?.model ?? payload.model;
-	if (!tokens && !model && !metadata?.latency) return metadata;
-	return {
-		...metadata,
-		model,
-		tokens,
-	};
+	const usage = mapUsage(payload.usage ?? payload);
+	const streamLatency = latencyFromRunCompletedTimes(payload.started_at, payload.completed_at);
+	return buildMessageMetadata(
+		{
+			...payload.metadata,
+			model: payload.metadata?.model ?? payload.model,
+			latency: payload.metadata?.latency ?? streamLatency,
+		},
+		usage,
+	);
 }
 
 function mergeToolCalls(current: ToolCall[] | undefined, updates: ToolCall[]): ToolCall[] {
@@ -584,7 +586,7 @@ function applySessionEventToMessage(
 			const artifacts = payload.artifacts
 				?.map(mapArtifactPayload)
 				.filter((artifact): artifact is MessageArtifact => artifact !== undefined);
-			return {
+			return enrichAssistantMessageMetrics({
 				...message,
 				content:
 					options.appendContent && !message.content && resultMessage
@@ -595,7 +597,7 @@ function applySessionEventToMessage(
 					: message.artifacts,
 				metadata: metadata ? { ...message.metadata, ...metadata } : message.metadata,
 				usage: usage ?? message.usage,
-			};
+			});
 		}
 		default:
 			return message;

--- a/frontend/packages/store/utils/messageMetrics.ts
+++ b/frontend/packages/store/utils/messageMetrics.ts
@@ -1,0 +1,75 @@
+import type { Message, MessageMetadata, MessageUsage } from "../types/chat";
+
+type MetadataSource = {
+	model?: string;
+	tokens?: number;
+	latency?: number;
+	extra?: Record<string, unknown>;
+};
+
+function pickString(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim()) {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+function pickNumber(...values: unknown[]): number | undefined {
+	for (const value of values) {
+		if (typeof value === "number" && Number.isFinite(value)) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+/** 从 run.completed 的起止时间计算单次回复耗时（毫秒）。 */
+export function latencyFromRunCompletedTimes(
+	startedAt?: string,
+	completedAt?: string,
+): number | undefined {
+	if (!startedAt || !completedAt) return undefined;
+	const startMs = Date.parse(startedAt);
+	const endMs = Date.parse(completedAt);
+	if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+		return undefined;
+	}
+	return endMs - startMs;
+}
+
+/** 归一化消息 metadata，合并 extra 与 usage 中的展示字段。 */
+export function buildMessageMetadata(
+	metadata?: MetadataSource,
+	usage?: MessageUsage,
+): MessageMetadata | undefined {
+	const extra = metadata?.extra;
+	const model = pickString(metadata?.model, extra?.model, extra?.model_name);
+	const tokens = pickNumber(metadata?.tokens, extra?.tokens, usage?.totalTokens);
+	const latency = pickNumber(metadata?.latency, extra?.latency, extra?.latency_ms);
+
+	if (!model && tokens === undefined && latency === undefined) {
+		return undefined;
+	}
+	return { model, tokens, latency };
+}
+
+/** 获取单条 assistant 消息 footer 应展示的 model / tokens / latency。 */
+export function getAssistantMessageMetrics(message: Message): MessageMetadata | undefined {
+	if (message.role !== "assistant") return undefined;
+	return buildMessageMetadata(message.metadata, message.usage);
+}
+
+/** 将 usage 中的 token 总数回填到 metadata，便于统一展示逻辑。 */
+export function enrichAssistantMessageMetrics(message: Message): Message {
+	if (message.role !== "assistant") {
+		return message;
+	}
+	const metadata = buildMessageMetadata(message.metadata, message.usage);
+	if (!metadata) {
+		const { metadata: _removed, ...rest } = message;
+		return rest;
+	}
+	return { ...message, metadata };
+}


### PR DESCRIPTION
## Summary

- 后端在 `run.completed` 落库时，向每条 assistant 消息的 `metadata.extra` 写入标准展示字段：`model`、`tokens`、`latency`（基于 `CompletedAt - StartedAt` 计算毫秒耗时）
- 前端新增 `messageMetrics.ts`，统一从 `metadata.extra` 与 `usage` 归一化单条消息指标
- `AIMessageBubble` 仅在 model/tokens/latency 有有效值时才渲染 footer，修复此前每条消息下方出现空 `· tokens · ms` 占位的问题
- 右侧「Token 消耗」卡片逻辑不变，仍为当前会话 assistant 消息的 `usage` 聚合

## 背景

消息 footer 设计为展示**单条 AI 回复**的模型、token 与耗时；右侧卡片展示**会话累计**消耗。此前后端已写入 per-message `usage`，但未写入 footer 所需的 `metadata` 标准字段，导致 footer 有占位无数据。

## 变更文件

**Backend**
- `backend/internal/runnable/session_completed.go` — 落库时 enrich 展示字段
- `backend/internal/runnable/session_completed_test.go` — 补充 metadata enrich 单测

**Frontend**
- `frontend/packages/store/utils/messageMetrics.ts` — 指标归一化工具（新文件）
- `frontend/packages/store/slices/chatSlice.ts` — 加载/SSE 路径归一化 metadata
- `frontend/packages/app-ui/components/chat/AIMessageBubble.tsx` — 条件渲染 footer
- `frontend/packages/store/api/types.ts` — SSE payload 增加 `started_at` / `completed_at`
- `frontend/packages/store/index.ts` — 导出 `getAssistantMessageMetrics`

## Test plan

- [ ] 部署后端后发送新消息，确认 AI 回复下方显示类似 `gpt-4o · 120 tokens · 1500ms`
- [ ] 确认无有效指标时不显示 footer 占位文字
- [ ] 确认右侧「Token 消耗」仍正确累计当前会话
- [ ] 刷新页面后 footer 指标仍可从历史消息恢复（依赖后端落库）
- [ ] 历史消息（改动前产生）有 `usage` 的应能显示 tokens；无 `latency` 的不显示 ms
- [ ] `go test ./backend/internal/runnable/... -run TestMessageMetadataFromRunCompleted`

## 备注

- `latency` 表示整次 run 耗时（含工具调用等），非纯 LLM 首 token 时间
- 历史消息不会自动补 `latency`，仅新产生的回复有完整三项指标
- 关联 Issue：（如有请补充链接）