### PR TITLE
refactor(chat): AI 消息 footer 仅展示耗时与 token 用量

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -2,7 +2,7 @@
 
 import {
 	formatTime,
-	getAssistantMessageMetrics,
+	getAssistantMessageFooterSegments,
 	mapBackendArtifactToProjectArtifact,
 	mergeProjectArtifacts,
 	messageArtifactToProjectArtifact,
@@ -63,12 +63,7 @@ export function AIMessageBubble({
 	const hasThinking = (message.thinking ?? "").trim().length > 0;
 	const hasToolCalls = message.toolCalls && message.toolCalls.length > 0;
 	const hasArtifacts = message.artifacts && message.artifacts.length > 0;
-	const metrics = getAssistantMessageMetrics(message);
-	const metricSegments = [
-		metrics?.model,
-		metrics?.tokens !== undefined ? `${metrics.tokens} tokens` : undefined,
-		metrics?.latency !== undefined ? `${metrics.latency}ms` : undefined,
-	].filter((segment): segment is string => Boolean(segment));
+	const metricSegments = getAssistantMessageFooterSegments(message);
 
 	return (
 		<div data-slot="ai-message" className="group flex items-start gap-3">

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -88,9 +88,15 @@ export {
 	messageArtifactToProjectArtifact,
 } from "./utils/artifacts";
 export { AUTH_SESSION_EXPIRED_EVENT, getValidJwtToken } from "./utils/authStorage";
-export { formatDate, formatFileSize, formatTime, formatTokenCount } from "./utils/format";
+export {
+	formatDate,
+	formatFileSize,
+	formatLatency,
+	formatTime,
+	formatTokenCount,
+} from "./utils/format";
 export {
 	buildMessageMetadata,
-	getAssistantMessageMetrics,
+	getAssistantMessageFooterSegments,
 	latencyFromRunCompletedTimes,
 } from "./utils/messageMetrics";

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -92,7 +92,7 @@ function mapBackendMessage(msg: BackendMessage): Message {
 		content: msg.content ?? "",
 		timestamp: msg.timestamp ?? new Date(msg.created_at).getTime(),
 		sequence: msg.sequence,
-		metadata: mapMetadata(msg.metadata),
+		metadata: buildMessageMetadata(msg.metadata),
 		usage: mapUsage(msg.usage),
 	};
 
@@ -124,15 +124,6 @@ function mapToolCalls(tcList?: BackendToolCall[]): ToolCall[] | undefined {
 
 type NormalizedSessionEvent = Exclude<BackendMessageChunk, string> | SSEMessageEvent;
 type SessionEventLike = BackendMessageChunk | SSEMessageEvent;
-
-function mapMetadata(metadata?: {
-	model?: string;
-	tokens?: number;
-	latency?: number;
-	extra?: Record<string, unknown>;
-}): MessageMetadata | undefined {
-	return buildMessageMetadata(metadata);
-}
 
 function mapUsage(usage?: {
 	input_tokens?: number;

--- a/frontend/packages/store/utils/format.ts
+++ b/frontend/packages/store/utils/format.ts
@@ -32,3 +32,13 @@ export function formatTokenCount(count: number): string {
 	if (count >= 1000) return `${(count / 1000).toFixed(1)}K`;
 	return String(count);
 }
+
+/** 格式化单条回复耗时：不足 1 秒用 ms，否则用秒。 */
+export function formatLatency(ms: number): string {
+	if (!Number.isFinite(ms) || ms <= 0) return "0ms";
+	if (ms >= 1000) {
+		const seconds = ms / 1000;
+		return seconds >= 10 ? `${Math.round(seconds)}s` : `${seconds.toFixed(1)}s`;
+	}
+	return `${Math.round(ms)}ms`;
+}

--- a/frontend/packages/store/utils/messageMetrics.ts
+++ b/frontend/packages/store/utils/messageMetrics.ts
@@ -72,7 +72,7 @@ export function getAssistantMessageFooterSegments(message: Message): string[] {
 		segments.push(formatLatency(metrics.latency));
 	}
 	if (metrics.tokens !== undefined) {
-		segments.push(`${formatTokenCount(metrics.tokens)} tokens`);
+		segments.push(`${formatTokenCount(metrics.tokens)} Tokens`);
 	}
 	return segments;
 }

--- a/frontend/packages/store/utils/messageMetrics.ts
+++ b/frontend/packages/store/utils/messageMetrics.ts
@@ -1,4 +1,5 @@
 import type { Message, MessageMetadata, MessageUsage } from "../types/chat";
+import { formatLatency, formatTokenCount } from "./format";
 
 type MetadataSource = {
 	model?: string;
@@ -55,10 +56,25 @@ export function buildMessageMetadata(
 	return { model, tokens, latency };
 }
 
-/** 获取单条 assistant 消息 footer 应展示的 model / tokens / latency。 */
-export function getAssistantMessageMetrics(message: Message): MessageMetadata | undefined {
+/** 读取单条 assistant 消息的 tokens / latency 原始指标。 */
+function getAssistantMessageMetrics(message: Message): MessageMetadata | undefined {
 	if (message.role !== "assistant") return undefined;
 	return buildMessageMetadata(message.metadata, message.usage);
+}
+
+/** 生成消息 footer 展示片段：仅耗时与 token 用量。 */
+export function getAssistantMessageFooterSegments(message: Message): string[] {
+	const metrics = getAssistantMessageMetrics(message);
+	if (!metrics) return [];
+
+	const segments: string[] = [];
+	if (metrics.latency !== undefined) {
+		segments.push(formatLatency(metrics.latency));
+	}
+	if (metrics.tokens !== undefined) {
+		segments.push(`${formatTokenCount(metrics.tokens)} tokens`);
+	}
+	return segments;
 }
 
 /** 将 usage 中的 token 总数回填到 metadata，便于统一展示逻辑。 */


### PR DESCRIPTION
## Summary

- AI 回复消息 footer 改为只展示 **耗时 + token 用量**，不再重复展示模型名（模型已在 ChatHeader 显示）
- 新增 `formatLatency`：不足 1 秒显示 `850ms`，否则显示 `1.5s` / `12s`
- token 用量复用 `formatTokenCount` 压缩展示，如 `24.4K tokens`
- 新增 `getAssistantMessageFooterSegments` 统一 footer 展示逻辑
- 清理 `mapMetadata` 冗余封装，改为直接使用 `buildMessageMetadata`

## 背景

PR #242 已合入 per-message 指标落库与 footer 基础展示（model · tokens · latency）。  
本次为 UI 优化：footer 聚焦「这条回复等了多久、用了多少 token」，避免与顶部模型信息重复。

## 变更文件

- `frontend/packages/app-ui/components/chat/AIMessageBubble.tsx`
- `frontend/packages/store/utils/messageMetrics.ts`
- `frontend/packages/store/utils/format.ts`
- `frontend/packages/store/slices/chatSlice.ts`
- `frontend/packages/store/index.ts`

## Test plan

- [ ] 发送新消息后，footer 显示类似 `1.5s · 24.4K tokens`，**不显示模型名**
- [ ] 顶部 ChatHeader 仍正常显示当前模型
- [ ] 右侧「Token 消耗」会话汇总不受影响
- [ ] 无 latency 的历史消息仅显示 tokens，不显示空占位
- [ ] 刷新页面后 footer 指标仍可从历史消息恢复

## 依赖说明

- 依赖 PR #242 已合入的后端 `metadata.extra` 写入（`latency` 需后端部署后才有）
- 关联 Issue：（如有请补充链接）