### PR TITLE
chore(ui): 临时隐藏消息 footer 与右侧 Token 消耗卡片

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -27,8 +27,11 @@ import {
 	Table2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import {
+	SHOW_ASSISTANT_MESSAGE_METRICS,
+	SHOW_ASSISTANT_MESSAGE_REGENERATE_BUTTON,
+} from "../../constants/temporaryUiFlags";
 import { MarkdownRenderer } from "../common/MarkdownRenderer";
-import { SHOW_ASSISTANT_MESSAGE_METRICS } from "../../constants/temporaryUiFlags";
 import { ArtifactPreviewDialog } from "../layout/ArtifactPreviewDialog";
 import { ToolCallBlock } from "./ToolCallBlock";
 
@@ -129,14 +132,16 @@ export function AIMessageBubble({
 						)}
 						<div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
 							<CopyButton text={content} />
-							<Button
-								variant="ghost"
-								size="icon-xs"
-								className="text-slate-400 hover:text-slate-600"
-								onClick={() => resendMessage(message.id)}
-							>
-								<RefreshCw className="size-3.5" />
-							</Button>
+							{SHOW_ASSISTANT_MESSAGE_REGENERATE_BUTTON && (
+								<Button
+									variant="ghost"
+									size="icon-xs"
+									className="text-slate-400 hover:text-slate-600"
+									onClick={() => resendMessage(message.id)}
+								>
+									<RefreshCw className="size-3.5" />
+								</Button>
+							)}
 						</div>
 					</div>
 				)}

--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { MarkdownRenderer } from "../common/MarkdownRenderer";
+import { SHOW_ASSISTANT_MESSAGE_METRICS } from "../../constants/temporaryUiFlags";
 import { ArtifactPreviewDialog } from "../layout/ArtifactPreviewDialog";
 import { ToolCallBlock } from "./ToolCallBlock";
 
@@ -63,7 +64,9 @@ export function AIMessageBubble({
 	const hasThinking = (message.thinking ?? "").trim().length > 0;
 	const hasToolCalls = message.toolCalls && message.toolCalls.length > 0;
 	const hasArtifacts = message.artifacts && message.artifacts.length > 0;
-	const metricSegments = getAssistantMessageFooterSegments(message);
+	const metricSegments = SHOW_ASSISTANT_MESSAGE_METRICS
+		? getAssistantMessageFooterSegments(message)
+		: [];
 
 	return (
 		<div data-slot="ai-message" className="group flex items-start gap-3">

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { MessageTimeline } from "../chat/MessageTimeline";
+import { SHOW_TASK_TOKEN_USAGE_CARD } from "../../constants/temporaryUiFlags";
 import { ChatInput } from "../input/ChatInput";
 import { ArtifactPreviewDialog } from "./ArtifactPreviewDialog";
 import type { AppNavigation } from "./LeftRail";
@@ -88,13 +89,17 @@ export function TaskDetailPage({
 	);
 
 	const tokenSummary = useMemo(() => {
-		// 任务详情右侧成本卡统一按当前会话内 assistant 消息聚合，刷新后可直接从历史消息恢复。
-		const initialSummary = {
+		const emptySummary = {
 			inputTokens: 0,
 			outputTokens: 0,
 			totalTokens: 0,
 			messageCount: 0,
 		};
+		if (!SHOW_TASK_TOKEN_USAGE_CARD) {
+			return emptySummary;
+		}
+		// 任务详情右侧成本卡统一按当前会话内 assistant 消息聚合，刷新后可直接从历史消息恢复。
+		const initialSummary = emptySummary;
 
 		return messageIds.reduce((summary, id) => {
 			const message = messagesMap[id];
@@ -296,14 +301,16 @@ export function TaskDetailPage({
 
 				<aside className="flex w-[352px] shrink-0 flex-col border-l border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-5 py-6">
 					<div className="min-h-0 flex-1 space-y-8 overflow-y-auto pr-1">
-						<section>
-							<TaskTokenUsageCard
-								totalTokens={tokenSummary.totalTokens}
-								inputTokens={tokenSummary.inputTokens}
-								outputTokens={tokenSummary.outputTokens}
-								messageCount={tokenSummary.messageCount}
-							/>
-						</section>
+						{SHOW_TASK_TOKEN_USAGE_CARD && (
+							<section>
+								<TaskTokenUsageCard
+									totalTokens={tokenSummary.totalTokens}
+									inputTokens={tokenSummary.inputTokens}
+									outputTokens={tokenSummary.outputTokens}
+									messageCount={tokenSummary.messageCount}
+								/>
+							</section>
+						)}
 						{task?.description && (
 							<section>
 								<h3 className="mb-3 text-xs font-semibold text-[var(--leros-text-muted)]">

--- a/frontend/packages/app-ui/constants/temporaryUiFlags.ts
+++ b/frontend/packages/app-ui/constants/temporaryUiFlags.ts
@@ -1,5 +1,8 @@
 /** 临时关闭 AI 消息 footer 的耗时与 Token 展示，恢复时改为 true。 */
-export const SHOW_ASSISTANT_MESSAGE_METRICS = false
+export const SHOW_ASSISTANT_MESSAGE_METRICS = false;
 
 /** 临时关闭任务详情右侧 Token 消耗卡片，恢复时改为 true。 */
-export const SHOW_TASK_TOKEN_USAGE_CARD = false
+export const SHOW_TASK_TOKEN_USAGE_CARD = false;
+
+/** 临时关闭 AI 消息 footer 的重新生成按钮，恢复时改为 true。 */
+export const SHOW_ASSISTANT_MESSAGE_REGENERATE_BUTTON = false;

--- a/frontend/packages/app-ui/constants/temporaryUiFlags.ts
+++ b/frontend/packages/app-ui/constants/temporaryUiFlags.ts
@@ -1,0 +1,5 @@
+/** 临时关闭 AI 消息 footer 的耗时与 Token 展示，恢复时改为 true。 */
+export const SHOW_ASSISTANT_MESSAGE_METRICS = false
+
+/** 临时关闭任务详情右侧 Token 消耗卡片，恢复时改为 true。 */
+export const SHOW_TASK_TOKEN_USAGE_CARD = false


### PR DESCRIPTION
## Summary

- 临时隐藏 AI 消息 footer 的耗时与 Token 展示
- 临时隐藏任务详情页右侧「Token 消耗」整块卡片，下方内容自动上移
- 新增 `temporaryUiFlags.ts` 统一开关，恢复展示时改回 `true` 即可

## 背景

当前为临时产品需求，先不在 UI 暴露 token / 耗时相关指标；底层 metrics 归一化与落库逻辑保持不变，便于后续快速恢复。

## 变更文件

- `frontend/packages/app-ui/constants/temporaryUiFlags.ts`（新增）
- `frontend/packages/app-ui/components/chat/AIMessageBubble.tsx`
- `frontend/packages/app-ui/components/layout/TaskDetailPage.tsx`

## 恢复方式

编辑 `temporaryUiFlags.ts`：

```ts
export const SHOW_ASSISTANT_MESSAGE_METRICS = true;
export const SHOW_TASK_TOKEN_USAGE_CARD = true;