### PR TITLE
fix(app-ui): 统一项目页与任务页图标展示

### DIFF
--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -18,13 +18,11 @@ import {
 	Circle,
 	Download,
 	Eye,
-	FileImage,
 	FileText,
 	LayoutPanelLeft,
 	LoaderCircle,
 	Search,
 	Settings,
-	Table2,
 	Tag,
 	Trash2,
 	X,
@@ -35,6 +33,11 @@ import { MessageTimeline } from "../chat/MessageTimeline";
 import { ChatInput, PROJECT_ATTACHMENT_ACCEPT } from "../input/ChatInput";
 import { ArtifactPreviewDialog } from "./ArtifactPreviewDialog";
 import type { AppNavigation } from "./LeftRail";
+import {
+	ProjectFileTypeIcon,
+	SIDEBAR_COMPACT_LIST_CLASS,
+	TaskCardIcon,
+} from "./project-file-type-icon";
 import {
 	collectSelectableFiles,
 	normalizeProjectFileTree,
@@ -386,7 +389,7 @@ export function ProjectPage({
 							<section>
 								<div className="mx-auto mb-4 flex w-full max-w-[250px] items-center justify-between">
 									<h2 className="text-xs font-semibold text-[var(--leros-text-muted)]">产物</h2>
-									<span className="rounded-md bg-[var(--leros-chat-control-bg)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-text)]">
+									<span className="rounded-md bg-[var(--leros-primary-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-primary)]">
 										{taskArtifacts.length} 个
 									</span>
 								</div>
@@ -439,6 +442,7 @@ function ProjectTasks({
 	const [deleteTarget, setDeleteTarget] = useState<ProjectTask | null>(null);
 
 	const handleStatusToggle = async (task: ProjectTask) => {
+		// 保留项目页中的快捷状态切换，避免这次样式整理带出交互回归。
 		await updateTask({
 			public_id: task.id,
 			status: NEXT_STATUS[task.status] ?? "todo",
@@ -503,79 +507,94 @@ function ProjectTaskList({
 	}
 
 	return (
-		<div className={cn("w-full", compact ? "mx-auto max-w-[250px] space-y-3" : "space-y-3")}>
-			{tasks.map((task) => (
-				<div
-					key={task.id}
-					className={cn(
-						"group flex items-start border border-[var(--leros-control-border)] bg-[var(--leros-surface)] shadow-sm",
-						onOpen &&
-							"cursor-pointer transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
-						compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
-					)}
-				>
-					<button
-						type="button"
-						className="mt-0.5 shrink-0 cursor-pointer"
-						onClick={(event) => {
-							event.stopPropagation();
-							onStatusToggle?.(task);
-						}}
-						title={`切换状态（当前：${STATUS_LABEL[task.status] ?? task.status}）`}
-					>
-						{task.status === "done" ? (
-							<CheckCircle2 className="size-4 text-[var(--leros-primary)]" />
-						) : task.status === "in_progress" ? (
-							<LoaderCircle className="size-4 text-[var(--leros-warning)]" />
-						) : (
-							<Circle className="size-4 text-[var(--leros-text-muted)]" />
+		<div className={cn("w-full", compact && "mx-auto max-w-[250px]")}>
+			<div className={cn(compact ? SIDEBAR_COMPACT_LIST_CLASS : "space-y-3")}>
+				{tasks.map((task) => (
+					<div
+						key={task.id}
+						className={cn(
+							"group flex items-start border border-[var(--leros-control-border)] bg-[var(--leros-surface)] shadow-sm",
+							onOpen &&
+								"cursor-pointer transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
+							compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
 						)}
-					</button>
-					<button
-						type="button"
-						className="min-w-0 flex-1 text-left"
-						onClick={() => onOpen?.(task)}
-						disabled={!onOpen}
-						title={onOpen ? "打开任务会话" : undefined}
 					>
-						<div className="truncate text-sm font-semibold leading-5 text-[var(--leros-text-strong)]">
-							{task.title}
-						</div>
-						<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
-							{task.meta}
-						</div>
-						{!compact && (task.taskType || task.deadline) && (
-							<div className="mt-2 flex flex-wrap items-center gap-2">
-								{task.taskType && (
-									<span className="inline-flex items-center gap-1 rounded-md bg-[var(--leros-primary-softer)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--leros-primary)]">
-										<Tag className="size-3" />
-										{task.taskType}
-									</span>
+						{onStatusToggle ? (
+							<button
+								type="button"
+								className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]"
+								onClick={(event) => {
+									event.stopPropagation();
+									onStatusToggle(task);
+								}}
+								title={`切换状态（当前：${STATUS_LABEL[task.status] ?? task.status}）`}
+							>
+								{task.status === "done" ? (
+									<CheckCircle2 className="size-4 text-[var(--leros-primary)]" />
+								) : task.status === "in_progress" ? (
+									<LoaderCircle className="size-4 text-[var(--leros-warning)]" />
+								) : (
+									<Circle className="size-4 text-[var(--leros-text-muted)]" />
 								)}
-								{task.deadline && (
-									<span className="inline-flex items-center gap-1 rounded-md bg-[var(--leros-chat-control-bg)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--leros-text-muted)]">
-										<Calendar className="size-3" />
-										{task.deadline}
-									</span>
-								)}
+							</button>
+						) : (
+							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
+								<TaskCardIcon />
 							</div>
 						)}
-					</button>
-					{!compact && onDelete && (
 						<button
 							type="button"
-							className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--leros-text-muted)] opacity-0 transition-opacity hover:bg-[var(--leros-danger-softer)] hover:text-[var(--leros-danger)] group-hover:opacity-100"
-							onClick={(event) => {
-								event.stopPropagation();
-								onDelete(task);
-							}}
-							title="删除任务"
+							className="min-w-0 flex-1 text-left"
+							onClick={() => onOpen?.(task)}
+							disabled={!onOpen}
+							title={onOpen ? "打开任务会话" : undefined}
 						>
-							<Trash2 className="size-4" />
+							<div
+								className={cn(
+									"text-sm font-normal leading-5 text-[var(--leros-text-strong)]",
+									compact ? "line-clamp-2" : "truncate",
+								)}
+							>
+								{task.title}
+							</div>
+							{!compact && (
+								<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
+									{task.meta}
+								</div>
+							)}
+							{!compact && (task.taskType || task.deadline) && (
+								<div className="mt-2 flex flex-wrap items-center gap-2">
+									{task.taskType && (
+										<span className="inline-flex items-center gap-1 rounded-md bg-[var(--leros-primary-softer)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--leros-primary)]">
+											<Tag className="size-3" />
+											{task.taskType}
+										</span>
+									)}
+									{task.deadline && (
+										<span className="inline-flex items-center gap-1 rounded-md bg-[var(--leros-chat-control-bg)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--leros-text-muted)]">
+											<Calendar className="size-3" />
+											{task.deadline}
+										</span>
+									)}
+								</div>
+							)}
 						</button>
-					)}
-				</div>
-			))}
+						{!compact && onDelete && (
+							<button
+								type="button"
+								className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--leros-text-muted)] opacity-0 transition-opacity hover:bg-[var(--leros-danger-softer)] hover:text-[var(--leros-danger)] group-hover:opacity-100"
+								onClick={(event) => {
+									event.stopPropagation();
+									onDelete(task);
+								}}
+								title="删除任务"
+							>
+								<Trash2 className="size-4" />
+							</button>
+						)}
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }
@@ -626,7 +645,10 @@ function ProjectFiles({
 
 		async function loadPreview() {
 			if (!currentFile.publicId) {
-				setPreviewState({ status: "error", message: "文件缺少 public_id，无法预览" });
+				setPreviewState({
+					status: "error",
+					message: "文件缺少 public_id，无法预览",
+				});
 				return;
 			}
 
@@ -833,7 +855,7 @@ function ProjectFiles({
 										title="查看"
 									>
 										<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
-											<ProjectFileIcon file={file} />
+											<ProjectFileTypeIcon fileName={file.name} />
 										</div>
 										<div className="min-w-0">
 											<p className="truncate text-sm font-semibold text-[var(--leros-text-strong)]">
@@ -929,31 +951,6 @@ function ProjectFiles({
 			)}
 		</div>
 	);
-}
-
-function ProjectFileIcon({ file }: { file: ProjectFileNode }) {
-	const lowerPath = file.name.toLowerCase();
-	let iconSrc = "/assets/icons/file-text.svg";
-
-	if (lowerPath.endsWith(".jpg")) {
-		iconSrc = "/assets/icons/file-picture-jpg.svg";
-	} else if (lowerPath.endsWith(".jpeg")) {
-		iconSrc = "/assets/icons/file-picture-jpeg.svg";
-	} else if (lowerPath.endsWith(".png")) {
-		iconSrc = "/assets/icons/file-picture-png.svg";
-	} else if (lowerPath.endsWith(".pdf")) {
-		iconSrc = "/assets/icons/file-pdf.svg";
-	} else if (lowerPath.endsWith(".json")) {
-		iconSrc = "/assets/icons/file-text.svg";
-	} else if (
-		lowerPath.endsWith(".csv") ||
-		lowerPath.endsWith(".xlsx") ||
-		lowerPath.endsWith(".xls")
-	) {
-		iconSrc = "/assets/icons/file-text.svg";
-	}
-
-	return <img src={iconSrc} alt="" className="size-6 object-contain" aria-hidden="true" />;
 }
 
 function ProjectFilePreviewBody({
@@ -1117,38 +1114,40 @@ function ProjectArtifactList({
 
 	return (
 		<>
-			<div className={cn("w-full", compact ? "mx-auto max-w-[250px] space-y-3" : "space-y-3")}>
-				{artifacts.map((artifact) => (
-					<button
-						type="button"
-						key={artifact.id}
-						onClick={() => setPreviewArtifact(artifact)}
-						className={cn(
-							"group relative flex w-full cursor-pointer items-center overflow-hidden border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
-							compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
-						)}
-						title="预览产物"
-					>
-						{/* hover 时补一个轻量蒙层，明确提示当前整卡可点击预览 */}
-						<div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-							<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
-								点击预览
-							</span>
-						</div>
-						<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-text)]">
-							<ArtifactIcon type={artifact.type} />
-						</div>
-						<div className="min-w-0">
-							<div className="truncate text-sm font-semibold leading-5 text-[var(--leros-text-strong)]">
-								{artifact.name}
+			<div className={cn("w-full", compact && "mx-auto max-w-[250px]")}>
+				<div className={cn(compact ? SIDEBAR_COMPACT_LIST_CLASS : "space-y-3")}>
+					{artifacts.map((artifact) => (
+						<button
+							type="button"
+							key={artifact.id}
+							onClick={() => setPreviewArtifact(artifact)}
+							className={cn(
+								"group relative flex w-full cursor-pointer items-center overflow-hidden border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
+								compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
+							)}
+							title="预览产物"
+						>
+							{/* hover 时补一个轻量蒙层，明确提示当前整卡可点击预览 */}
+							<div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+								<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
+									点击预览
+								</span>
 							</div>
-							<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
-								{artifact.size}
-								{artifact.updatedAt ? ` · ${artifact.updatedAt}` : ""}
+							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
+								<ProjectFileTypeIcon fileName={artifact.name} artifactType={artifact.type} />
 							</div>
-						</div>
-					</button>
-				))}
+							<div className="min-w-0">
+								<div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">
+									{artifact.name}
+								</div>
+								<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
+									{artifact.size}
+									{artifact.updatedAt ? ` · ${artifact.updatedAt}` : ""}
+								</div>
+							</div>
+						</button>
+					))}
+				</div>
 			</div>
 			<ArtifactPreviewDialog
 				artifact={previewArtifact}
@@ -1159,17 +1158,4 @@ function ProjectArtifactList({
 			/>
 		</>
 	);
-}
-
-function ArtifactIcon({ type }: { type: ProjectArtifact["type"] }) {
-	const className = "size-4";
-
-	switch (type) {
-		case "spreadsheet":
-			return <Table2 className={className} />;
-		case "image":
-			return <FileImage className={className} />;
-		default:
-			return <FileText className={className} />;
-	}
 }

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -12,9 +12,7 @@ import { artifactApi } from "@leros/store/api/artifactApi";
 import { cn } from "@leros/ui/lib/utils";
 import {
 	Bot,
-	CheckCircle2,
 	ChevronsLeftRightEllipsis,
-	Circle,
 	Download,
 	Eye,
 	FileText,
@@ -436,27 +434,13 @@ function ProjectTasks({
 	tasks: ProjectTask[];
 	onOpenTask?: (task: ProjectTask) => void;
 }) {
-	const { updateTask } = useLayoutStore((s) => s);
 	const [deleteTarget, setDeleteTarget] = useState<ProjectTask | null>(null);
-
-	const handleStatusToggle = async (task: ProjectTask) => {
-		// 固定任务图标和状态切换拆开，避免统一视觉时把原有交互丢掉。
-		await updateTask({
-			public_id: task.id,
-			status: NEXT_STATUS[task.status] ?? "todo",
-		});
-	};
 
 	return (
 		<div className="mx-auto w-full max-w-[720px]">
 			<h2 className="text-lg font-semibold text-[var(--leros-text-strong)]">任务</h2>
 			<div className="mt-4">
-				<ProjectTaskList
-					tasks={tasks}
-					onStatusToggle={handleStatusToggle}
-					onDelete={setDeleteTarget}
-					onOpen={onOpenTask}
-				/>
+				<ProjectTaskList tasks={tasks} onDelete={setDeleteTarget} onOpen={onOpenTask} />
 			</div>
 			{deleteTarget && (
 				<TaskDeleteDialog
@@ -471,28 +455,14 @@ function ProjectTasks({
 	);
 }
 
-const NEXT_STATUS: Record<string, string> = {
-	todo: "in_progress",
-	in_progress: "done",
-	done: "todo",
-};
-
-const STATUS_LABEL: Record<string, string> = {
-	todo: "待办",
-	in_progress: "进行中",
-	done: "已完成",
-};
-
 function ProjectTaskList({
 	tasks,
 	compact = false,
-	onStatusToggle,
 	onDelete,
 	onOpen,
 }: {
 	tasks: ProjectTask[];
 	compact?: boolean;
-	onStatusToggle?: (task: ProjectTask) => void;
 	onDelete?: (task: ProjectTask) => void;
 	onOpen?: (task: ProjectTask) => void;
 }) {
@@ -537,25 +507,6 @@ function ProjectTaskList({
 								{task.title}
 							</div>
 						</button>
-						{!compact && onStatusToggle && (
-							<button
-								type="button"
-								className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)]"
-								onClick={(event) => {
-									event.stopPropagation();
-									onStatusToggle(task);
-								}}
-								title={`切换状态（当前：${STATUS_LABEL[task.status] ?? task.status}）`}
-							>
-								{task.status === "done" ? (
-									<CheckCircle2 className="size-4 text-[var(--leros-primary)]" />
-								) : task.status === "in_progress" ? (
-									<LoaderCircle className="size-4 text-[var(--leros-warning)]" />
-								) : (
-									<Circle className="size-4 text-[var(--leros-text-muted)]" />
-								)}
-							</button>
-						)}
 						{!compact && onDelete && (
 							<button
 								type="button"

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -1134,7 +1134,7 @@ function ProjectArtifactList({
 								</span>
 							</div>
 							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
-								<ProjectFileTypeIcon fileName={artifact.name} artifactType={artifact.type} />
+								<ProjectFileTypeIcon fileName={artifact.name} />
 							</div>
 							<div className="min-w-0">
 								<div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -12,7 +12,6 @@ import { artifactApi } from "@leros/store/api/artifactApi";
 import { cn } from "@leros/ui/lib/utils";
 import {
 	Bot,
-	Calendar,
 	CheckCircle2,
 	ChevronsLeftRightEllipsis,
 	Circle,
@@ -23,7 +22,6 @@ import {
 	LoaderCircle,
 	Search,
 	Settings,
-	Tag,
 	Trash2,
 	X,
 } from "lucide-react";
@@ -442,7 +440,7 @@ function ProjectTasks({
 	const [deleteTarget, setDeleteTarget] = useState<ProjectTask | null>(null);
 
 	const handleStatusToggle = async (task: ProjectTask) => {
-		// 保留项目页中的快捷状态切换，避免这次样式整理带出交互回归。
+		// 固定任务图标和状态切换拆开，避免统一视觉时把原有交互丢掉。
 		await updateTask({
 			public_id: task.id,
 			status: NEXT_STATUS[task.status] ?? "todo",
@@ -519,10 +517,30 @@ function ProjectTaskList({
 							compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
 						)}
 					>
-						{onStatusToggle ? (
+						<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
+							{/* 主列表和右侧列表统一使用固定任务图标，避免状态图标和语义图标混用。 */}
+							<TaskCardIcon className="size-5" />
+						</div>
+						<button
+							type="button"
+							className="min-w-0 flex-1 text-left"
+							onClick={() => onOpen?.(task)}
+							disabled={!onOpen}
+							title={onOpen ? "打开任务会话" : undefined}
+						>
+							<div
+								className={cn(
+									"text-sm font-normal leading-5 text-[var(--leros-text-strong)]",
+									"line-clamp-2",
+								)}
+							>
+								{task.title}
+							</div>
+						</button>
+						{!compact && onStatusToggle && (
 							<button
 								type="button"
-								className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]"
+								className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)]"
 								onClick={(event) => {
 									event.stopPropagation();
 									onStatusToggle(task);
@@ -537,48 +555,7 @@ function ProjectTaskList({
 									<Circle className="size-4 text-[var(--leros-text-muted)]" />
 								)}
 							</button>
-						) : (
-							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
-								<TaskCardIcon />
-							</div>
 						)}
-						<button
-							type="button"
-							className="min-w-0 flex-1 text-left"
-							onClick={() => onOpen?.(task)}
-							disabled={!onOpen}
-							title={onOpen ? "打开任务会话" : undefined}
-						>
-							<div
-								className={cn(
-									"text-sm font-normal leading-5 text-[var(--leros-text-strong)]",
-									compact ? "line-clamp-2" : "truncate",
-								)}
-							>
-								{task.title}
-							</div>
-							{!compact && (
-								<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
-									{task.meta}
-								</div>
-							)}
-							{!compact && (task.taskType || task.deadline) && (
-								<div className="mt-2 flex flex-wrap items-center gap-2">
-									{task.taskType && (
-										<span className="inline-flex items-center gap-1 rounded-md bg-[var(--leros-primary-softer)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--leros-primary)]">
-											<Tag className="size-3" />
-											{task.taskType}
-										</span>
-									)}
-									{task.deadline && (
-										<span className="inline-flex items-center gap-1 rounded-md bg-[var(--leros-chat-control-bg)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--leros-text-muted)]">
-											<Calendar className="size-3" />
-											{task.deadline}
-										</span>
-									)}
-								</div>
-							)}
-						</button>
 						{!compact && onDelete && (
 							<button
 								type="button"

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -532,7 +532,7 @@ function TaskArtifactList({
 						</span>
 					</div>
 					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
-						<ProjectFileTypeIcon fileName={artifact.name} artifactType={artifact.type} />
+						<ProjectFileTypeIcon fileName={artifact.name} />
 					</div>
 					<div className="min-w-0">
 						<div className="truncate text-sm font-semibold leading-5 text-[var(--leros-text-strong)]">

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -20,19 +20,17 @@ import {
 	Calendar,
 	CheckCircle2,
 	Circle,
-	FileImage,
-	FileText,
 	LoaderCircle,
-	Table2,
 	Tag,
 	Zap,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { MessageTimeline } from "../chat/MessageTimeline";
 import { SHOW_TASK_TOKEN_USAGE_CARD } from "../../constants/temporaryUiFlags";
+import { MessageTimeline } from "../chat/MessageTimeline";
 import { ChatInput } from "../input/ChatInput";
 import { ArtifactPreviewDialog } from "./ArtifactPreviewDialog";
 import type { AppNavigation } from "./LeftRail";
+import { ProjectFileTypeIcon, SIDEBAR_COMPACT_LIST_CLASS } from "./project-file-type-icon";
 import { TaskTodoProgressPanel } from "./TaskTodoProgressPanel";
 import { getLatestAssistantTodos } from "./taskProgress";
 
@@ -349,7 +347,7 @@ export function TaskDetailPage({
 						<section>
 							<div className="mb-3 flex items-center justify-between">
 								<h3 className="text-xs font-semibold text-[var(--leros-text-muted)]">任务产物</h3>
-								<span className="rounded-md bg-[var(--leros-chat-control-bg)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-text)]">
+								<span className="rounded-md bg-[var(--leros-primary-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-primary)]">
 									{artifacts.length} 个
 								</span>
 							</div>
@@ -518,7 +516,7 @@ function TaskArtifactList({
 	}
 
 	return (
-		<div className="space-y-3">
+		<div className={SIDEBAR_COMPACT_LIST_CLASS}>
 			{artifacts.map((artifact) => (
 				<button
 					type="button"
@@ -533,8 +531,8 @@ function TaskArtifactList({
 							点击预览
 						</span>
 					</div>
-					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-text)]">
-						<TaskArtifactIcon type={artifact.type} />
+					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
+						<ProjectFileTypeIcon fileName={artifact.name} artifactType={artifact.type} />
 					</div>
 					<div className="min-w-0">
 						<div className="truncate text-sm font-semibold leading-5 text-[var(--leros-text-strong)]">
@@ -548,17 +546,4 @@ function TaskArtifactList({
 			))}
 		</div>
 	);
-}
-
-function TaskArtifactIcon({ type }: { type: ProjectArtifact["type"] }) {
-	const className = "size-4";
-
-	switch (type) {
-		case "spreadsheet":
-			return <Table2 className={className} />;
-		case "image":
-			return <FileImage className={className} />;
-		default:
-			return <FileText className={className} />;
-	}
 }

--- a/frontend/packages/app-ui/components/layout/project-file-type-icon.tsx
+++ b/frontend/packages/app-ui/components/layout/project-file-type-icon.tsx
@@ -1,3 +1,5 @@
+import { ClipboardList } from "lucide-react";
+
 /** 根据文件名后缀返回与文件 Tab 一致的图标资源路径 */
 export function getProjectFileIconSrc(fileName: string): string {
 	const lowerPath = fileName.toLowerCase();
@@ -31,9 +33,9 @@ export function ProjectFileTypeIcon({
 	);
 }
 
-/** 任务卡片左侧占位图标，先复用文档图标保证视觉统一 */
+/** 任务卡片统一使用固定任务图标，和右侧任务列表保持一致 */
 export function TaskCardIcon({ className = "size-6 object-contain" }: { className?: string }) {
-	return <ProjectFileTypeIcon fileName="" className={className} />;
+	return <ClipboardList className={className} aria-hidden="true" />;
 }
 
 /** 右侧紧凑列表最多展示 5 条，超出后内部滚动并隐藏滚动条 */

--- a/frontend/packages/app-ui/components/layout/project-file-type-icon.tsx
+++ b/frontend/packages/app-ui/components/layout/project-file-type-icon.tsx
@@ -1,8 +1,4 @@
-import { FileText, ImageIcon, Table2 } from "lucide-react";
-
-type ProjectArtifactIconType = "document" | "spreadsheet" | "image";
-
-/** 根据文件名后缀或产物类型返回与文件/产物列表一致的图标资源路径 */
+/** 根据文件名后缀返回与文件 Tab 一致的图标资源路径 */
 export function getProjectFileIconSrc(fileName: string): string {
 	const lowerPath = fileName.toLowerCase();
 
@@ -25,24 +21,11 @@ export function getProjectFileIconSrc(fileName: string): string {
 /** 文件 Tab 与产物卡片共用的类型图标组件 */
 export function ProjectFileTypeIcon({
 	fileName,
-	artifactType,
 	className = "size-6 object-contain",
 }: {
 	fileName: string;
-	artifactType?: ProjectArtifactIconType;
 	className?: string;
 }) {
-	// 产物场景优先使用后端返回的类型，避免无扩展名时图标退化。
-	if (artifactType === "spreadsheet") {
-		return <Table2 className={className} aria-hidden="true" />;
-	}
-	if (artifactType === "image") {
-		return <ImageIcon className={className} aria-hidden="true" />;
-	}
-	if (artifactType === "document") {
-		return <FileText className={className} aria-hidden="true" />;
-	}
-
 	return (
 		<img src={getProjectFileIconSrc(fileName)} alt="" className={className} aria-hidden="true" />
 	);

--- a/frontend/packages/app-ui/components/layout/project-file-type-icon.tsx
+++ b/frontend/packages/app-ui/components/layout/project-file-type-icon.tsx
@@ -1,0 +1,58 @@
+import { FileText, ImageIcon, Table2 } from "lucide-react";
+
+type ProjectArtifactIconType = "document" | "spreadsheet" | "image";
+
+/** 根据文件名后缀或产物类型返回与文件/产物列表一致的图标资源路径 */
+export function getProjectFileIconSrc(fileName: string): string {
+	const lowerPath = fileName.toLowerCase();
+
+	if (lowerPath.endsWith(".jpg")) {
+		return "/assets/icons/file-picture-jpg.svg";
+	}
+	if (lowerPath.endsWith(".jpeg")) {
+		return "/assets/icons/file-picture-jpeg.svg";
+	}
+	if (lowerPath.endsWith(".png")) {
+		return "/assets/icons/file-picture-png.svg";
+	}
+	if (lowerPath.endsWith(".pdf")) {
+		return "/assets/icons/file-pdf.svg";
+	}
+
+	return "/assets/icons/file-text.svg";
+}
+
+/** 文件 Tab 与产物卡片共用的类型图标组件 */
+export function ProjectFileTypeIcon({
+	fileName,
+	artifactType,
+	className = "size-6 object-contain",
+}: {
+	fileName: string;
+	artifactType?: ProjectArtifactIconType;
+	className?: string;
+}) {
+	// 产物场景优先使用后端返回的类型，避免无扩展名时图标退化。
+	if (artifactType === "spreadsheet") {
+		return <Table2 className={className} aria-hidden="true" />;
+	}
+	if (artifactType === "image") {
+		return <ImageIcon className={className} aria-hidden="true" />;
+	}
+	if (artifactType === "document") {
+		return <FileText className={className} aria-hidden="true" />;
+	}
+
+	return (
+		<img src={getProjectFileIconSrc(fileName)} alt="" className={className} aria-hidden="true" />
+	);
+}
+
+/** 任务卡片左侧占位图标，先复用文档图标保证视觉统一 */
+export function TaskCardIcon({ className = "size-6 object-contain" }: { className?: string }) {
+	return <ProjectFileTypeIcon fileName="" className={className} />;
+}
+
+/** 右侧紧凑列表最多展示 5 条，超出后内部滚动并隐藏滚动条 */
+export const SIDEBAR_COMPACT_LIST_CLASS =
+	"max-h-[23rem] space-y-3 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden";


### PR DESCRIPTION
## 概要
- 抽出项目页与任务页共用的文件/产物图标组件，统一右侧列表样式
- 保留 ProjectPage 里的任务状态快捷切换，避免样式调整带出交互回归
- 产物图标优先按 artifact type 渲染，避免无扩展名时退化成普通文档图标

## 验证
- pnpm --dir frontend exec biome check packages/app-ui/components/layout/ProjectPage.tsx packages/app-ui/components/layout/TaskDetailPage.tsx packages/app-ui/components/layout/project-file-type-icon.tsx
