### PR TITLE
fix(frontend): 统一发送与换行快捷键

### DIFF
--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -269,7 +269,15 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 				</div>
 				{isProjectVariant && (
 					<div className="mt-3 text-center text-xs text-slate-500">
-						按 <kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">⌘</kbd> +{" "}
+						按{" "}
+						<kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">Enter</kbd>{" "}
+						发送，按{" "}
+						<kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">Shift</kbd>{" "}
+						+{" "}
+						<kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">Enter</kbd>{" "}
+						换行，也支持{" "}
+						<kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">Ctrl</kbd>/
+						<kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">⌘</kbd> +{" "}
 						<kbd className="rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5">Enter</kbd>{" "}
 						发送
 					</div>

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -543,7 +543,8 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					}
 				}
 
-				const submitByEnter = !isProjectVariant && event.key === "Enter" && !event.shiftKey;
+				const submitByEnter = event.key === "Enter" && !event.shiftKey;
+				// 项目态保留 Ctrl/Cmd + Enter 作为兼容发送快捷键，避免老用户肌肉记忆突然失效。
 				const submitByShortcut =
 					isProjectVariant && event.key === "Enter" && (event.metaKey || event.ctrlKey);
 				if (submitByEnter || submitByShortcut) {


### PR DESCRIPTION
## 变更说明
- 统一项目页/任务详情页与工作台的输入快捷键行为为 Enter 发送、Shift+Enter 换行
- 保留项目态 Ctrl/Cmd+Enter 发送，兼容已有用户习惯
- 同步更新项目态输入框底部快捷键提示文案

## 验证
- pnpm exec biome check packages/app-ui/components/input/StructuredComposer.tsx packages/app-ui/components/input/ChatInput.tsx
