### PR TITLE
fix(workspace): 修正 Server 侧 Worker workspace 路径解析

### DIFF
--- a/backend/internal/workspace/server_paths.go
+++ b/backend/internal/workspace/server_paths.go
@@ -10,7 +10,8 @@ import (
 )
 
 // WorkerMountedWorkspacePath 返回 server 视角下某个 worker 的 workspace 挂载目录。
-// storageKey 已经是相对于 workspaceRoot 的路径，因此直接返回根目录即可。
+// Server 挂载的是 workspace 根目录，单个 Worker 的实际目录位于
+// {workspaceRoot}/{orgID}/{workerID}/workspace。
 func WorkerMountedWorkspacePath(orgID uint, workerID uint) (string, error) {
 	if orgID == 0 {
 		return "", fmt.Errorf("org_id is required")
@@ -22,11 +23,12 @@ func WorkerMountedWorkspacePath(orgID uint, workerID uint) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Abs(root)
+	workspacePath := filepath.Join(root, fmt.Sprintf("%d", orgID), fmt.Sprintf("%d", workerID), "workspace")
+	return filepath.Abs(workspacePath)
 }
 
 // ProjectRepoPath 返回项目 repo 在 worker workspace 下的绝对路径。
-// 路径格式：{workspaceRoot}/projects/{orgID}/{publicID}/repo
+// 路径格式：{workspaceRoot}/{orgID}/{workerID}/workspace/projects/{orgID}/{publicID}/repo
 func ProjectRepoPath(orgID uint, workerID uint, publicID string) (string, error) {
 	workspacePath, err := WorkerMountedWorkspacePath(orgID, workerID)
 	if err != nil {

--- a/backend/internal/workspace/server_paths_test.go
+++ b/backend/internal/workspace/server_paths_test.go
@@ -16,7 +16,7 @@ func TestWorkerMountedWorkspacePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WorkerMountedWorkspacePath failed: %v", err)
 	}
-	want := serverRoot
+	want := filepath.Join(serverRoot, "1", "1", "workspace")
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
@@ -34,7 +34,7 @@ func TestArtifactStoragePathResolvesUnderWorkerWorkspace(t *testing.T) {
 	t.Setenv(leros.EnvWorkspaceRoot, serverRoot)
 
 	storageKey := filepath.Join("projects", "1", "project_1", "repo", "result.txt")
-	absolutePath := filepath.Join(serverRoot, storageKey)
+	absolutePath := filepath.Join(serverRoot, "1", "1", "workspace", storageKey)
 	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
 		t.Fatalf("failed to create artifact directory: %v", err)
 	}


### PR DESCRIPTION
将 Server 侧 WorkerMountedWorkspacePath 从直接返回 workspace_root， 调整为解析到 {workspace_root}/{org_id}/{worker_id}/workspace。

该修复匹配 k3s hostPath 部署结构，避免 Server 在持久化产物时错误查找
/leros-workspaces/projects/...，导致无法读取 Worker 实际生成在 /leros-workspaces/{org_id}/{worker_id}/workspace/projects/... 下的文件。