### PR TITLE
fix(chat): 修复会话附件展示与预览

### DIFF
--- a/backend/internal/service/message_poster.go
+++ b/backend/internal/service/message_poster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/insmtx/Leros/backend/internal/api/auth"
 	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/infra/db"
+	"github.com/insmtx/Leros/backend/internal/infra/filestore"
 	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
 	"github.com/insmtx/Leros/backend/internal/worker/protocol"
 	"github.com/insmtx/Leros/backend/pkg/dm"
@@ -120,6 +121,9 @@ func (p *MessagePoster) RunNewMessage(
 		return nil, err
 	}
 
+	// 先补齐附件的可访问 URL，再把附件写入用户消息，避免前端回显和后续上下文拿不到附件信息。
+	p.resolveAttachmentURLs(ctx, caller.OrgID, req.Attachments)
+
 	message, err := p.PostMessage(ctx, o.taskSession, func(sequence int64) *types.SessionMessage {
 		msgType := req.MessageType
 		if msgType == "" {
@@ -129,6 +133,7 @@ func (p *MessagePoster) RunNewMessage(
 			Role:        string(types.MessageRoleUser),
 			Content:     req.Content,
 			MessageType: msgType,
+			Attachments: req.Attachments,
 			Status:      string(types.MessageStatusPending),
 			Sequence:    sequence,
 			Timestamp:   time.Now().UnixMilli(),
@@ -438,6 +443,36 @@ func convertMessageToProtocolAttachments(attachments types.MessageAttachmentSlic
 		})
 	}
 	return result
+}
+
+func (p *MessagePoster) resolveAttachmentURLs(
+	ctx context.Context,
+	orgID uint,
+	attachments []types.MessageAttachment,
+) {
+	if len(attachments) == 0 {
+		return
+	}
+	for i := range attachments {
+		if attachments[i].FileUploadID == "" {
+			continue
+		}
+		fileUpload, err := db.GetFileUploadByPublicID(ctx, p.db, orgID, attachments[i].FileUploadID)
+		if err != nil {
+			logs.WarnContextf(ctx, "resolve attachment file %s: %v", attachments[i].FileUploadID, err)
+			continue
+		}
+		if fileUpload == nil {
+			logs.WarnContextf(ctx, "resolve attachment file %s: not found", attachments[i].FileUploadID)
+			continue
+		}
+		publicURL, err := filestore.ResolvePublicURL(ctx, fileUpload.StoragePath)
+		if err != nil {
+			logs.WarnContextf(ctx, "resolve attachment public url for %s: %v", attachments[i].FileUploadID, err)
+			continue
+		}
+		attachments[i].PublicURL = publicURL
+	}
 }
 
 func (p *MessagePoster) resolveWorkspaceIDs(ctx context.Context, session *types.Session) (string, string, error) {

--- a/frontend/packages/app-ui/components/chat/MessageAttachmentPreviewDialog.tsx
+++ b/frontend/packages/app-ui/components/chat/MessageAttachmentPreviewDialog.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { fetchFileDownload } from "@leros/store";
+import type { MessageAttachment } from "@leros/store/types/chat";
+import { Button } from "@leros/ui/components/ui/button";
+import {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+} from "@leros/ui/components/ui/sheet";
+import { Download, FileText, LoaderCircle, X } from "lucide-react";
+import { type ComponentType, type CSSProperties, useEffect, useMemo, useState } from "react";
+import { MarkdownRenderer } from "../common/MarkdownRenderer";
+import { ProjectFileTypeIcon } from "../layout/project-file-type-icon";
+import { SpreadsheetPreview } from "../layout/SpreadsheetPreview";
+
+type PreviewKind = "docx" | "spreadsheet" | "markdown" | "text" | "image" | "pdf" | "unsupported";
+
+type PreviewState =
+	| { status: "idle" }
+	| { status: "loading" }
+	| { status: "ready"; text?: string; objectUrl?: string; buffer?: ArrayBuffer }
+	| { status: "error"; message: string };
+
+type DocxEditorComponent = ComponentType<{
+	documentBuffer?: ArrayBuffer | null;
+	mode?: "editing" | "suggesting" | "viewing";
+	readOnly?: boolean;
+	showToolbar?: boolean;
+	showZoomControl?: boolean;
+	showRuler?: boolean;
+	showOutline?: boolean;
+	showOutlineButton?: boolean;
+	disableFindReplaceShortcuts?: boolean;
+	initialZoom?: number;
+	className?: string;
+	style?: CSSProperties;
+	documentName?: string;
+	documentNameEditable?: boolean;
+	loadingIndicator?: React.ReactNode;
+	onError?: (error: Error) => void;
+}>;
+
+let docxEditorComponent: DocxEditorComponent | null = null;
+let docxEditorPromise: Promise<DocxEditorComponent> | null = null;
+
+function loadDocxEditor(): Promise<DocxEditorComponent> {
+	if (docxEditorComponent) return Promise.resolve(docxEditorComponent);
+	docxEditorPromise ??= import("@eigenpal/docx-editor-react").then((module) => {
+		docxEditorComponent = module.DocxEditor as DocxEditorComponent;
+		return docxEditorComponent;
+	});
+	return docxEditorPromise;
+}
+
+export function MessageAttachmentPreviewDialog({
+	attachment,
+	open,
+	onOpenChange,
+}: {
+	attachment: MessageAttachment | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const [preview, setPreview] = useState<PreviewState>({ status: "idle" });
+	const previewKind = useMemo(() => getPreviewKind(attachment), [attachment]);
+
+	useEffect(() => {
+		if (!open || !attachment) {
+			setPreview({ status: "idle" });
+			return;
+		}
+
+		if (previewKind === "unsupported") {
+			setPreview({ status: "ready" });
+			return;
+		}
+
+		let cancelled = false;
+		let objectUrl: string | undefined;
+		const controller = new AbortController();
+
+		async function loadPreview() {
+			setPreview({ status: "loading" });
+			try {
+				const currentAttachment = attachment;
+				if (!currentAttachment) return;
+
+				const response = await fetchAttachmentContent(currentAttachment, {
+					signal: controller.signal,
+				});
+
+				if (previewKind === "markdown" || previewKind === "text") {
+					const text = await response.text();
+					if (!cancelled) setPreview({ status: "ready", text });
+					return;
+				}
+
+				// Word / 表格预览需要直接消费二进制内容，不能只转 blob URL。
+				if (previewKind === "docx" || previewKind === "spreadsheet") {
+					const buffer = await response.arrayBuffer();
+					if (!cancelled) setPreview({ status: "ready", buffer });
+					return;
+				}
+
+				const blob = await response.blob();
+				objectUrl = URL.createObjectURL(blob);
+				if (!cancelled) setPreview({ status: "ready", objectUrl });
+			} catch (err) {
+				if (cancelled || controller.signal.aborted) return;
+				const message = err instanceof Error ? err.message : "Failed to load preview";
+				setPreview({ status: "error", message });
+			}
+		}
+
+		loadPreview();
+
+		return () => {
+			cancelled = true;
+			controller.abort();
+			if (objectUrl) URL.revokeObjectURL(objectUrl);
+		};
+	}, [attachment, open, previewKind]);
+
+	const handleDownload = async () => {
+		if (!attachment) return;
+		try {
+			const response = await fetchAttachmentContent(attachment);
+			const blob = await response.blob();
+			const objectUrl = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = objectUrl;
+			link.download = attachment.name;
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+			window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+		} catch (err) {
+			console.error("Failed to download attachment", err);
+		}
+	};
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent
+				side="right"
+				showCloseButton={false}
+				className="inset-y-4 right-4 h-auto w-[calc(100vw-2rem)] gap-0 overflow-hidden rounded-2xl border border-[var(--leros-control-border)] bg-[var(--leros-surface)] p-0 shadow-2xl sm:max-w-none md:w-[min(48vw,980px)]"
+			>
+				{attachment && (
+					<>
+						<SheetHeader className="flex-row items-center gap-3 border-b border-[var(--leros-control-border)] px-5 py-4">
+							<div className="flex size-7 shrink-0 items-center justify-center rounded-md text-[var(--leros-text-muted)]">
+								<ProjectFileTypeIcon fileName={attachment.name} className="size-4 object-contain" />
+							</div>
+							<div className="h-5 w-px shrink-0 bg-[var(--leros-control-border)]" />
+							<div className="min-w-0 flex-1">
+								<SheetTitle className="truncate text-sm font-medium text-[var(--leros-text-muted)]">
+									{attachment.name}
+								</SheetTitle>
+								<SheetDescription className="sr-only">
+									{attachment.name} attachment preview
+								</SheetDescription>
+							</div>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onClick={handleDownload}
+								title="Download"
+								className="shrink-0 text-[var(--leros-text)]"
+							>
+								<Download className="size-4" />
+							</Button>
+							<SheetClose
+								render={
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										title="Close"
+										className="shrink-0 text-[var(--leros-text)]"
+									/>
+								}
+							>
+								<X className="size-4" />
+							</SheetClose>
+						</SheetHeader>
+						<div className="min-h-0 flex-1 overflow-hidden bg-[#f6f7fb]">
+							<AttachmentPreviewBody
+								attachment={attachment}
+								previewKind={previewKind}
+								preview={preview}
+							/>
+						</div>
+					</>
+				)}
+			</SheetContent>
+		</Sheet>
+	);
+}
+
+async function fetchAttachmentContent(
+	attachment: MessageAttachment,
+	options?: { signal?: AbortSignal },
+): Promise<Response> {
+	if (attachment.url?.startsWith("blob:")) {
+		return fetch(attachment.url, { signal: options?.signal });
+	}
+	if (attachment.fileUploadId) {
+		return fetchFileDownload(attachment.fileUploadId, options);
+	}
+	if (attachment.url) {
+		return fetch(attachment.url, { signal: options?.signal });
+	}
+	throw new Error("Attachment has no preview source");
+}
+
+function getPreviewKind(attachment: MessageAttachment | null): PreviewKind {
+	if (!attachment) return "unsupported";
+	const mimeType = attachment.mimeType.toLowerCase();
+	const name = attachment.name.toLowerCase();
+
+	if (
+		mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+		name.endsWith(".docx")
+	) {
+		return "docx";
+	}
+	if (
+		mimeType.includes("spreadsheet") ||
+		mimeType.includes("excel") ||
+		mimeType === "text/csv" ||
+		name.endsWith(".xlsx") ||
+		name.endsWith(".xls") ||
+		name.endsWith(".csv")
+	) {
+		return "spreadsheet";
+	}
+	if (mimeType.startsWith("image/")) return "image";
+	if (mimeType.includes("pdf") || name.endsWith(".pdf")) return "pdf";
+	if (mimeType.includes("markdown") || name.endsWith(".md") || name.endsWith(".markdown")) {
+		return "markdown";
+	}
+	if (
+		mimeType.startsWith("text/") ||
+		mimeType.includes("json") ||
+		name.endsWith(".txt") ||
+		name.endsWith(".json") ||
+		name.endsWith(".yaml") ||
+		name.endsWith(".yml") ||
+		name.endsWith(".log")
+	) {
+		return "text";
+	}
+	return "unsupported";
+}
+
+function AttachmentPreviewBody({
+	attachment,
+	previewKind,
+	preview,
+}: {
+	attachment: MessageAttachment;
+	previewKind: PreviewKind;
+	preview: PreviewState;
+}) {
+	if (preview.status === "loading" || preview.status === "idle") {
+		return (
+			<div className="flex h-full items-center justify-center text-[var(--leros-text-muted)]">
+				<LoaderCircle className="mr-2 size-4 animate-spin" />
+				Loading preview
+			</div>
+		);
+	}
+
+	if (preview.status === "error") {
+		return (
+			<div className="flex h-full items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
+				<div>
+					<p>Unable to load preview</p>
+					<p className="mt-1 text-xs">{preview.message}</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (preview.status !== "ready") {
+		return null;
+	}
+
+	if (previewKind === "docx" && preview.buffer) {
+		return <DocxPreview attachment={attachment} buffer={preview.buffer} />;
+	}
+
+	if (previewKind === "spreadsheet" && preview.buffer) {
+		return <SpreadsheetPreview buffer={preview.buffer} fileName={attachment.name} />;
+	}
+
+	if (previewKind === "markdown") {
+		return (
+			<div className="h-full overflow-auto bg-[var(--leros-surface)] px-8 py-7">
+				<MarkdownRenderer
+					content={preview.text ?? ""}
+					className="prose prose-slate prose-sm max-w-none prose-headings:text-[var(--leros-text-strong)] prose-p:leading-7 prose-pre:rounded-lg prose-pre:bg-slate-950"
+				/>
+			</div>
+		);
+	}
+
+	if (previewKind === "text") {
+		return (
+			<pre className="h-full overflow-auto whitespace-pre-wrap break-words bg-[var(--leros-surface)] px-8 py-7 font-mono text-sm leading-6 text-[var(--leros-text-strong)]">
+				{preview.text ?? ""}
+			</pre>
+		);
+	}
+
+	if (previewKind === "image" && preview.objectUrl) {
+		return (
+			<div className="flex h-full items-center justify-center overflow-auto p-6">
+				<img
+					src={preview.objectUrl}
+					alt={attachment.name}
+					className="max-h-full max-w-full rounded-xl object-contain shadow-lg"
+				/>
+			</div>
+		);
+	}
+
+	if (previewKind === "pdf" && preview.objectUrl) {
+		return (
+			<iframe
+				title={attachment.name}
+				src={preview.objectUrl}
+				className="h-full w-full border-0 bg-white"
+			/>
+		);
+	}
+
+	return (
+		<div className="flex h-full items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
+			<div>
+				<FileText className="mx-auto mb-3 size-10 text-slate-300" />
+				<p>This attachment type cannot be previewed yet</p>
+			</div>
+		</div>
+	);
+}
+
+function DocxPreview({
+	attachment,
+	buffer,
+}: {
+	attachment: MessageAttachment;
+	buffer: ArrayBuffer;
+}) {
+	const [DocxEditor, setDocxEditor] = useState<DocxEditorComponent | null>(docxEditorComponent);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setError(null);
+
+		loadDocxEditor()
+			.then((component) => {
+				if (!cancelled) setDocxEditor(() => component);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				setError(err instanceof Error ? err.message : "Failed to load DOCX preview");
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (error) {
+		return (
+			<div className="flex h-full items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
+				<div>
+					<p>Unable to load DOCX preview</p>
+					<p className="mt-1 text-xs">{error}</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!DocxEditor) {
+		return (
+			<div className="flex h-full items-center justify-center text-[var(--leros-text-muted)]">
+				<LoaderCircle className="mr-2 size-4 animate-spin" />
+				Preparing DOCX preview
+			</div>
+		);
+	}
+
+	return (
+		<div className="h-full overflow-hidden">
+			<DocxEditor
+				key={attachment.fileUploadId || attachment.url || attachment.name}
+				documentBuffer={buffer}
+				mode="viewing"
+				readOnly
+				showToolbar={false}
+				showZoomControl={false}
+				showRuler={false}
+				showOutline={false}
+				showOutlineButton={false}
+				disableFindReplaceShortcuts
+				initialZoom={0.82}
+				documentName={attachment.name}
+				documentNameEditable={false}
+				className="leros-docx-preview h-full"
+				style={{ height: "100%", background: "#f6f7fb" }}
+				loadingIndicator={
+					<div className="flex h-full items-center justify-center text-[var(--leros-text-muted)]">
+						<LoaderCircle className="mr-2 size-4 animate-spin" />
+						Rendering DOCX
+					</div>
+				}
+				onError={(err) => setError(err.message)}
+			/>
+		</div>
+	);
+}

--- a/frontend/packages/app-ui/components/chat/UserMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/UserMessageBubble.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { formatTime } from "@leros/store";
-import type { Message } from "@leros/store/types/chat";
+import { fetchFileDownload, formatFileSize, formatTime } from "@leros/store";
+import type { Message, MessageAttachment } from "@leros/store/types/chat";
 import { Button } from "@leros/ui/components/ui/button";
-import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { Check, Copy, ImageIcon, LoaderCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ProjectFileTypeIcon } from "../layout/project-file-type-icon";
+import { MessageAttachmentPreviewDialog } from "./MessageAttachmentPreviewDialog";
 
 function CopyButton({ text }: { text: string }) {
 	const [copied, setCopied] = useState(false);
@@ -30,18 +32,175 @@ function CopyButton({ text }: { text: string }) {
 }
 
 export function UserMessageBubble({ message }: { message: Message }) {
+	const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
+	const visibleText = message.content.trim();
+	const attachments = message.attachments ?? [];
+
 	return (
-		<div data-slot="user-message" className="flex justify-end group">
-			<div className="flex max-w-[min(720px,78%)] flex-col items-end">
-				<div className="mb-1.5 flex items-center gap-2">
-					<CopyButton text={message.content} />
-					<span className="text-xs text-slate-400">{formatTime(message.timestamp)}</span>
-					<span className="text-xs font-medium text-slate-500">你</span>
-				</div>
-				<div className="w-fit rounded-2xl rounded-tr-md bg-blue-600 px-4 py-3 text-sm leading-7 text-white shadow-sm shadow-blue-600/10">
-					{message.content}
+		<>
+			<div data-slot="user-message" className="flex justify-end group">
+				<div className="flex max-w-[min(720px,78%)] flex-col items-end">
+					<div className="mb-1.5 flex items-center gap-2">
+						{visibleText && <CopyButton text={message.content} />}
+						<span className="text-xs text-slate-400">{formatTime(message.timestamp)}</span>
+						<span className="text-xs font-medium text-slate-500">你</span>
+					</div>
+					{attachments.length > 0 && (
+						<div className="mb-2 flex flex-col items-end gap-2">
+							{attachments.map((attachment) =>
+								attachment.mimeType.startsWith("image/") ? (
+									<ImageAttachmentCard
+										key={attachment.id}
+										attachment={attachment}
+										onClick={() => setPreviewAttachment(attachment)}
+									/>
+								) : (
+									<FileAttachmentCard
+										key={attachment.id}
+										attachment={attachment}
+										onClick={() => setPreviewAttachment(attachment)}
+									/>
+								),
+							)}
+						</div>
+					)}
+					{visibleText && (
+						<div className="w-fit rounded-2xl rounded-tr-md bg-blue-600 px-4 py-3 text-sm leading-7 text-white shadow-sm shadow-blue-600/10">
+							{message.content}
+						</div>
+					)}
 				</div>
 			</div>
+			<MessageAttachmentPreviewDialog
+				attachment={previewAttachment}
+				open={previewAttachment !== null}
+				onOpenChange={(open) => {
+					if (!open) setPreviewAttachment(null);
+				}}
+			/>
+		</>
+	);
+}
+
+function ImageAttachmentCard({
+	attachment,
+	onClick,
+}: {
+	attachment: MessageAttachment;
+	onClick: () => void;
+}) {
+	const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(
+		isInlinePreviewableUrl(attachment.url) ? (attachment.url ?? null) : null,
+	);
+	const [thumbnailLoading, setThumbnailLoading] = useState(false);
+
+	useEffect(() => {
+		if (attachment.url && isInlinePreviewableUrl(attachment.url)) {
+			setThumbnailUrl(attachment.url);
+			return;
+		}
+		if (!attachment.fileUploadId) {
+			setThumbnailUrl(null);
+			return;
+		}
+
+		let cancelled = false;
+		let objectUrl: string | null = null;
+
+		// 历史消息中的图片补拉一次 blob 生成缩略图，避免只剩存储路径时消息区展示不出来。
+		async function loadThumbnail() {
+			setThumbnailLoading(true);
+			try {
+				const response = await fetchFileDownload(attachment.fileUploadId);
+				const blob = await response.blob();
+				objectUrl = URL.createObjectURL(blob);
+				if (!cancelled) setThumbnailUrl(objectUrl);
+			} catch (error) {
+				if (!cancelled) {
+					console.error("Load user attachment thumbnail error:", error);
+					setThumbnailUrl(null);
+				}
+			} finally {
+				if (!cancelled) setThumbnailLoading(false);
+			}
+		}
+
+		void loadThumbnail();
+
+		return () => {
+			cancelled = true;
+			if (objectUrl) URL.revokeObjectURL(objectUrl);
+		};
+	}, [attachment.fileUploadId, attachment.url]);
+
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="group/attachment relative size-[92px] overflow-hidden rounded-2xl border border-blue-200/70 bg-white shadow-sm transition-colors hover:border-blue-300"
+			title={attachment.name}
+		>
+			{thumbnailUrl ? (
+				<img src={thumbnailUrl} alt={attachment.name} className="h-full w-full object-cover" />
+			) : (
+				<div className="flex h-full w-full items-center justify-center bg-slate-100 text-slate-400">
+					{thumbnailLoading ? (
+						<LoaderCircle className="size-5 animate-spin" />
+					) : (
+						<ImageIcon className="size-6" />
+					)}
+				</div>
+			)}
+			<AttachmentHoverMask />
+		</button>
+	);
+}
+
+function FileAttachmentCard({
+	attachment,
+	onClick,
+}: {
+	attachment: MessageAttachment;
+	onClick: () => void;
+}) {
+	const sizeText = attachment.size > 0 ? formatFileSize(attachment.size) : "";
+
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="group/attachment relative flex w-[260px] min-w-0 items-center gap-3 overflow-hidden rounded-xl border border-slate-200/70 bg-white/90 px-3.5 py-3 text-left shadow-sm transition-colors hover:border-blue-200 hover:bg-blue-50/60"
+			title={attachment.name}
+		>
+			<AttachmentHoverMask />
+			<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
+				<ProjectFileTypeIcon fileName={attachment.name} />
+			</div>
+			<div className="min-w-0">
+				<div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">
+					{attachment.name}
+				</div>
+				{sizeText ? (
+					<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
+						{sizeText}
+					</div>
+				) : null}
+			</div>
+		</button>
+	);
+}
+
+function AttachmentHoverMask() {
+	return (
+		<div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover/attachment:opacity-100">
+			<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
+				点击预览
+			</span>
 		</div>
 	);
+}
+
+function isInlinePreviewableUrl(url?: string): boolean {
+	if (!url) return false;
+	return url.startsWith("blob:") || url.startsWith("data:") || /^https?:\/\//.test(url);
 }

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -57,7 +57,8 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 	const pendingApproval = findPendingApproval(messageIds, messagesMap, activeSessionId);
 
 	const submitMessage = useCallback(() => {
-		if (inputText.trim() || inputAttachments.length > 0) {
+		// 仅上传附件而无文字时接口会报错，因此必须输入内容才可发送
+		if (inputText.trim()) {
 			if (isProjectVariant && currentView === "project") {
 				sendProjectMessage(inputText, activeProjectId, inputAttachments);
 			} else {
@@ -259,7 +260,7 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 										isProjectVariant && "size-11 min-w-0 rounded-2xl",
 									)}
 									onClick={handleSend}
-									disabled={!inputText.trim() && inputAttachments.length === 0}
+									disabled={!inputText.trim()}
 								>
 									<SendHorizonal className={cn("size-4", !isProjectVariant && "mr-1")} />
 									{!isProjectVariant && "发送"}

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -59,7 +59,7 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 	const submitMessage = useCallback(() => {
 		if (inputText.trim() || inputAttachments.length > 0) {
 			if (isProjectVariant && currentView === "project") {
-				sendProjectMessage(inputText, activeProjectId);
+				sendProjectMessage(inputText, activeProjectId, inputAttachments);
 			} else {
 				sendMessage(inputText, inputAttachments);
 			}

--- a/frontend/packages/store/api/types.ts
+++ b/frontend/packages/store/api/types.ts
@@ -59,7 +59,18 @@ export type BackendMessage = {
 	};
 	chunks?: BackendMessageChunk[];
 	artifacts?: BackendSessionArtifactPayload[];
+	attachments?: BackendMessageAttachment[];
 	created_at: string;
+};
+
+export type BackendMessageAttachment = {
+	file_upload_id?: string;
+	name?: string;
+	mime_type?: string;
+	size?: number;
+	purpose?: string;
+	PublicURL?: string;
+	public_url?: string;
 };
 
 export type BackendSessionEvent = {

--- a/frontend/packages/store/api/workApi.ts
+++ b/frontend/packages/store/api/workApi.ts
@@ -7,6 +7,11 @@ export type NewMessageParams = {
 	task_id?: string;
 	message_type?: string;
 	assistant_id?: number;
+	attachments?: {
+		file_upload_id: string;
+		name: string;
+		mime_type: string;
+	}[];
 };
 
 const WORK_ENDPOINTS = {

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -72,6 +72,7 @@ export type {
 	Attachment,
 	Message,
 	MessageArtifact,
+	MessageAttachment,
 	MessageMetadata,
 	MessageRole,
 	MessageUsage,

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -867,7 +867,8 @@ export class ChatActionImpl {
 	};
 
 	sendMessage = async (content: string, attachments?: Attachment[]) => {
-		if (!content.trim() && !attachments?.length) return;
+		// 仅上传附件而无文字时后端会报错，必须要求有文本内容
+		if (!content.trim()) return;
 
 		const state = this.#get();
 		let { activeSessionId } = state;

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -6,6 +6,7 @@ import type {
 	BackendApprovalDecisionPayload,
 	BackendApprovalRequestPayload,
 	BackendMessage,
+	BackendMessageAttachment,
 	BackendMessageChunk,
 	BackendRuntimeTodoItem,
 	BackendSessionArtifactPayload,
@@ -22,6 +23,7 @@ import type {
 	Attachment,
 	Message,
 	MessageArtifact,
+	MessageAttachment,
 	MessageMetadata,
 	MessageRole,
 	MessageUsage,
@@ -109,7 +111,65 @@ function mapBackendMessage(msg: BackendMessage): Message {
 			mapped = { ...mapped, artifacts: mergeArtifacts(mapped.artifacts, artifacts) };
 		}
 	}
+	if (msg.attachments?.length) {
+		const attachments = msg.attachments
+			.map(mapBackendAttachment)
+			.filter((attachment): attachment is MessageAttachment => attachment !== undefined);
+		if (attachments.length) {
+			mapped = { ...mapped, attachments };
+		}
+	}
 	return enrichAssistantMessageMetrics(mapped);
+}
+
+function mapBackendAttachment(attachment: BackendMessageAttachment): MessageAttachment | undefined {
+	const fileUploadId = attachment.file_upload_id?.trim();
+	if (!fileUploadId) return undefined;
+
+	return {
+		id: fileUploadId,
+		fileUploadId,
+		name: attachment.name?.trim() || fileUploadId,
+		mimeType: attachment.mime_type?.trim() || "application/octet-stream",
+		size: attachment.size ?? 0,
+		url: attachment.PublicURL?.trim() || attachment.public_url?.trim() || undefined,
+	};
+}
+
+function mapComposerAttachment(attachment: Attachment): MessageAttachment | undefined {
+	const fileUploadId = attachment.fileUploadId?.trim();
+	if (!fileUploadId) return undefined;
+
+	return {
+		id: attachment.id,
+		fileUploadId,
+		name: attachment.name,
+		mimeType: attachment.mimeType || attachment.file?.type || "application/octet-stream",
+		size: attachment.size,
+		url: attachment.url,
+	};
+}
+
+function mapComposerAttachments(attachments?: Attachment[]): MessageAttachment[] | undefined {
+	const mapped = attachments
+		?.map(mapComposerAttachment)
+		.filter((attachment): attachment is MessageAttachment => attachment !== undefined);
+	return mapped?.length ? mapped : undefined;
+}
+
+function mapOutgoingAttachments(
+	attachments?: Attachment[],
+): Array<{ file_upload_id: string; name: string; mime_type: string }> | undefined {
+	const mapped = attachments
+		?.filter((attachment): attachment is Attachment & { fileUploadId: string } =>
+			Boolean(attachment.fileUploadId?.trim()),
+		)
+		.map((attachment) => ({
+			file_upload_id: attachment.fileUploadId.trim(),
+			name: attachment.name,
+			mime_type: attachment.mimeType || attachment.file?.type || "application/octet-stream",
+		}));
+	return mapped?.length ? mapped : undefined;
 }
 
 function mapToolCalls(tcList?: BackendToolCall[]): ToolCall[] | undefined {
@@ -638,13 +698,61 @@ function countMatchingMessages(messages: Message[], target: Message, targetIndex
 	return count;
 }
 
+function countMessagesByRole(messages: Message[], role: MessageRole, targetIndex?: number): number {
+	let count = 0;
+	const end = targetIndex ?? messages.length - 1;
+	for (let index = 0; index <= end; index += 1) {
+		if (messages[index]?.role === role) {
+			count += 1;
+		}
+	}
+	return count;
+}
+
+function findMessageByRoleOccurrence(
+	messages: Message[],
+	role: MessageRole,
+	occurrence: number,
+): Message | undefined {
+	if (occurrence <= 0) return undefined;
+
+	let count = 0;
+	for (const message of messages) {
+		if (message.role !== role) continue;
+		count += 1;
+		if (count === occurrence) {
+			return message;
+		}
+	}
+	return undefined;
+}
+
+function findPersistedMessageMatch(
+	persistedMessages: Message[],
+	localMessages: Message[],
+	localMessage: Message,
+	localIndex?: number,
+): Message | undefined {
+	const exactMatch = persistedMessages.find((message) => message.id === localMessage.id);
+	if (exactMatch) return exactMatch;
+
+	if (!isOptimisticMessage(localMessage)) return undefined;
+
+	// 中文注释：流式阶段的 optimistic 消息和落库消息 id 不同，这里按同角色出现顺序兜底配对，
+	// 避免 markdown/空白字符略有差异时把同一轮回复渲染成两条。
+	const roleOccurrence = countMessagesByRole(localMessages, localMessage.role, localIndex);
+	return findMessageByRoleOccurrence(persistedMessages, localMessage.role, roleOccurrence);
+}
+
 function shouldKeepLocalMessage(
 	persistedMessages: Message[],
 	localMessages: Message[],
 	localMessage: Message,
 	localIndex: number,
 ): boolean {
-	if (persistedMessages.some((message) => message.id === localMessage.id)) return false;
+	if (findPersistedMessageMatch(persistedMessages, localMessages, localMessage, localIndex)) {
+		return false;
+	}
 	if (!isOptimisticMessage(localMessage)) return true;
 	if (!messageMergeKey(localMessage)) return true;
 
@@ -660,10 +768,69 @@ function compareMessages(a: Message, b: Message): number {
 	return a.timestamp - b.timestamp;
 }
 
+function mergeMessageAttachments(
+	persistedAttachments: MessageAttachment[] | undefined,
+	localAttachments: MessageAttachment[] | undefined,
+): MessageAttachment[] | undefined {
+	if (!persistedAttachments?.length) return persistedAttachments;
+	if (!localAttachments?.length) return persistedAttachments;
+
+	const localByUploadId = new Map(
+		localAttachments.map((attachment) => [attachment.fileUploadId, attachment] as const),
+	);
+
+	return persistedAttachments.map((attachment) => {
+		const localAttachment = localByUploadId.get(attachment.fileUploadId);
+		if (!localAttachment?.url?.startsWith("blob:")) return attachment;
+		return {
+			...attachment,
+			url: localAttachment.url,
+			size: attachment.size || localAttachment.size,
+		};
+	});
+}
+
+function reconcilePersistedMessagesWithLocal(
+	persistedMessages: Message[],
+	localMessages: Message[],
+): Message[] {
+	return persistedMessages.map((persistedMessage, persistedIndex) => {
+		const roleOccurrence = countMessagesByRole(
+			persistedMessages,
+			persistedMessage.role,
+			persistedIndex,
+		);
+		const localMatch =
+			localMessages.find((localMessage) => localMessage.id === persistedMessage.id) ??
+			localMessages.find((localMessage) => {
+				if (localMessage.role !== persistedMessage.role) return false;
+				if (messageMergeKey(localMessage) !== messageMergeKey(persistedMessage)) return false;
+				return (
+					countMatchingMessages(localMessages, localMessage) ===
+					countMatchingMessages(persistedMessages, persistedMessage)
+				);
+			}) ??
+			findMessageByRoleOccurrence(localMessages, persistedMessage.role, roleOccurrence);
+
+		if (!localMatch?.attachments?.length || !persistedMessage.attachments?.length) {
+			return persistedMessage;
+		}
+
+		return {
+			...persistedMessage,
+			attachments: mergeMessageAttachments(persistedMessage.attachments, localMatch.attachments),
+		};
+	});
+}
+
 function mergeSessionMessages(persistedMessages: Message[], localMessages: Message[]): Message[] {
-	const merged = [...persistedMessages];
+	const reconciledPersistedMessages = reconcilePersistedMessagesWithLocal(
+		persistedMessages,
+		localMessages,
+	);
+	const merged = [...reconciledPersistedMessages];
 	localMessages.forEach((localMessage, index) => {
-		if (!shouldKeepLocalMessage(persistedMessages, localMessages, localMessage, index)) {
+		if (!shouldKeepLocalMessage(reconciledPersistedMessages, localMessages, localMessage, index)) {
 			return;
 		}
 		if (merged.some((message) => message.id === localMessage.id)) return;
@@ -743,15 +910,7 @@ export class ChatActionImpl {
 				role: "user",
 				content,
 				message_type: "text",
-				attachments: attachments
-					?.filter((attachment): attachment is Attachment & { fileUploadId: string } =>
-						Boolean(attachment.fileUploadId?.trim()),
-					)
-					.map((attachment) => ({
-						file_upload_id: attachment.fileUploadId.trim(),
-						name: attachment.name,
-						mime_type: attachment.mimeType || attachment.file?.type || "application/octet-stream",
-					})),
+				attachments: mapOutgoingAttachments(attachments),
 			});
 		} catch (err) {
 			console.error("sendMessage addMessage error:", err);
@@ -765,6 +924,7 @@ export class ChatActionImpl {
 			role: "user",
 			content,
 			timestamp: now,
+			attachments: mapComposerAttachments(attachments),
 		};
 
 		const assistantMsg: Message = {
@@ -787,12 +947,20 @@ export class ChatActionImpl {
 		this.#startSSE(activeSessionId, assistantMsg.id);
 	};
 
-	sendProjectMessage = async (content: string, projectId?: string | null) => {
+	sendProjectMessage = async (
+		content: string,
+		projectId?: string | null,
+		attachments?: Attachment[],
+	) => {
 		const trimmed = content.trim();
 		if (!trimmed || !projectId) return;
 
 		try {
-			const res = await workApi.newMessage({ content: trimmed, project_id: projectId });
+			const res = await workApi.newMessage({
+				content: trimmed,
+				project_id: projectId,
+				attachments: mapOutgoingAttachments(attachments),
+			});
 			const data = res.data.data;
 			if (!data?.project_id || !data?.task_id || !data?.session_id) return;
 
@@ -801,7 +969,7 @@ export class ChatActionImpl {
 				activeTaskDetailProjectId: data.project_id,
 				activeTaskDetailTaskId: data.task_id,
 				activeTaskDetailSessionId: data.session_id,
-				// 标记“刚创建并准备开流”的 session，避免切页 useEffect 先把旧历史覆盖进来。
+				// 先标记这个新 session 正在接管流式响应，避免切页副作用把旧消息列表提前刷回来。
 				pendingBootstrapSessionId: data.session_id,
 				currentView: "taskDetail",
 				activeProjectTab: "chat",
@@ -810,7 +978,7 @@ export class ChatActionImpl {
 				inputAttachments: [],
 			});
 
-			await this.startSessionResponseStream(data.session_id, trimmed);
+			await this.startSessionResponseStream(data.session_id, trimmed, attachments);
 
 			const fullState = this.#fullGet() as {
 				fetchProjectDetail?: (projectId: string) => Promise<void>;
@@ -821,7 +989,11 @@ export class ChatActionImpl {
 		}
 	};
 
-	startSessionResponseStream = async (sessionId: string, content: string) => {
+	startSessionResponseStream = async (
+		sessionId: string,
+		content: string,
+		attachments?: Attachment[],
+	) => {
 		const trimmed = content.trim();
 		if (!sessionId || !trimmed) return;
 
@@ -849,6 +1021,7 @@ export class ChatActionImpl {
 			role: "user",
 			content: trimmed,
 			timestamp: now,
+			attachments: mapComposerAttachments(attachments),
 		};
 		const assistantMsg: Message = {
 			id: `msg-assistant-${now}`,

--- a/frontend/packages/store/types/chat.ts
+++ b/frontend/packages/store/types/chat.ts
@@ -63,6 +63,15 @@ export type MessageUsage = {
 	totalTokens?: number;
 };
 
+export type MessageAttachment = {
+	id: string;
+	fileUploadId: string;
+	name: string;
+	mimeType: string;
+	size: number;
+	url?: string;
+};
+
 export type Message = {
 	id: string;
 	conversationId: string;
@@ -74,6 +83,7 @@ export type Message = {
 	todos?: RuntimeTodoItem[];
 	approvals?: ApprovalRequest[];
 	artifacts?: MessageArtifact[];
+	attachments?: MessageAttachment[];
 	thinking?: string;
 	metadata?: MessageMetadata;
 	usage?: MessageUsage;


### PR DESCRIPTION

## 变更说明
- 修复会话消息发送后附件在消息列表中丢失的问题，保留图片本地 blob 缩略图并兼容历史消息回填
- 为用户消息补充附件缩略图/文件卡片展示，支持点击预览，图片与非图片文件采用不同展示样式
- 为消息附件预览弹窗补齐图片、PDF、Markdown、文本、Word、表格文件的预览能力
- 补齐项目/任务问答链路的附件透传与消息持久化字段映射

## 验证
- pnpm exec biome check packages/store/slices/chatSlice.ts packages/app-ui/components/chat/MessageAttachmentPreviewDialog.tsx packages/app-ui/components/chat/UserMessageBubble.tsx packages/app-ui/components/input/ChatInput.tsx
- pnpm --filter @leros/web typecheck
