### PR TITLE
feat(workbench): 支持首页上传附件

### DIFF
--- a/backend/internal/service/message_poster.go
+++ b/backend/internal/service/message_poster.go
@@ -108,6 +108,8 @@ func (p *MessagePoster) RunNewMessage(
 		logs.ErrorContextf(ctx, "NewMessage resolveOrCreateProject failed: %v", err)
 		return nil, err
 	}
+	// 无项目预上传的附件，需要在项目创建完成后回填项目归属，确保后续文件树可见。
+	p.attachFilesToProject(ctx, caller.OrgID, o.project.PublicID, req.Attachments)
 	if err := o.ensureProjectSession(); err != nil {
 		logs.ErrorContextf(ctx, "NewMessage ensureProjectSession failed: %v", err)
 		return nil, err
@@ -472,6 +474,37 @@ func (p *MessagePoster) resolveAttachmentURLs(
 			continue
 		}
 		attachments[i].PublicURL = publicURL
+	}
+}
+
+func (p *MessagePoster) attachFilesToProject(
+	ctx context.Context,
+	orgID uint,
+	projectPublicID string,
+	attachments []types.MessageAttachment,
+) {
+	if strings.TrimSpace(projectPublicID) == "" || len(attachments) == 0 {
+		return
+	}
+	for i := range attachments {
+		if attachments[i].FileUploadID == "" {
+			continue
+		}
+		fileUpload, err := db.GetFileUploadByPublicID(ctx, p.db, orgID, attachments[i].FileUploadID)
+		if err != nil {
+			logs.WarnContextf(ctx, "attach file %s to project %s failed: %v", attachments[i].FileUploadID, projectPublicID, err)
+			continue
+		}
+		if fileUpload == nil {
+			continue
+		}
+		if fileUpload.Metadata.Extra == nil {
+			fileUpload.Metadata.Extra = make(map[string]interface{})
+		}
+		fileUpload.Metadata.Extra["project_public_id"] = projectPublicID
+		if err := db.UpdateFileUpload(ctx, p.db, fileUpload); err != nil {
+			logs.WarnContextf(ctx, "persist file %s project_public_id failed: %v", attachments[i].FileUploadID, err)
+		}
 	}
 }
 

--- a/backend/internal/service/session_service_test.go
+++ b/backend/internal/service/session_service_test.go
@@ -26,7 +26,16 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test database: %v", err)
 	}
 
-	if err := db.AutoMigrate(&types.Session{}, &types.SessionMessage{}, &types.Artifact{}, &types.LLMModel{}); err != nil {
+	if err := db.AutoMigrate(
+		&types.Project{},
+		&types.ProjectMember{},
+		&types.Task{},
+		&types.Session{},
+		&types.SessionMessage{},
+		&types.Artifact{},
+		&types.LLMModel{},
+		&types.FileUpload{},
+	); err != nil {
 		t.Fatalf("failed to migrate test database: %v", err)
 	}
 	if err := db.Create(&types.LLMModel{

--- a/backend/internal/service/work_service_test.go
+++ b/backend/internal/service/work_service_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	dbpkg "github.com/insmtx/Leros/backend/internal/infra/db"
+	"github.com/insmtx/Leros/backend/types"
+)
+
+func setupTestWorkService(t *testing.T) (*workService, *gorm.DB) {
+	t.Helper()
+	db := setupTestDB(t)
+	inferrer := &mockInferrer{assistantID: 1}
+	service := NewWorkService(db, &mockEventBus{}, inferrer)
+	typed, ok := service.(*workService)
+	if !ok {
+		t.Fatalf("expected *workService, got %T", service)
+	}
+	return typed, db
+}
+
+func TestWorkServiceNewMessage_PersistsAttachmentsOnFirstMessage(t *testing.T) {
+	service, database := setupTestWorkService(t)
+	ctx := setupTestContextWithCaller(t)
+
+	// 预先落一条 file_upload，模拟前端已完成项目文件上传。
+	fileUpload := &types.FileUpload{
+		PublicID:     "fu_test_attachment",
+		OrgID:        1,
+		OwnerID:      1,
+		Filename:     "spec.pdf",
+		OriginalName: "spec.pdf",
+		MimeType:     "application/pdf",
+		FileSize:     1024,
+		StoragePath:  "project-files/spec.pdf",
+		Purpose:      "project_file",
+		Status:       "active",
+	}
+	if err := dbpkg.CreateFileUpload(context.Background(), database, fileUpload); err != nil {
+		t.Fatalf("CreateFileUpload failed: %v", err)
+	}
+
+	req := &contract.NewMessageRequest{
+		Content: "请基于附件开始分析",
+		Attachments: []types.MessageAttachment{
+			{
+				FileUploadID: fileUpload.PublicID,
+				Name:         "spec.pdf",
+				MimeType:     "application/pdf",
+				Size:         1024,
+			},
+		},
+	}
+
+	resp, err := service.NewMessage(ctx, req)
+	if err != nil {
+		t.Fatalf("NewMessage failed: %v", err)
+	}
+
+	var session types.Session
+	if err := database.WithContext(context.Background()).
+		Where("public_id = ?", resp.SessionID).
+		First(&session).Error; err != nil {
+		t.Fatalf("load session failed: %v", err)
+	}
+
+	var message types.SessionMessage
+	if err := database.WithContext(context.Background()).
+		Where("session_id = ? AND sequence = ?", session.ID, 1).
+		First(&message).Error; err != nil {
+		t.Fatalf("load first message failed: %v", err)
+	}
+
+	if len(message.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(message.Attachments))
+	}
+
+	attachment := message.Attachments[0]
+	if attachment.FileUploadID != fileUpload.PublicID {
+		t.Fatalf("expected file upload id %q, got %q", fileUpload.PublicID, attachment.FileUploadID)
+	}
+	if attachment.Name != "spec.pdf" {
+		t.Fatalf("expected attachment name spec.pdf, got %q", attachment.Name)
+	}
+
+	refreshedUpload, err := dbpkg.GetFileUploadByPublicID(context.Background(), database, 1, fileUpload.PublicID)
+	if err != nil {
+		t.Fatalf("reload file upload failed: %v", err)
+	}
+	if refreshedUpload == nil {
+		t.Fatal("expected file upload to exist after new message")
+	}
+
+	projectPublicID, _ := refreshedUpload.Metadata.Extra["project_public_id"].(string)
+	if projectPublicID != resp.ProjectID {
+		t.Fatalf("expected file upload project_public_id %q, got %q", resp.ProjectID, projectPublicID)
+	}
+}

--- a/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useChatStore, useLayoutStore } from "@leros/store";
+import { projectFileApi, useChatStore, useLayoutStore } from "@leros/store";
+import type { Attachment } from "@leros/store/types/chat";
 import { Button } from "@leros/ui/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@leros/ui/components/ui/popover";
 import { cn } from "@leros/ui/lib/utils";
@@ -10,13 +11,16 @@ import {
 	ChevronDown,
 	Folder,
 	ListTodo,
+	Paperclip,
 	Plus,
 	Search,
 	SendHorizonal,
 	X,
 } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { useAuth } from "../auth";
+import { PROJECT_ATTACHMENT_ACCEPT } from "../input/ChatInput";
 import type { AppNavigation } from "./LeftRail";
 
 const mockActivities = [
@@ -52,13 +56,35 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		switchProject,
 		clearTaskDetailRoute,
 	} = useLayoutStore((s) => s);
-	const { startSessionResponseStream, resetLocalMessages } = useChatStore((s) => s);
+	const { startSessionResponseStream, resetLocalMessages, addUploadedAttachment } = useChatStore(
+		(s) => s,
+	);
 	const { isAuthenticated, openAuthDialog, requireAuth, user } = useAuth();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const attachmentsRef = useRef<Attachment[]>([]);
 	const [input, setInput] = useState("");
+	const [attachments, setAttachments] = useState<Attachment[]>([]);
 	const [projectMenuOpen, setProjectMenuOpen] = useState(false);
 	const [projectSearch, setProjectSearch] = useState("");
 	const [taskMenuOpen, setTaskMenuOpen] = useState(false);
 	const [taskSearch, setTaskSearch] = useState("");
+
+	const revokeAttachmentURLs = (items: Attachment[]) => {
+		for (const attachment of items) {
+			if (attachment.url?.startsWith("blob:")) {
+				URL.revokeObjectURL(attachment.url);
+			}
+		}
+	};
+
+	const clearAttachments = () => {
+		revokeAttachmentURLs(attachmentsRef.current);
+		setAttachments([]);
+	};
+
+	useEffect(() => {
+		attachmentsRef.current = attachments;
+	}, [attachments]);
 
 	useEffect(() => {
 		fetchProjects();
@@ -70,7 +96,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 	}, [clearTaskDetailRoute, resetLocalMessages]);
 
 	const performSend = async (content: string) => {
-		const data = await sendWorkbenchMessage(content, activeWorkbenchProjectId);
+		const data = await sendWorkbenchMessage(content, activeWorkbenchProjectId, attachments);
 		if (data?.session_id) {
 			await startSessionResponseStream(data.session_id, content);
 		}
@@ -78,6 +104,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 			navigation.goToTaskDetail(data.project_id, data.task_id, data.session_id);
 		}
 		setInput("");
+		clearAttachments();
 	};
 
 	const handleSend = async () => {
@@ -90,6 +117,55 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 			return;
 		}
 		await performSend(content);
+	};
+
+	const handleAttachmentSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+		const files = Array.from(event.target.files ?? []);
+		if (!files.length) return;
+
+		for (const file of files) {
+			try {
+				const uploaded = activeWorkbenchProjectId
+					? await addUploadedAttachment(activeWorkbenchProjectId, file)
+					: await uploadWorkbenchAttachment(file);
+				const { attachment, message } = uploaded;
+				setAttachments((prev) => [...prev, attachment]);
+				toast.success(message || "文件上传成功");
+			} catch (err) {
+				const message = err instanceof Error ? err.message : "文件上传失败";
+				console.error("Workbench upload attachment error:", err);
+				toast.error(message);
+			}
+		}
+		event.target.value = "";
+	};
+
+	const uploadWorkbenchAttachment = async (file: File) => {
+		// 无项目时先走通用上传，后续随 NewMessage 自动关联到新建项目。
+		const response = await projectFileApi.uploadLoose({ file, purpose: "attachment" });
+		const payload = response.data;
+		const attachment: Attachment = {
+			id: `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+			type: file.type.startsWith("image/") ? "image" : "file",
+			name: payload.original_name || payload.filename || file.name,
+			size: payload.file_size ?? payload.size ?? file.size,
+			url: file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined,
+			file,
+			path: payload.public_id || payload.storage_path || payload.path,
+			fileUploadId: payload.file_upload_id,
+			mimeType: payload.mime_type || file.type,
+		};
+		return { attachment, message: response.message };
+	};
+
+	const handleRemoveAttachment = (attachmentId: string) => {
+		setAttachments((prev) => {
+			const target = prev.find((attachment) => attachment.id === attachmentId);
+			if (target?.url?.startsWith("blob:")) {
+				URL.revokeObjectURL(target.url);
+			}
+			return prev.filter((attachment) => attachment.id !== attachmentId);
+		});
 	};
 	const activeProject = projects.find((project) => project.id === activeWorkbenchProjectId);
 	const latestProject = projects[0];
@@ -154,6 +230,8 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		}
 	};
 
+	useEffect(() => () => revokeAttachmentURLs(attachmentsRef.current), []);
+
 	return (
 		<div
 			data-slot="workbench-panel"
@@ -203,6 +281,44 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 
 						{/* Enhanced Command Input Card */}
 						<div className="flex flex-col rounded-[24px] border border-[var(--leros-control-border)] bg-[var(--leros-surface)] p-4 shadow-sm transition-all focus-within:border-[var(--leros-primary)] focus-within:shadow-md">
+							<input
+								ref={fileInputRef}
+								type="file"
+								className="hidden"
+								accept={PROJECT_ATTACHMENT_ACCEPT}
+								multiple
+								onChange={handleAttachmentSelect}
+							/>
+							{attachments.length > 0 && (
+								<div className="mb-3 flex flex-wrap gap-2">
+									{attachments.map((attachment) => (
+										<div
+											key={attachment.id}
+											className="flex items-center gap-2 rounded-lg bg-white/90 px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/70"
+										>
+											{attachment.type === "image" && attachment.url ? (
+												<img
+													src={attachment.url}
+													alt={attachment.name}
+													className="size-8 rounded object-cover"
+												/>
+											) : (
+												<Paperclip className="size-3.5 text-slate-400" />
+											)}
+											<span className="max-w-[160px] truncate text-slate-600">
+												{attachment.name}
+											</span>
+											<button
+												type="button"
+												onClick={() => handleRemoveAttachment(attachment.id)}
+												className="text-slate-400 transition-colors hover:text-slate-600"
+											>
+												<X className="size-3.5" />
+											</button>
+										</div>
+									))}
+								</div>
+							)}
 							<div className="mb-2 flex gap-3">
 								<textarea
 									value={input}
@@ -221,6 +337,13 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 								<div className="flex items-center gap-3">
 									<button
 										type="button"
+										onClick={() => {
+											if (!isAuthenticated) {
+												openAuthDialog("login");
+												return;
+											}
+											fileInputRef.current?.click();
+										}}
 										className="rounded-full p-1.5 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-chat-control-bg)]"
 										aria-label="添加附件"
 									>
@@ -387,7 +510,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 									<Button
 										size="icon"
 										onClick={handleSend}
-										disabled={!input.trim()}
+										disabled={!input.trim() && attachments.length === 0}
 										className="size-9 rounded-xl bg-[var(--leros-primary)] text-white shadow-sm hover:bg-[var(--leros-primary-strong)] disabled:bg-[var(--leros-chat-control-bg)] disabled:text-[var(--leros-text-subtle)]"
 									>
 										<SendHorizonal className="size-4" />

--- a/frontend/packages/store/api/projectFileApi.ts
+++ b/frontend/packages/store/api/projectFileApi.ts
@@ -18,6 +18,11 @@ export type UploadProjectFileParams = {
 	file: File;
 };
 
+export type UploadLooseFileParams = {
+	file: File;
+	purpose?: string;
+};
+
 type BackendUploadFilePayload = {
 	public_id: string;
 	file_upload_id?: string;
@@ -59,9 +64,16 @@ function assertBackendSuccess<T>(
 }
 
 async function uploadFile(file: File): Promise<BackendDataResponse<BackendUploadFilePayload>> {
+	return uploadLooseFile({ file, purpose: "project" });
+}
+
+async function uploadLooseFile({
+	file,
+	purpose = "attachment",
+}: UploadLooseFileParams): Promise<BackendDataResponse<BackendUploadFilePayload>> {
 	const formData = new FormData();
 	formData.append("file", file);
-	formData.append("purpose", "project");
+	formData.append("purpose", purpose);
 
 	const response = await authenticatedFetch(`${API_BASE_URL}/files/upload`, {
 		method: "POST",
@@ -124,6 +136,35 @@ export const projectFileApi = {
 		return {
 			code: addResponse.code,
 			message: addResponse.message,
+			data: {
+				path: uploaded.storage_path || uploaded.url || uploaded.public_id,
+				filename: uploaded.original_name || uploaded.filename || file.name,
+				size: uploaded.file_size ?? file.size,
+				public_id: uploaded.public_id,
+				file_upload_id: uploaded.file_upload_id,
+				original_name: uploaded.original_name,
+				mime_type: uploaded.mime_type || file.type,
+				file_size: uploaded.file_size ?? file.size,
+				sha256: uploaded.sha256,
+				storage_path: uploaded.storage_path,
+				url: uploaded.url,
+			} satisfies BackendProjectFileUploadResult,
+		} as BackendDataResponse<BackendProjectFileUploadResult>;
+	},
+
+	uploadLoose: async ({ file, purpose = "attachment" }: UploadLooseFileParams) => {
+		const uploadResponse = assertBackendSuccess(
+			await uploadLooseFile({ file, purpose }),
+			"文件上传失败",
+		);
+		const uploaded = uploadResponse.data;
+		if (!uploaded?.public_id) {
+			throw new Error("上传接口未返回 public_id");
+		}
+
+		return {
+			code: uploadResponse.code,
+			message: uploadResponse.message,
 			data: {
 				path: uploaded.storage_path || uploaded.url || uploaded.public_id,
 				filename: uploaded.original_name || uploaded.filename || file.name,

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -4,6 +4,7 @@ import { taskApi } from "../api/taskApi";
 import type { BackendArtifact, BackendProject, BackendSession, BackendTask } from "../api/types";
 import { workApi } from "../api/workApi";
 import type { SliceCreator } from "../types";
+import type { Attachment } from "../types/chat";
 import { flattenActions } from "../utils";
 import { formatFileSize } from "../utils/format";
 
@@ -347,7 +348,11 @@ export class LayoutActionImpl {
 		this.#set({ activeProjectTab: tab });
 	};
 
-	sendWorkbenchMessage = async (content: string, projectId?: string | null) => {
+	sendWorkbenchMessage = async (
+		content: string,
+		projectId?: string | null,
+		attachments?: Attachment[],
+	) => {
 		const trimmed = content.trim();
 		if (!trimmed) return;
 
@@ -401,6 +406,16 @@ export class LayoutActionImpl {
 						role: "user",
 						content: trimmed,
 						message_type: "text",
+						attachments: attachments
+							?.filter((attachment): attachment is Attachment & { fileUploadId: string } =>
+								Boolean(attachment.fileUploadId?.trim()),
+							)
+							.map((attachment) => ({
+								file_upload_id: attachment.fileUploadId.trim(),
+								name: attachment.name,
+								mime_type:
+									attachment.mimeType || attachment.file?.type || "application/octet-stream",
+							})),
 					});
 					const data = {
 						project_id: workbenchProjectId,
@@ -425,13 +440,33 @@ export class LayoutActionImpl {
 			}
 		}
 
-		const params: { content: string; project_id?: string; task_id?: string } = { content: trimmed };
+		const params: {
+			content: string;
+			project_id?: string;
+			task_id?: string;
+			attachments?: {
+				file_upload_id: string;
+				name: string;
+				mime_type: string;
+			}[];
+		} = { content: trimmed };
 
 		if (workbenchProjectId) {
 			params.project_id = workbenchProjectId;
 		}
 		if (selectedTaskId) {
 			params.task_id = selectedTaskId;
+		}
+		if (attachments?.length) {
+			params.attachments = attachments
+				.filter((attachment): attachment is Attachment & { fileUploadId: string } =>
+					Boolean(attachment.fileUploadId?.trim()),
+				)
+				.map((attachment) => ({
+					file_upload_id: attachment.fileUploadId.trim(),
+					name: attachment.name,
+					mime_type: attachment.mimeType || attachment.file?.type || "application/octet-stream",
+				}));
 		}
 
 		try {


### PR DESCRIPTION
## 变更说明
- 工作台首页输入框新增附件上传入口，支持图片缩略图预览和普通文件标签预览
- 已选项目时沿用现有项目文件上传链路；未选项目时先走通用上传，再随 `NewMessage` 自动关联到新建项目
- workbench 消息发送链路补充附件透传，并新增后端回归测试覆盖首条消息附件持久化与项目归属回填

## 验证
- `pnpm exec biome check packages/app-ui/components/layout/WorkbenchPanel.tsx packages/store/api/projectFileApi.ts packages/store/slices/layoutSlice.ts`
- 当前机器未安装/不可用 `go` 命令，未能本地执行新增后端测试