### PR TITLE
feat(api): 增加桌面端安装包下载量统计接口

### DIFF
--- a/backend/internal/api/contract/desktop_package_download.go
+++ b/backend/internal/api/contract/desktop_package_download.go
@@ -1,0 +1,32 @@
+package contract
+
+import "context"
+
+// DesktopPackageDownloadService defines desktop installer download stat APIs.
+type DesktopPackageDownloadService interface {
+	ReportDesktopPackageDownload(ctx context.Context, req *ReportDesktopPackageDownloadRequest) (*ReportDesktopPackageDownloadResponse, error)
+	GetDesktopPackageDownloadTotal(ctx context.Context) (*GetDesktopPackageDownloadTotalResponse, error)
+}
+
+// ReportDesktopPackageDownloadRequest is the anonymous desktop installer download report request.
+type ReportDesktopPackageDownloadRequest struct {
+	Version     string `json:"version" binding:"required"`
+	Platform    string `json:"platform,omitempty"`
+	Arch        string `json:"arch,omitempty"`
+	Channel     string `json:"channel,omitempty"`
+	PackageType string `json:"package_type,omitempty"`
+	Source      string `json:"source,omitempty"`
+
+	ClientIP string `json:"-"`
+}
+
+// ReportDesktopPackageDownloadResponse describes whether the report increased the count.
+type ReportDesktopPackageDownloadResponse struct {
+	DownloadCount int64 `json:"download_count"`
+	Counted       bool  `json:"counted"`
+}
+
+// GetDesktopPackageDownloadTotalResponse is the global desktop installer download total.
+type GetDesktopPackageDownloadTotalResponse struct {
+	DownloadCount int64 `json:"download_count"`
+}

--- a/backend/internal/api/handler/desktop_package_download_handler.go
+++ b/backend/internal/api/handler/desktop_package_download_handler.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/api/dto"
+)
+
+// DesktopPackageDownloadHandler handles desktop installer download stat APIs.
+type DesktopPackageDownloadHandler struct {
+	service contract.DesktopPackageDownloadService
+}
+
+// NewDesktopPackageDownloadHandler creates a desktop installer download stat handler.
+func NewDesktopPackageDownloadHandler(service contract.DesktopPackageDownloadService) *DesktopPackageDownloadHandler {
+	return &DesktopPackageDownloadHandler{service: service}
+}
+
+// RegisterRoutes registers desktop installer download stat routes.
+func (h *DesktopPackageDownloadHandler) RegisterRoutes(r gin.IRouter) {
+	r.POST("/ReportDesktopPackageDownload", h.ReportDesktopPackageDownload)
+	r.POST("/GetDesktopPackageDownloadTotal", h.GetDesktopPackageDownloadTotal)
+}
+
+// RegisterDesktopPackageDownloadRoutes registers desktop installer download stat routes.
+func RegisterDesktopPackageDownloadRoutes(r gin.IRouter, service contract.DesktopPackageDownloadService) {
+	h := NewDesktopPackageDownloadHandler(service)
+	h.RegisterRoutes(r)
+}
+
+// ReportDesktopPackageDownload records one desktop installer download report.
+// @Summary 上报桌面端安装包下载
+// @Description 上报一次桌面端安装包下载，同一 IP、版本、平台、架构 1 分钟内重复上报不会重复计数。
+// @Tags DesktopPackageDownload
+// @Accept json
+// @Produce json
+// @Param body body contract.ReportDesktopPackageDownloadRequest true "下载上报请求"
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 400 {object} dto.ErrorResponse "请求参数错误"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /ReportDesktopPackageDownload [post]
+func (h *DesktopPackageDownloadHandler) ReportDesktopPackageDownload(ctx *gin.Context) {
+	var req contract.ReportDesktopPackageDownloadRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+		return
+	}
+	req.ClientIP = ctx.ClientIP()
+
+	result, err := h.service.ReportDesktopPackageDownload(ctx, &req)
+	if err != nil {
+		handleDesktopPackageDownloadServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+// GetDesktopPackageDownloadTotal returns total desktop installer download count.
+// @Summary 查询桌面端安装包总下载量
+// @Description 查询桌面端安装包累计总下载量。
+// @Tags DesktopPackageDownload
+// @Accept json
+// @Produce json
+// @Success 200 {object} dto.Response "成功响应"
+// @Failure 500 {object} dto.ErrorResponse "内部服务器错误"
+// @Router /GetDesktopPackageDownloadTotal [post]
+func (h *DesktopPackageDownloadHandler) GetDesktopPackageDownloadTotal(ctx *gin.Context) {
+	result, err := h.service.GetDesktopPackageDownloadTotal(ctx)
+	if err != nil {
+		handleDesktopPackageDownloadServiceError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+func handleDesktopPackageDownloadServiceError(ctx *gin.Context, err error) {
+	switch err.Error() {
+	case "request is required",
+		"version is required",
+		"client ip is required":
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, err.Error()))
+	default:
+		ctx.JSON(http.StatusInternalServerError, dto.Error(dto.CodeInternalError, err.Error()))
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -11,8 +11,8 @@ import (
 	"github.com/insmtx/Leros/backend/config"
 	"github.com/insmtx/Leros/backend/internal/api/handler"
 	"github.com/insmtx/Leros/backend/internal/api/middleware"
-	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
 	"github.com/insmtx/Leros/backend/internal/infra/filestore"
+	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
 	"github.com/insmtx/Leros/backend/internal/infra/websocket"
 	"github.com/insmtx/Leros/backend/internal/runnable"
 	"github.com/insmtx/Leros/backend/internal/service"
@@ -103,6 +103,10 @@ func SetupRouter(cfg config.Config, eventbus eventbus.EventBus, db *gorm.DB) *gi
 		skillMarketplaceService := service.NewSkillMarketplaceService(db, eventbus)
 		handler.RegisterSkillMarketplaceRoutes(v1, skillMarketplaceService)
 		logs.Info("Skill marketplace routes registered successfully")
+
+		desktopPackageDownloadService := service.NewDesktopPackageDownloadService(db)
+		handler.RegisterDesktopPackageDownloadRoutes(v1, desktopPackageDownloadService)
+		logs.Info("Desktop package download stat routes registered successfully")
 
 		// Start background consumers
 		go runnable.StartSessionArtifactDeclared(context.Background(), eventbus, db)

--- a/backend/internal/infra/db/database.go
+++ b/backend/internal/infra/db/database.go
@@ -87,6 +87,8 @@ func runMigrations(db *gorm.DB) error {
 		&types.Artifact{},
 		&types.FileUpload{},
 		&types.BuiltinSkillMarketplaceItem{},
+		&types.DesktopPackageDownloadStat{},
+		&types.DesktopPackageDownloadRateLimit{},
 	}
 
 	if err := dbtools.InitModel(db, models...); err != nil {

--- a/backend/internal/infra/db/desktop_package_download_dao.go
+++ b/backend/internal/infra/db/desktop_package_download_dao.go
@@ -1,0 +1,120 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/insmtx/Leros/backend/types"
+)
+
+// DesktopPackageDownloadDimension identifies one aggregated desktop installer package.
+type DesktopPackageDownloadDimension struct {
+	Version     string
+	Platform    string
+	Arch        string
+	Channel     string
+	PackageType string
+	Source      string
+}
+
+// ClaimDesktopPackageDownloadWindow claims one report window for the same IP and package dimension.
+func ClaimDesktopPackageDownloadWindow(
+	ctx context.Context,
+	db *gorm.DB,
+	ipHash string,
+	dim DesktopPackageDownloadDimension,
+	now time.Time,
+	window time.Duration,
+) (bool, error) {
+	var entity types.DesktopPackageDownloadRateLimit
+	err := db.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("ip_hash = ? AND version = ? AND platform = ? AND arch = ?", ipHash, dim.Version, dim.Platform, dim.Arch).
+		First(&entity).Error
+	if err == nil {
+		if entity.UpdatedAt.After(now.Add(-window)) {
+			return false, nil
+		}
+		entity.UpdatedAt = now
+		if err := db.WithContext(ctx).Save(&entity).Error; err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, err
+	}
+
+	entity = types.DesktopPackageDownloadRateLimit{
+		IPHash:   ipHash,
+		Version:  dim.Version,
+		Platform: dim.Platform,
+		Arch:     dim.Arch,
+	}
+	result := db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&entity)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
+}
+
+// IncrementDesktopPackageDownload increments one package dimension and returns the dimension count.
+func IncrementDesktopPackageDownload(
+	ctx context.Context,
+	db *gorm.DB,
+	dim DesktopPackageDownloadDimension,
+	now time.Time,
+) (int64, error) {
+	stat := &types.DesktopPackageDownloadStat{
+		Version:          dim.Version,
+		Platform:         dim.Platform,
+		Arch:             dim.Arch,
+		Channel:          dim.Channel,
+		PackageType:      dim.PackageType,
+		Source:           dim.Source,
+		DownloadCount:    1,
+		LastDownloadedAt: &now,
+	}
+
+	err := db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "version"},
+			{Name: "platform"},
+			{Name: "arch"},
+			{Name: "channel"},
+			{Name: "package_type"},
+			{Name: "source"},
+		},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"download_count":     gorm.Expr(types.TableNameDesktopPackageDownloadStat+".download_count + ?", 1),
+			"last_downloaded_at": now,
+			"updated_at":         now,
+		}),
+	}).Create(stat).Error
+	if err != nil {
+		return 0, err
+	}
+
+	var downloadCount int64
+	err = db.WithContext(ctx).Model(&types.DesktopPackageDownloadStat{}).
+		Where("version = ? AND platform = ? AND arch = ? AND channel = ? AND package_type = ? AND source = ?",
+			dim.Version, dim.Platform, dim.Arch, dim.Channel, dim.PackageType, dim.Source).
+		Select("download_count").
+		Scan(&downloadCount).Error
+	if err != nil {
+		return 0, err
+	}
+	return downloadCount, nil
+}
+
+// GetDesktopPackageDownloadTotal returns all desktop installer download counts.
+func GetDesktopPackageDownloadTotal(ctx context.Context, db *gorm.DB) (int64, error) {
+	var total int64
+	query := db.WithContext(ctx).Model(&types.DesktopPackageDownloadStat{})
+	err := query.Select("COALESCE(SUM(download_count), 0)").Scan(&total).Error
+	return total, err
+}

--- a/backend/internal/infra/db/desktop_package_download_dao_test.go
+++ b/backend/internal/infra/db/desktop_package_download_dao_test.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/types"
+)
+
+func setupDesktopPackageDownloadTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := database.AutoMigrate(
+		&types.DesktopPackageDownloadStat{},
+		&types.DesktopPackageDownloadRateLimit{},
+	); err != nil {
+		t.Fatalf("migrate test db: %v", err)
+	}
+	return database
+}
+
+func TestDesktopPackageDownloadClaimWindowAndTotal(t *testing.T) {
+	database := setupDesktopPackageDownloadTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	dim := DesktopPackageDownloadDimension{
+		Version:     "0.1.2",
+		Platform:    "darwin",
+		Arch:        "arm64",
+		Channel:     "stable",
+		PackageType: "dmg",
+		Source:      "website",
+	}
+
+	claimed, err := ClaimDesktopPackageDownloadWindow(ctx, database, "ip_hash", dim, now, time.Minute)
+	if err != nil {
+		t.Fatalf("claim first window: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected first report to be counted")
+	}
+	if _, err := IncrementDesktopPackageDownload(ctx, database, dim, now); err != nil {
+		t.Fatalf("increment first report: %v", err)
+	}
+
+	claimed, err = ClaimDesktopPackageDownloadWindow(ctx, database, "ip_hash", dim, now.Add(30*time.Second), time.Minute)
+	if err != nil {
+		t.Fatalf("claim duplicate window: %v", err)
+	}
+	if claimed {
+		t.Fatal("expected duplicate report in the same window to be ignored")
+	}
+
+	claimed, err = ClaimDesktopPackageDownloadWindow(ctx, database, "ip_hash", dim, now.Add(61*time.Second), time.Minute)
+	if err != nil {
+		t.Fatalf("claim next window: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected report after the window to be counted")
+	}
+	if _, err := IncrementDesktopPackageDownload(ctx, database, dim, now.Add(61*time.Second)); err != nil {
+		t.Fatalf("increment next report: %v", err)
+	}
+
+	total, err := GetDesktopPackageDownloadTotal(ctx, database)
+	if err != nil {
+		t.Fatalf("get total: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
+	}
+}

--- a/backend/internal/service/desktop_package_download_service.go
+++ b/backend/internal/service/desktop_package_download_service.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	"github.com/insmtx/Leros/backend/internal/infra/db"
+	"github.com/insmtx/Leros/backend/pkg/utils"
+)
+
+const desktopPackageDownloadWindow = time.Minute
+
+var _ contract.DesktopPackageDownloadService = (*desktopPackageDownloadService)(nil)
+
+type desktopPackageDownloadService struct {
+	db *gorm.DB
+}
+
+// NewDesktopPackageDownloadService creates a desktop installer download stat service.
+func NewDesktopPackageDownloadService(db *gorm.DB) contract.DesktopPackageDownloadService {
+	return &desktopPackageDownloadService{db: db}
+}
+
+func (s *desktopPackageDownloadService) ReportDesktopPackageDownload(
+	ctx context.Context,
+	req *contract.ReportDesktopPackageDownloadRequest,
+) (*contract.ReportDesktopPackageDownloadResponse, error) {
+	if req == nil {
+		return nil, errors.New("request is required")
+	}
+	version := strings.TrimSpace(req.Version)
+	if version == "" {
+		return nil, errors.New("version is required")
+	}
+	clientIP := strings.TrimSpace(req.ClientIP)
+	if clientIP == "" {
+		return nil, errors.New("client ip is required")
+	}
+
+	now := time.Now()
+	dim := db.DesktopPackageDownloadDimension{
+		Version:     version,
+		Platform:    normalizeDesktopDownloadField(req.Platform, "unknown"),
+		Arch:        normalizeDesktopDownloadField(req.Arch, "unknown"),
+		Channel:     normalizeDesktopDownloadField(req.Channel, "stable"),
+		PackageType: normalizeDesktopDownloadField(req.PackageType, ""),
+		Source:      normalizeDesktopDownloadField(req.Source, ""),
+	}
+
+	var counted bool
+	var total int64
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		claimed, err := db.ClaimDesktopPackageDownloadWindow(
+			ctx,
+			tx,
+			hashDesktopDownloadIP(clientIP),
+			dim,
+			now,
+			desktopPackageDownloadWindow,
+		)
+		if err != nil {
+			return err
+		}
+		counted = claimed
+		if counted {
+			if _, err := db.IncrementDesktopPackageDownload(ctx, tx, dim, now); err != nil {
+				return err
+			}
+		}
+
+		total, err = db.GetDesktopPackageDownloadTotal(ctx, tx)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return &contract.ReportDesktopPackageDownloadResponse{
+		DownloadCount: total,
+		Counted:       counted,
+	}, nil
+}
+
+func (s *desktopPackageDownloadService) GetDesktopPackageDownloadTotal(
+	ctx context.Context,
+) (*contract.GetDesktopPackageDownloadTotalResponse, error) {
+	total, err := db.GetDesktopPackageDownloadTotal(ctx, s.db)
+	if err != nil {
+		return nil, err
+	}
+	return &contract.GetDesktopPackageDownloadTotalResponse{DownloadCount: total}, nil
+}
+
+func normalizeDesktopDownloadField(value string, fallback string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	return utils.DefaultString(value, fallback)
+}
+
+func hashDesktopDownloadIP(ip string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(ip)))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/types/desktop_package_download.go
+++ b/backend/types/desktop_package_download.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// DesktopPackageDownloadStat stores aggregated desktop installer download counts.
+type DesktopPackageDownloadStat struct {
+	gorm.Model
+
+	Version     string `gorm:"column:version;type:varchar(64);not null;uniqueIndex:idx_desktop_download_dim"`
+	Platform    string `gorm:"column:platform;type:varchar(32);not null;uniqueIndex:idx_desktop_download_dim"`
+	Arch        string `gorm:"column:arch;type:varchar(32);not null;uniqueIndex:idx_desktop_download_dim"`
+	Channel     string `gorm:"column:channel;type:varchar(32);not null;default:'stable';uniqueIndex:idx_desktop_download_dim"`
+	PackageType string `gorm:"column:package_type;type:varchar(32);not null;default:'';uniqueIndex:idx_desktop_download_dim"`
+	Source      string `gorm:"column:source;type:varchar(64);not null;default:'';uniqueIndex:idx_desktop_download_dim"`
+
+	DownloadCount    int64      `gorm:"column:download_count;type:bigint;not null;default:0"`
+	LastDownloadedAt *time.Time `gorm:"column:last_downloaded_at"`
+}
+
+// TableName 指定 DesktopPackageDownloadStat 结构体对应的数据库表名。
+func (DesktopPackageDownloadStat) TableName() string {
+	return TableNameDesktopPackageDownloadStat
+}
+
+// DesktopPackageDownloadRateLimit stores recent IP report windows for anonymous download stats.
+type DesktopPackageDownloadRateLimit struct {
+	gorm.Model
+
+	IPHash   string `gorm:"column:ip_hash;type:varchar(64);not null;uniqueIndex:idx_desktop_download_rate_limit"`
+	Version  string `gorm:"column:version;type:varchar(64);not null;uniqueIndex:idx_desktop_download_rate_limit"`
+	Platform string `gorm:"column:platform;type:varchar(32);not null;uniqueIndex:idx_desktop_download_rate_limit"`
+	Arch     string `gorm:"column:arch;type:varchar(32);not null;uniqueIndex:idx_desktop_download_rate_limit"`
+}
+
+// TableName 指定 DesktopPackageDownloadRateLimit 结构体对应的数据库表名。
+func (DesktopPackageDownloadRateLimit) TableName() string {
+	return TableNameDesktopPackageDownloadRateLimit
+}

--- a/backend/types/tables.go
+++ b/backend/types/tables.go
@@ -61,4 +61,8 @@ const (
 	TableNameFileUpload = tablenamePrefix + "file_upload"
 	// TableNameBuiltinSkillMarketplaceItem 内置 Skill 市场条目表名
 	TableNameBuiltinSkillMarketplaceItem = tablenamePrefix + "builtin_skill_marketplace_item"
+	// TableNameDesktopPackageDownloadStat 桌面端安装包下载统计表名
+	TableNameDesktopPackageDownloadStat = tablenamePrefix + "desktop_package_download_stat"
+	// TableNameDesktopPackageDownloadRateLimit 桌面端安装包下载限流表名
+	TableNameDesktopPackageDownloadRateLimit = tablenamePrefix + "desktop_package_download_rate_limit"
 )

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1180,6 +1180,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/GetDesktopPackageDownloadTotal": {
+            "post": {
+                "description": "查询桌面端安装包累计总下载量。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DesktopPackageDownload"
+                ],
+                "summary": "查询桌面端安装包总下载量",
+                "responses": {
+                    "200": {
+                        "description": "成功响应",
+                        "schema": {
+                            "$ref": "#/definitions/dto.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "内部服务器错误",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/GetDigitalAssistant": {
             "post": {
                 "description": "根据ID或Code获取数字助手详情",
@@ -2319,6 +2348,52 @@ const docTemplate = `{
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/contract.RegisterByEmailRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功响应",
+                        "schema": {
+                            "$ref": "#/definitions/dto.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部服务器错误",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ReportDesktopPackageDownload": {
+            "post": {
+                "description": "上报一次桌面端安装包下载，同一 IP、版本、平台、架构 1 分钟内重复上报不会重复计数。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DesktopPackageDownload"
+                ],
+                "summary": "上报桌面端安装包下载",
+                "parameters": [
+                    {
+                        "description": "下载上报请求",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/contract.ReportDesktopPackageDownloadRequest"
                         }
                     }
                 ],
@@ -4159,6 +4234,32 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "contract.ReportDesktopPackageDownloadRequest": {
+            "type": "object",
+            "required": [
+                "version"
+            ],
+            "properties": {
+                "arch": {
+                    "type": "string"
+                },
+                "channel": {
+                    "type": "string"
+                },
+                "package_type": {
+                    "type": "string"
+                },
+                "platform": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1178,6 +1178,35 @@
                 }
             }
         },
+        "/GetDesktopPackageDownloadTotal": {
+            "post": {
+                "description": "查询桌面端安装包累计总下载量。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DesktopPackageDownload"
+                ],
+                "summary": "查询桌面端安装包总下载量",
+                "responses": {
+                    "200": {
+                        "description": "成功响应",
+                        "schema": {
+                            "$ref": "#/definitions/dto.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "内部服务器错误",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/GetDigitalAssistant": {
             "post": {
                 "description": "根据ID或Code获取数字助手详情",
@@ -2317,6 +2346,52 @@
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/contract.RegisterByEmailRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功响应",
+                        "schema": {
+                            "$ref": "#/definitions/dto.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部服务器错误",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ReportDesktopPackageDownload": {
+            "post": {
+                "description": "上报一次桌面端安装包下载，同一 IP、版本、平台、架构 1 分钟内重复上报不会重复计数。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DesktopPackageDownload"
+                ],
+                "summary": "上报桌面端安装包下载",
+                "parameters": [
+                    {
+                        "description": "下载上报请求",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/contract.ReportDesktopPackageDownloadRequest"
                         }
                     }
                 ],
@@ -4157,6 +4232,32 @@
                     "type": "string"
                 },
                 "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "contract.ReportDesktopPackageDownloadRequest": {
+            "type": "object",
+            "required": [
+                "version"
+            ],
+            "properties": {
+                "arch": {
+                    "type": "string"
+                },
+                "channel": {
+                    "type": "string"
+                },
+                "package_type": {
+                    "type": "string"
+                },
+                "platform": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -347,6 +347,23 @@ definitions:
     - email
     - password
     type: object
+  contract.ReportDesktopPackageDownloadRequest:
+    properties:
+      arch:
+        type: string
+      channel:
+        type: string
+      package_type:
+        type: string
+      platform:
+        type: string
+      source:
+        type: string
+      version:
+        type: string
+    required:
+    - version
+    type: object
   contract.TestLLMModelRequest:
     properties:
       api_key:
@@ -1550,6 +1567,25 @@ paths:
       summary: 获取默认LLM模型
       tags:
       - LLMModel
+  /GetDesktopPackageDownloadTotal:
+    post:
+      consumes:
+      - application/json
+      description: 查询桌面端安装包累计总下载量。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 成功响应
+          schema:
+            $ref: '#/definitions/dto.Response'
+        "500":
+          description: 内部服务器错误
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: 查询桌面端安装包总下载量
+      tags:
+      - DesktopPackageDownload
   /GetDigitalAssistant:
     post:
       consumes:
@@ -2312,6 +2348,36 @@ paths:
       summary: 邮箱注册
       tags:
       - Auth
+  /ReportDesktopPackageDownload:
+    post:
+      consumes:
+      - application/json
+      description: 上报一次桌面端安装包下载，同一 IP、版本、平台、架构 1 分钟内重复上报不会重复计数。
+      parameters:
+      - description: 下载上报请求
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/contract.ReportDesktopPackageDownloadRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 成功响应
+          schema:
+            $ref: '#/definitions/dto.Response'
+        "400":
+          description: 请求参数错误
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: 内部服务器错误
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: 上报桌面端安装包下载
+      tags:
+      - DesktopPackageDownload
   /SessionEvents:
     post:
       consumes:


### PR DESCRIPTION
新增桌面端安装包下载上报与总下载量查询接口：
- 支持匿名公网调用下载上报接口
- 按 IP、版本、平台、架构进行 1 分钟窗口限流
- 使用数据库聚合表记录各版本安装包下载量
- 新增总下载量查询接口
- 更新 Swagger 文档