### PR TITLE
fix(desktop): 修复发布流程依赖安装失败

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -11,6 +11,7 @@ import { cn } from "@leros/ui/lib/utils";
 import { Bot } from "lucide-react";
 import {
 	forwardRef,
+	type MouseEvent,
 	useCallback,
 	useEffect,
 	useImperativeHandle,
@@ -636,7 +637,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 												<CommandItem
 													key={assistant.code}
 													value={assistant.code}
-													onMouseDown={(event) => event.preventDefault()}
+													onMouseDown={(event: MouseEvent) => event.preventDefault()}
 													onSelect={() => selectToken("assistant", assistant, trigger)}
 													className={cn(
 														"rounded-xl px-2.5 py-2",
@@ -660,7 +661,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 												<CommandItem
 													key={command.code}
 													value={command.code}
-													onMouseDown={(event) => event.preventDefault()}
+													onMouseDown={(event: MouseEvent) => event.preventDefault()}
 													onSelect={() => selectToken("command", command, trigger)}
 													className={cn(
 														"rounded-xl px-2.5 py-2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -217,6 +217,12 @@ importers:
 
   packages/app-ui:
     dependencies:
+      '@dicebear/core':
+        specifier: ^10.3.0
+        version: 10.3.0
+      '@dicebear/styles':
+        specifier: ^10.2.0
+        version: 10.2.0
       '@eigenpal/docx-editor-react':
         specifier: ^1.1.0
         version: 1.4.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prosemirror-commands@1.7.1)(prosemirror-dropcursor@1.8.2)(prosemirror-history@1.5.0)(prosemirror-keymap@1.2.3)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-tables@1.8.5)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -676,6 +682,13 @@ packages:
 
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
+
+  '@dicebear/core@10.3.0':
+    resolution: {integrity: sha512-HbzHvYY/E0m3B7BfBjs8SO7JyqJnORJgQhM2YM7VoN/EQzrqJ3Z0j4+op+WfEWXWzZj75tQqBU5SZpUssi5m/Q==}
+    engines: {node: '>=22.0.0'}
+
+  '@dicebear/styles@10.2.0':
+    resolution: {integrity: sha512-o4rw0+7Q7sSAyr9YxYrUe3jCxlOAzEcBvbQvl4hQKQ+9WNmBK4p7wGYvsmGeJbxFh8y/Ux6ltrCPyXBIDV6qYA==}
 
   '@dotenvx/dotenvx@1.71.3':
     resolution: {integrity: sha512-WSmox5aD+XxJEUEOTk7gKLpd5+Iz9Nik89Zpbu5DijMln6LsFiv3xpNKBMc/b9sSkUlKvAblzrhik2TqKFE7NA==}
@@ -5122,6 +5135,10 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.5.0': {}
+
+  '@dicebear/core@10.3.0': {}
+
+  '@dicebear/styles@10.2.0': {}
 
   '@dotenvx/dotenvx@1.71.3':
     dependencies:


### PR DESCRIPTION
同步 app-ui 新增 DiceBear 依赖到 pnpm-lock.yaml，避免 CI frozen-lockfile 安装失败。 将桌面端发布 workflow 升级到 Node 22 以满足 DiceBear engine 要求，并补充 StructuredComposer 事件类型。