### PR TITLE
fix(chat): 修复会话发送保护与历史消息加载

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -40,6 +40,9 @@ import { ArtifactPreviewDialog } from "../layout/ArtifactPreviewDialog";
 import { ProjectFileTypeIcon } from "../layout/project-file-type-icon";
 import { ToolCallBlock } from "./ToolCallBlock";
 
+// Button 的 size 只支持预设枚举，这里用受支持的尺寸并通过 className 微调成更紧凑的操作按钮。
+const compactActionButtonClassName = "size-[26px]";
+
 function CopyButton({ text }: { text: string }) {
 	const [copied, setCopied] = useState(false);
 	const handleCopy = () => {
@@ -50,8 +53,8 @@ function CopyButton({ text }: { text: string }) {
 	return (
 		<Button
 			variant="ghost"
-			size="icon-[13px]"
-			className={copied ? "text-green-500" : "text-slate-400 hover:text-slate-600"}
+			size="icon-xs"
+			className={`${compactActionButtonClassName} ${copied ? "text-green-500" : "text-slate-400 hover:text-slate-600"}`}
 			onClick={handleCopy}
 		>
 			{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
@@ -137,8 +140,8 @@ export function AIMessageBubble({
 							{SHOW_ASSISTANT_MESSAGE_REGENERATE_BUTTON && (
 								<Button
 									variant="ghost"
-									size="icon-[13px]"
-									className="text-slate-400 hover:text-slate-600"
+									size="icon-xs"
+									className={`${compactActionButtonClassName} text-slate-400 hover:text-slate-600`}
 									onClick={() => resendMessage(message.id)}
 								>
 									<RefreshCw className="size-3.5" />

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -57,6 +57,8 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 	const pendingApproval = findPendingApproval(messageIds, messagesMap, activeSessionId);
 
 	const submitMessage = useCallback(() => {
+		// 中文注释：输入区先做一次生成态拦截，避免回车绕过按钮态再次触发发送。
+		if (isGenerating) return;
 		// 仅上传附件而无文字时接口会报错，因此必须输入内容才可发送
 		if (inputText.trim()) {
 			if (isProjectVariant && currentView === "project") {
@@ -71,6 +73,7 @@ export function ChatInput({ variant = "default" }: { variant?: "default" | "proj
 		isProjectVariant,
 		currentView,
 		activeProjectId,
+		isGenerating,
 		sendMessage,
 		sendProjectMessage,
 	]);

--- a/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
@@ -56,9 +56,8 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		switchProject,
 		clearTaskDetailRoute,
 	} = useLayoutStore((s) => s);
-	const { startSessionResponseStream, resetLocalMessages, addUploadedAttachment } = useChatStore(
-		(s) => s,
-	);
+	const { startSessionResponseStream, resetLocalMessages, addUploadedAttachment, isGenerating } =
+		useChatStore((s) => s);
 	const { isAuthenticated, openAuthDialog, requireAuth, user } = useAuth();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const attachmentsRef = useRef<Attachment[]>([]);
@@ -82,6 +81,18 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		setAttachments([]);
 	};
 
+	const cloneAttachmentsForOptimisticMessage = (items: Attachment[]) =>
+		items.map((attachment) => {
+			// 中文注释：工作台清空输入区时会释放原 blob 预览，这里为任务页首屏回显复制一份独立预览地址。
+			if (attachment.type === "image" && attachment.file) {
+				return {
+					...attachment,
+					url: URL.createObjectURL(attachment.file),
+				};
+			}
+			return { ...attachment };
+		});
+
 	useEffect(() => {
 		attachmentsRef.current = attachments;
 	}, [attachments]);
@@ -96,9 +107,12 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 	}, [clearTaskDetailRoute, resetLocalMessages]);
 
 	const performSend = async (content: string) => {
+		if (isGenerating) return;
 		const data = await sendWorkbenchMessage(content, activeWorkbenchProjectId, attachments);
 		if (data?.session_id) {
-			await startSessionResponseStream(data.session_id, content);
+			const optimisticAttachments = cloneAttachmentsForOptimisticMessage(attachments);
+			// 中文注释：工作台跳转任务页前，先把附件一起写入 optimistic 消息，避免首屏只显示文本。
+			await startSessionResponseStream(data.session_id, content, optimisticAttachments);
 		}
 		if (navigation && data?.project_id && data?.task_id && data?.session_id) {
 			navigation.goToTaskDetail(data.project_id, data.task_id, data.session_id);
@@ -109,7 +123,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 
 	const handleSend = async () => {
 		const content = input.trim();
-		if (!content) return;
+		if (!content || isGenerating) return;
 		if (!isAuthenticated) {
 			requireAuth(() => {
 				void performSend(content);
@@ -510,7 +524,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 									<Button
 										size="icon"
 										onClick={handleSend}
-										disabled={!input.trim() && attachments.length === 0}
+										disabled={isGenerating || (!input.trim() && attachments.length === 0)}
 										className="size-9 rounded-xl bg-[var(--leros-primary)] text-white shadow-sm hover:bg-[var(--leros-primary-strong)] disabled:bg-[var(--leros-chat-control-bg)] disabled:text-[var(--leros-text-subtle)]"
 									>
 										<SendHorizonal className="size-4" />

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -341,6 +341,13 @@ function getRunResultMessage(payload: BackendSessionEventPayload): string | unde
 	return typeof value.message === "string" ? value.message : undefined;
 }
 
+function getRunFailedMessage(payload: BackendSessionEventPayload): string | undefined {
+	if (typeof payload.error === "string" && payload.error.trim()) {
+		return payload.error;
+	}
+	return getRunResultMessage(payload);
+}
+
 function splitThinkingStepContent(content: string): string[] {
 	const normalized = content.replace(/\r\n/g, "\n");
 	const withStageBoundaries = normalized.replace(
@@ -829,6 +836,15 @@ function applySessionEventToMessage(
 				usage: usage ?? message.usage,
 			});
 		}
+		case "run.failed": {
+			const failedMessage = getRunFailedMessage(payload);
+			if (!failedMessage) return message;
+			return {
+				...message,
+				// 中文注释：失败事件也要回填到当前 assistant 消息里，避免界面只剩空占位。
+				content: failedMessage,
+			};
+		}
 		default:
 			return message;
 	}
@@ -1048,6 +1064,8 @@ export class ChatActionImpl {
 		if (!content.trim()) return;
 
 		const state = this.#get();
+		// 中文注释：生成中禁止再次发送，避免新的请求把上一条流式响应直接顶掉。
+		if (state.isGenerating) return;
 		let { activeSessionId } = state;
 
 		if (!activeSessionId) {
@@ -1132,6 +1150,7 @@ export class ChatActionImpl {
 	) => {
 		const trimmed = content.trim();
 		if (!trimmed || !projectId) return;
+		if (this.#get().isGenerating) return;
 
 		try {
 			const res = await workApi.newMessage({
@@ -1176,6 +1195,7 @@ export class ChatActionImpl {
 		if (!sessionId || !trimmed) return;
 
 		const state = this.#get();
+		if (state.isGenerating) return;
 		if (state.activeSessionId === sessionId && state.isGenerating) {
 			if (state.pendingBootstrapSessionId === sessionId) {
 				this.#set({ pendingBootstrapSessionId: null });
@@ -1331,6 +1351,30 @@ export class ChatActionImpl {
 		return loadPromise;
 	};
 
+	#fetchAllConversationMessages = async (sessionId: string) => {
+		const perPage = 100;
+		let page = 1;
+		let total = Number.POSITIVE_INFINITY;
+		const items: BackendMessage[] = [];
+
+		while (items.length < total) {
+			const res = await sessionApi.getMessages(sessionId, page, perPage);
+			const data = res.data.data;
+			const pageItems = data?.items ?? [];
+			total = data?.total ?? items.length + pageItems.length;
+			items.push(...pageItems);
+
+			// 中文注释：当最后一页不足 perPage 或后端未返回更多记录时，直接停止翻页，避免无意义请求。
+			if (pageItems.length < perPage || pageItems.length === 0) {
+				break;
+			}
+
+			page += 1;
+		}
+
+		return items;
+	};
+
 	#loadConversationMessages = async (sessionId: string, options?: { resumeStream?: boolean }) => {
 		try {
 			const shouldCheckRuntime = options?.resumeStream !== false;
@@ -1348,8 +1392,7 @@ export class ChatActionImpl {
 			const optimisticCountBeforeLoad = getSessionLocalMessages(stateBeforeLoad, sessionId).filter(
 				isOptimisticMessage,
 			).length;
-			const res = await sessionApi.getMessages(sessionId, 1, 100);
-			const items = res.data.data?.items ?? [];
+			const items = await this.#fetchAllConversationMessages(sessionId);
 			const persistedMessages = items.map(mapBackendMessage);
 			const state = this.#get();
 			if (state.pendingBootstrapSessionId === sessionId) return;
@@ -1519,6 +1562,7 @@ export class ChatActionImpl {
 
 	resendMessage = async (messageId: string) => {
 		const state = this.#get();
+		if (state.isGenerating) return;
 		const oldMsg = state.messagesMap[messageId];
 		if (oldMsg?.role !== "assistant") return;
 


### PR DESCRIPTION
## 变更说明

- 生成中增加发送保护，避免再次发送打断当前流式响应
- 补充 `run.failed` 的消息回填，避免失败时界面只剩空的 assistant 占位
- 会话历史改为分页拉全后再统一合并，避免长会话只加载前 100 条
- 工作台发送后保留 optimistic 附件预览，减少跳转任务页首屏丢附件展示的问题

## 验证情况

- 已执行：`pnpm exec biome check packages/store/slices/chatSlice.ts packages/app-ui/components/input/ChatInput.tsx packages/app-ui/components/layout/WorkbenchPanel.tsx`
- 已执行：`pnpm run typecheck`
- 说明：`typecheck` 当前失败为仓库已有问题，位于 `frontend/packages/app-ui/components/chat/AIMessageBubble.tsx`，与本次改动无关

## 影响范围

- 工作台问答
- 项目新任务问答
- 已有任务页问答