### PR TITLE
chore(gitignore): 忽略本地开发脚本目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ logs/
 .omo/
 .leros-workspace/**
 leros-storage/
+.codex-local/


### PR DESCRIPTION
## 变更内容

- 在 `.gitignore` 中新增 `.codex-local/`
- 避免本机调试和本地开发辅助脚本被误提交到仓库

## 背景

本次本地联调过程中新增了一些仅用于个人 Windows 环境的辅助脚本，这些文件不属于项目正式代码，不应进入版本库。

## 影响范围

- 仅影响 Git 忽略规则
- 不影响前后端业务逻辑
- 不影响构建、运行和线上行为

## 验证

- 确认 Git 仅跟踪 `.gitignore` 改动
- 确认 `.codex-local/` 下本地脚本不会进入提交