### PR TITLE
chore(dev): 新增 Windows 本地联调脚本

### DIFF
--- a/deployments/dev/README.md
+++ b/deployments/dev/README.md
@@ -45,6 +45,27 @@ After starting infrastructure, start components independently:
 ./dev-frontend.sh
 ```
 
+### Windows Quick Start
+
+If you are developing on Windows, use the tracked PowerShell/CMD wrappers under `deployments/dev/`:
+
+```powershell
+# Start Docker deps + server + worker + frontend
+.\deployments\dev\start-dev.cmd
+
+# Rebuild and restart backend only
+.\deployments\dev\restart-backend.cmd
+
+# Stop frontend + backend + Docker deps
+.\deployments\dev\stop-dev.cmd
+```
+
+Notes for Windows:
+
+- `stop-dev.cmd` will auto request administrator permission when needed, because Windows may block killing the frontend process tree under normal permission.
+- `start-dev.cmd` keeps using the repo's normal frontend `dev:web` flow, so frontend still hot reloads as usual.
+- If `bundles/leros.exe` is missing, `start-dev.cmd` will rebuild it automatically.
+
 The server and worker scripts support `--build` (or `-b`) to rebuild `./bundles/leros` before starting. The scripts load `deployments/dev/.env` before reading YAML config, so values like `${LLM_API_KEY}` in config files are resolved from `.env`.
 
 ### View Logs

--- a/deployments/dev/rebuild-backend.cmd
+++ b/deployments/dev/rebuild-backend.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0rebuild-backend.ps1"

--- a/deployments/dev/rebuild-backend.ps1
+++ b/deployments/dev/rebuild-backend.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+$root = Get-LerosRepoRoot
+Set-OptionalGoBuildEnvironment
+$goExe = Get-GoExe
+
+if (-not (Test-Path "$root\bundles")) {
+    New-Item -ItemType Directory -Path "$root\bundles" | Out-Null
+}
+
+Set-Location $root
+Write-Host '[Leros] Rebuilding backend...' -ForegroundColor Cyan
+& $goExe build -v -o "$root\bundles\leros.exe" .\backend\cmd\leros\
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'Backend rebuild failed.'
+}
+
+Write-Host '[Leros] Backend rebuild completed.' -ForegroundColor Green

--- a/deployments/dev/restart-backend.cmd
+++ b/deployments/dev/restart-backend.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0restart-backend.ps1"

--- a/deployments/dev/restart-backend.ps1
+++ b/deployments/dev/restart-backend.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+$root = Get-LerosRepoRoot
+
+Stop-DevProcessesByPorts -Ports @(8080, 8081)
+
+Write-Host '[Leros] Stopping remaining backend processes...' -ForegroundColor Cyan
+Get-Process leros -ErrorAction SilentlyContinue | Stop-Process -Force
+
+& "$PSScriptRoot\rebuild-backend.ps1"
+
+Write-Host '[Leros] Restarting server and worker...' -ForegroundColor Cyan
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-server-dev.ps1" | Out-Null
+Start-Sleep -Seconds 2
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-worker-dev.ps1" | Out-Null
+
+Write-Host ''
+Write-Host '[Leros] Backend restart completed.' -ForegroundColor Green
+Write-Host '[Leros] Frontend does not need to restart. Just refresh the page.' -ForegroundColor Green
+Read-Host 'Press Enter to exit'

--- a/deployments/dev/run-frontend-dev.cmd
+++ b/deployments/dev/run-frontend-dev.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoExit -ExecutionPolicy Bypass -File "%~dp0run-frontend-dev.ps1"

--- a/deployments/dev/run-frontend-dev.ps1
+++ b/deployments/dev/run-frontend-dev.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+$root = Get-LerosRepoRoot
+$pnpmExe = Get-PnpmExe
+
+Set-Location "$root\frontend"
+Write-Host '[Leros][Frontend] Starting on http://localhost:3005' -ForegroundColor Cyan
+& $pnpmExe run dev:web

--- a/deployments/dev/run-server-dev.cmd
+++ b/deployments/dev/run-server-dev.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoExit -ExecutionPolicy Bypass -File "%~dp0run-server-dev.ps1"

--- a/deployments/dev/run-server-dev.ps1
+++ b/deployments/dev/run-server-dev.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+$root = Get-LerosRepoRoot
+$env:LEROS_STORAGE_LOCAL_DIR = "$root\leros-storage"
+
+if (-not (Test-Path $env:LEROS_STORAGE_LOCAL_DIR)) {
+    New-Item -ItemType Directory -Path $env:LEROS_STORAGE_LOCAL_DIR | Out-Null
+}
+
+Set-Location $root
+Write-Host '[Leros][Server] Starting on http://localhost:8080' -ForegroundColor Cyan
+& "$root\bundles\leros.exe" server --config "$root\deployments\dev\server.config.yaml" --workspace-root "$root\.leros-workspace\1\1\workspace"

--- a/deployments/dev/run-worker-dev.cmd
+++ b/deployments/dev/run-worker-dev.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoExit -ExecutionPolicy Bypass -File "%~dp0run-worker-dev.ps1"

--- a/deployments/dev/run-worker-dev.ps1
+++ b/deployments/dev/run-worker-dev.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+$root = Get-LerosRepoRoot
+$env:LEROS_DEV = 'true'
+
+Set-Location $root
+Write-Host '[Leros][Worker] Starting on http://localhost:8081' -ForegroundColor Cyan
+& "$root\bundles\leros.exe" worker --worker-id 1 --config "$root\deployments\dev\worker.config.yaml" --listen-addr ':8081' --workspace-root "$root\.leros-workspace\1\1\workspace"

--- a/deployments/dev/shared.ps1
+++ b/deployments/dev/shared.ps1
@@ -1,0 +1,173 @@
+$ErrorActionPreference = 'Stop'
+
+function Get-LerosRepoRoot {
+    return (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+function Resolve-ToolPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CommandName,
+
+        [string[]]$FallbackPaths = @()
+    )
+
+    $command = Get-Command $CommandName -ErrorAction SilentlyContinue
+    if ($command -and $command.Source) {
+        return $command.Source
+    }
+
+    foreach ($path in $FallbackPaths) {
+        if ($path -and (Test-Path $path)) {
+            return $path
+        }
+    }
+
+    throw "Required command not found: $CommandName"
+}
+
+function Get-DockerExe {
+    return (Resolve-ToolPath -CommandName 'docker.exe' -FallbackPaths @(
+        'E:\DevEnv\Docker\app\resources\bin\docker.exe'
+    ))
+}
+
+function Get-GoExe {
+    return (Resolve-ToolPath -CommandName 'go.exe' -FallbackPaths @(
+        'E:\DevEnv\Go\goroot\bin\go.exe'
+    ))
+}
+
+function Get-PnpmExe {
+    return (Resolve-ToolPath -CommandName 'pnpm.cmd' -FallbackPaths @(
+        'D:\nvm\nodejs\pnpm.cmd'
+    ))
+}
+
+function Set-OptionalGoBuildEnvironment {
+    $fallbackGoroot = 'E:\DevEnv\Go\goroot'
+    $fallbackGopath = 'E:\DevEnv\Go\gopath'
+    $fallbackGocache = 'E:\DevEnv\Go\cache'
+    $fallbackGcc = 'E:\DevEnv\MSYS2\ucrt64\bin\gcc.exe'
+    $fallbackGccDir = 'E:\DevEnv\MSYS2\ucrt64\bin'
+
+    if (-not $env:GOROOT -and (Test-Path $fallbackGoroot)) {
+        $env:GOROOT = $fallbackGoroot
+    }
+    if (-not $env:GOPATH -and (Test-Path $fallbackGopath)) {
+        $env:GOPATH = $fallbackGopath
+    }
+    if (-not $env:GOCACHE -and (Test-Path $fallbackGocache)) {
+        $env:GOCACHE = $fallbackGocache
+    }
+    if (-not $env:GOMODCACHE -and $env:GOPATH) {
+        $env:GOMODCACHE = Join-Path $env:GOPATH 'pkg\mod'
+    }
+    if (-not $env:GOBIN -and $env:GOPATH) {
+        $env:GOBIN = Join-Path $env:GOPATH 'bin'
+    }
+
+    $env:CGO_ENABLED = '1'
+
+    if (-not $env:CC -and (Test-Path $fallbackGcc)) {
+        $env:CC = $fallbackGcc
+    }
+
+    if ((Test-Path $fallbackGccDir) -and ($env:PATH -notlike "*$fallbackGccDir*")) {
+        $env:PATH = "$fallbackGccDir;$env:PATH"
+    }
+
+    if ($env:GOROOT) {
+        $goBinDir = Join-Path $env:GOROOT 'bin'
+        if ((Test-Path $goBinDir) -and ($env:PATH -notlike "*$goBinDir*")) {
+            $env:PATH = "$goBinDir;$env:PATH"
+        }
+    }
+}
+
+function Wait-DockerReady {
+    $dockerExe = Get-DockerExe
+
+    Write-Host '[Leros] Waiting for Docker engine...' -ForegroundColor Cyan
+    for ($i = 0; $i -lt 30; $i++) {
+        & $dockerExe info *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    throw 'Docker engine did not become ready in time.'
+}
+
+function Get-IsAdministrator {
+    $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $currentPrincipal = New-Object System.Security.Principal.WindowsPrincipal($currentIdentity)
+    return $currentPrincipal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Ensure-Administrator {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptPath
+    )
+
+    if (Get-IsAdministrator) {
+        return $true
+    }
+
+    Write-Host '[Leros] Re-launching with administrator permission...' -ForegroundColor Yellow
+    Start-Process -FilePath 'powershell.exe' -ArgumentList @(
+        '-ExecutionPolicy', 'Bypass',
+        '-File', $ScriptPath
+    ) -Verb RunAs | Out-Null
+
+    return $false
+}
+
+function Stop-DevProcessesByPorts {
+    param(
+        [int[]]$Ports
+    )
+
+    $repoRoot = Get-LerosRepoRoot
+    $stoppedProcessIds = New-Object 'System.Collections.Generic.HashSet[int]'
+
+    foreach ($port in $Ports) {
+        $listenRows = netstat -ano -p tcp |
+            Select-String -Pattern 'LISTENING\s+\d+$' |
+            Where-Object { $_.ToString() -match "[:\.]$port\s" }
+
+        foreach ($row in $listenRows) {
+            $text = ($row.ToString() -replace '\s+', ' ').Trim()
+            $parts = $text.Split(' ')
+            if ($parts.Length -lt 5) {
+                continue
+            }
+
+            $processId = $parts[-1]
+            if ($processId -notmatch '^\d+$' -or $processId -eq '0') {
+                continue
+            }
+
+            $pidValue = [int]$processId
+            if ($stoppedProcessIds.Contains($pidValue)) {
+                continue
+            }
+
+            $stoppedProcessIds.Add($pidValue) | Out-Null
+            & taskkill /PID $pidValue /T /F *> $null
+
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "[Leros] Stopped process tree on port $port (PID: $pidValue)." -ForegroundColor Cyan
+                continue
+            }
+
+            $proc = Get-CimInstance Win32_Process -Filter "ProcessId = $pidValue" -ErrorAction SilentlyContinue
+            if ($proc -and $proc.CommandLine -and $proc.CommandLine -match [regex]::Escape($repoRoot)) {
+                throw "Failed to stop process on port $port. Please run stop script as administrator."
+            }
+        }
+    }
+}

--- a/deployments/dev/start-dev.cmd
+++ b/deployments/dev/start-dev.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0start-dev.ps1"

--- a/deployments/dev/start-dev.ps1
+++ b/deployments/dev/start-dev.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+$root = Get-LerosRepoRoot
+$dockerDesktop = 'E:\DevEnv\Docker\app\Docker Desktop.exe'
+$dockerExe = Get-DockerExe
+
+if (Get-Process leros -ErrorAction SilentlyContinue) {
+    Write-Host '[Leros] Backend is already running.' -ForegroundColor Yellow
+    Write-Host '[Leros] If you changed backend code, run deployments\dev\restart-backend.cmd' -ForegroundColor Yellow
+    Read-Host 'Press Enter to exit'
+    exit 0
+}
+
+if (Test-Path $dockerDesktop) {
+    Start-Process -FilePath $dockerDesktop | Out-Null
+}
+
+Wait-DockerReady
+
+Write-Host '[Leros] Starting Postgres and NATS...' -ForegroundColor Cyan
+& $dockerExe compose -f "$root\deployments\dev\docker-compose.dev.yml" up -d postgresql nats
+if ($LASTEXITCODE -ne 0) {
+    throw 'Docker dependencies failed to start.'
+}
+
+if (-not (Test-Path "$root\bundles\leros.exe")) {
+    & "$PSScriptRoot\rebuild-backend.ps1"
+}
+
+Write-Host '[Leros] Opening server, worker and frontend windows...' -ForegroundColor Cyan
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-server-dev.ps1" | Out-Null
+Start-Sleep -Seconds 2
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-worker-dev.ps1" | Out-Null
+Start-Sleep -Seconds 2
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-frontend-dev.ps1" | Out-Null
+
+Write-Host ''
+Write-Host '[Leros] Dev environment is ready.' -ForegroundColor Green
+Write-Host '[Leros] Frontend auto refreshes. For backend changes, run deployments\dev\restart-backend.cmd' -ForegroundColor Green
+Read-Host 'Press Enter to exit'

--- a/deployments/dev/stop-dev.cmd
+++ b/deployments/dev/stop-dev.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0stop-dev.ps1"

--- a/deployments/dev/stop-dev.ps1
+++ b/deployments/dev/stop-dev.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+
+if (-not (Ensure-Administrator -ScriptPath "$PSScriptRoot\stop-dev.ps1")) {
+    exit 0
+}
+
+$root = Get-LerosRepoRoot
+$dockerExe = Get-DockerExe
+
+Stop-DevProcessesByPorts -Ports @(3005, 8080, 8081)
+
+Write-Host '[Leros] Stopping remaining backend processes...' -ForegroundColor Cyan
+Get-Process leros -ErrorAction SilentlyContinue | Stop-Process -Force
+
+Write-Host '[Leros] Stopping Postgres and NATS...' -ForegroundColor Cyan
+& $dockerExe info *> $null
+if ($LASTEXITCODE -eq 0) {
+    & $dockerExe compose -f "$root\deployments\dev\docker-compose.dev.yml" down
+} else {
+    Write-Host '[Leros] Docker engine is not running, skip stopping containers.' -ForegroundColor Yellow
+}
+
+Write-Host ''
+Write-Host '[Leros] Backend and Docker dependencies have been stopped.' -ForegroundColor Green
+Write-Host '[Leros] Frontend on port 3005 has also been stopped if it was running.' -ForegroundColor Green
+Read-Host 'Press Enter to exit'


### PR DESCRIPTION
## 变更说明

- 新增 Windows 本地联调脚本，统一放到 `deployments/dev/`
- 支持一键启动前端、后端、worker 和 Docker 依赖
- 支持仅重启后端，便于本地修改 Go 代码后快速验证
- 支持停止前端、后端和 Docker 依赖
- 补充 `deployments/dev/README.md` 的 Windows 使用说明

## 新增脚本

- `deployments/dev/start-dev.cmd`
- `deployments/dev/start-dev.ps1`
- `deployments/dev/restart-backend.cmd`
- `deployments/dev/restart-backend.ps1`
- `deployments/dev/stop-dev.cmd`
- `deployments/dev/stop-dev.ps1`
- `deployments/dev/rebuild-backend.cmd`
- `deployments/dev/rebuild-backend.ps1`
- `deployments/dev/run-server-dev.cmd`
- `deployments/dev/run-server-dev.ps1`
- `deployments/dev/run-worker-dev.cmd`
- `deployments/dev/run-worker-dev.ps1`
- `deployments/dev/run-frontend-dev.cmd`
- `deployments/dev/run-frontend-dev.ps1`
- `deployments/dev/shared.ps1`

## 验证

- PowerShell 脚本语法检查通过
- 本地执行 `.\deployments\dev\start-dev.cmd` 成功
- 本地执行 `.\deployments\dev\restart-backend.cmd` 成功
- 本地执行 `.\deployments\dev\stop-dev.cmd` 成功
- 已验证修改后端代码后，通过 `restart-backend.cmd` 可让新后端逻辑生效