### PR TITLE
feat(desktop): 优化桌面端更新提醒交互

### DIFF
--- a/frontend/apps/desktop/src/renderer/src/App.tsx
+++ b/frontend/apps/desktop/src/renderer/src/App.tsx
@@ -1,19 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { ThemeProvider } from "@leros/ui/components/common/theme-provider";
 import { Button } from "@leros/ui/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@leros/ui/components/ui/dialog";
 import { Toaster } from "@leros/ui/components/ui/sonner";
-import { toast } from "sonner";
+import { ArrowUpCircle, X } from "lucide-react";
 import { HashRouter } from "react-router-dom";
 import { AppRoutes } from "./routes";
 import type { DesktopUpdateState } from "../../shared/auto-update";
+
+const updatePromptSnoozeMs = 5 * 60 * 1000;
 
 export default function App() {
 	return (
@@ -30,9 +24,39 @@ export default function App() {
 function DesktopUpdateNotifier() {
 	const previousPhaseRef = useRef<DesktopUpdateState["phase"] | null>(null);
 	const previousVersionRef = useRef<string | undefined>(undefined);
-	const [confirmOpen, setConfirmOpen] = useState(false);
+	const snoozeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [promptOpen, setPromptOpen] = useState(false);
 	const [downloadedVersion, setDownloadedVersion] = useState<string | undefined>(undefined);
 	const [installing, setInstalling] = useState(false);
+	const [installError, setInstallError] = useState<string | null>(null);
+
+	const clearSnoozeTimer = () => {
+		if (snoozeTimerRef.current) {
+			clearTimeout(snoozeTimerRef.current);
+			snoozeTimerRef.current = null;
+		}
+	};
+
+	const openUpdatePrompt = (version?: string) => {
+		clearSnoozeTimer();
+		setDownloadedVersion(version);
+		setInstallError(null);
+		setPromptOpen(true);
+	};
+
+	const snoozeUpdatePrompt = () => {
+		setPromptOpen(false);
+
+		if (!downloadedVersion || installing) {
+			return;
+		}
+
+		clearSnoozeTimer();
+		snoozeTimerRef.current = setTimeout(() => {
+			setPromptOpen(true);
+			snoozeTimerRef.current = null;
+		}, updatePromptSnoozeMs);
+	};
 
 	useEffect(() => {
 		let mounted = true;
@@ -44,6 +68,10 @@ function DesktopUpdateNotifier() {
 
 			previousPhaseRef.current = state.phase;
 			previousVersionRef.current = state.availableVersion ?? state.downloadedVersion;
+
+			if (state.phase === "downloaded") {
+				openUpdatePrompt(state.downloadedVersion ?? state.availableVersion);
+			}
 		});
 
 		const unsubscribe = window.lerosDesktop.subscribe((state) => {
@@ -52,29 +80,10 @@ function DesktopUpdateNotifier() {
 			const nextVersion = state.availableVersion ?? state.downloadedVersion;
 
 			if (
-				state.phase === "available" &&
-				(previousPhase !== "available" || previousVersion !== nextVersion)
-			) {
-				toast.message(`发现新版本 ${nextVersion ? `v${nextVersion}` : ""}`.trim(), {
-					description: "正在后台下载更新包",
-				});
-			}
-
-			if (
 				state.phase === "downloaded" &&
 				(previousPhase !== "downloaded" || previousVersion !== nextVersion)
 			) {
-				setDownloadedVersion(nextVersion);
-				setConfirmOpen(true);
-				toast.success("新版本已经下载完成", {
-					description: "确认后可立即重启并安装更新",
-				});
-			}
-
-			if (state.phase === "error" && previousPhase !== "error") {
-				toast.error("更新失败", {
-					description: state.message,
-				});
+				openUpdatePrompt(nextVersion);
 			}
 
 			previousPhaseRef.current = state.phase;
@@ -83,46 +92,78 @@ function DesktopUpdateNotifier() {
 
 		return () => {
 			mounted = false;
+			clearSnoozeTimer();
 			unsubscribe();
 		};
 	}, []);
 
 	const handleInstallNow = async () => {
 		setInstalling(true);
+		setInstallError(null);
 		try {
 			const accepted = await window.lerosDesktop.quitAndInstall();
 			if (!accepted) {
-				toast.message("当前还没有可安装的更新");
 				setInstalling(false);
-				setConfirmOpen(false);
+				setInstallError("当前还没有可安装的更新");
 			}
 		} catch (error) {
 			setInstalling(false);
-			toast.error("启动安装失败", {
-				description: error instanceof Error ? error.message : "请稍后重试",
-			});
+			setInstallError(error instanceof Error ? error.message : "启动安装失败，请稍后重试");
 		}
 	};
 
+	if (!promptOpen) {
+		return null;
+	}
+
 	return (
-		<Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-			<DialogContent className="sm:max-w-md" showCloseButton={!installing}>
-				<DialogHeader>
-					<DialogTitle>新版本已经下载完成</DialogTitle>
-					<DialogDescription>
-						{downloadedVersion ? `v${downloadedVersion} 已准备就绪。` : "更新包已准备就绪。"}
-						是否立即重启应用并安装更新？
-					</DialogDescription>
-				</DialogHeader>
-				<DialogFooter className="mt-4">
-					<Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={installing}>
-						稍后
-					</Button>
-					<Button onClick={handleInstallNow} disabled={installing}>
-						{installing ? "正在启动安装…" : "立即重启安装"}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+		<div className="pointer-events-none fixed right-2 bottom-4 z-50 flex max-w-[calc(100vw-1rem)] justify-end">
+			<div className="pointer-events-auto relative w-auto max-w-full rounded-2xl border border-slate-200/90 bg-white px-3.5 py-2 text-slate-900 shadow-[0_16px_48px_rgba(15,23,42,0.14)]">
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					className="absolute -top-2 -right-2 rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm hover:bg-white hover:text-slate-900"
+					onClick={snoozeUpdatePrompt}
+					disabled={installing}
+					aria-label="稍后安装"
+				>
+					<X className="size-3" />
+				</Button>
+				<div className="flex max-w-full items-center gap-2.5">
+					<div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-500 ring-1 ring-emerald-100">
+						<ArrowUpCircle className="size-3.5" />
+					</div>
+					<div className="min-w-[170px] max-w-[200px] flex-[0_1_auto]">
+						<div className="truncate text-[13px] font-semibold leading-4">新版本已经下载完成</div>
+						<div className="truncate text-[11px] leading-4 text-slate-500">
+							{downloadedVersion ? `v${downloadedVersion} 已准备就绪。` : "更新包已准备就绪。"}
+						</div>
+					</div>
+					<div className="flex shrink-0 items-center gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							className="h-7 min-w-14 rounded-xl border-slate-200 bg-white px-3 text-xs text-slate-700 hover:bg-slate-50"
+							onClick={snoozeUpdatePrompt}
+							disabled={installing}
+						>
+							稍后
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							className="h-7 min-w-20 rounded-xl bg-slate-950 px-3 text-xs text-white hover:bg-slate-800"
+							onClick={handleInstallNow}
+							disabled={installing}
+						>
+							{installing ? "正在启动..." : "重启升级"}
+						</Button>
+					</div>
+				</div>
+				{installError ? <div className="mt-2 truncate text-xs text-red-500">{installError}</div> : null}
+			</div>
+		</div>
 	);
 }

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -36,9 +36,7 @@ import {
 	Network,
 	Pencil,
 	RefreshCcw,
-	RotateCw,
 	Trash2,
-	Upload,
 	UserRound,
 	Zap,
 } from "lucide-react";
@@ -827,8 +825,6 @@ function DesktopUpdateMenuSection() {
 	const desktopApi = getDesktopUpdateApi();
 	const [updateState, setUpdateState] = useState<DesktopUpdateState>(initialDesktopUpdateState);
 	const [checking, setChecking] = useState(false);
-	const [restarting, setRestarting] = useState(false);
-	const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
 
 	useEffect(() => {
 		if (!desktopApi) {
@@ -872,85 +868,33 @@ function DesktopUpdateMenuSection() {
 		}
 	};
 
-	const handleRestartToUpdate = async () => {
-		setRestarting(true);
-		try {
-			const accepted = await desktopApi.quitAndInstall();
-			if (!accepted) {
-				toast.message("当前还没有可安装的更新");
-			}
-		} finally {
-			setRestarting(false);
-		}
-	};
-
-	const versionLabel = updateState.downloadedVersion ?? updateState.availableVersion;
-
 	return (
-		<>
-			<div className="space-y-1">
-				{typeof updateState.progressPercent === "number" ? (
-					<div className="px-2 pb-1">
-						<div className="h-1.5 overflow-hidden rounded-full bg-slate-200">
-							<div
-								className="h-full rounded-full bg-[#34c59a] transition-all"
-								style={{ width: `${Math.max(0, Math.min(updateState.progressPercent, 100))}%` }}
-							/>
-						</div>
+		<div className="space-y-1">
+			{updateState.phase === "downloading" && typeof updateState.progressPercent === "number" ? (
+				<div className="px-2 pb-1">
+					<div className="h-1.5 overflow-hidden rounded-full bg-slate-200">
+						<div
+							className="h-full rounded-full bg-[#34c59a] transition-all"
+							style={{ width: `${Math.max(0, Math.min(updateState.progressPercent, 100))}%` }}
+						/>
 					</div>
-				) : null}
+				</div>
+			) : null}
 
-				{updateState.canRestart ? (
-					<>
-						<button
-							type="button"
-							className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm text-slate-700 outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
-							onClick={() => setReleaseNotesOpen(true)}
-						>
-							<RefreshCcw className="size-4" />
-							<span>更新日志</span>
-						</button>
-						<button
-							type="button"
-							className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm font-medium text-[#34c59a] outline-none transition-colors hover:bg-[#34c59a]/8"
-							onClick={handleRestartToUpdate}
-							disabled={restarting}
-						>
-							{restarting ? <RotateCw className="size-4 animate-spin" /> : <Upload className="size-4" />}
-							<span>重启升级</span>
-						</button>
-					</>
+			<button
+				type="button"
+				className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm text-slate-700 outline-none transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+				onClick={handleCheckForUpdates}
+				disabled={!updateState.canCheck || checking}
+			>
+				{checking || updateState.phase === "checking" ? (
+					<Loader2 className="size-4 animate-spin" />
 				) : (
-					<button
-						type="button"
-						className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm text-slate-700 outline-none transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-						onClick={handleCheckForUpdates}
-						disabled={!updateState.canCheck || checking}
-					>
-						{checking || updateState.phase === "checking" ? (
-							<Loader2 className="size-4 animate-spin" />
-						) : (
-							<RefreshCcw className="size-4" />
-						)}
-						<span>检查更新</span>
-					</button>
+					<RefreshCcw className="size-4" />
 				)}
-			</div>
-
-			<Dialog open={releaseNotesOpen} onOpenChange={setReleaseNotesOpen}>
-				<DialogContent className="sm:max-w-lg" showCloseButton>
-					<DialogHeader>
-						<DialogTitle>更新日志</DialogTitle>
-						<DialogDescription>
-							{versionLabel ? `即将安装 v${versionLabel}` : "即将安装最新版本"}
-						</DialogDescription>
-					</DialogHeader>
-					<pre className="max-h-[360px] overflow-auto whitespace-pre-wrap rounded-2xl bg-slate-50 p-4 text-sm leading-6 text-slate-700">
-						{updateState.releaseNotes || "当前版本没有附带更新日志。"}
-					</pre>
-				</DialogContent>
-			</Dialog>
-		</>
+				<span>检查更新</span>
+			</button>
+		</div>
 	);
 }
 


### PR DESCRIPTION
- 将更新下载完成提示调整为右下角非阻塞浮层，避免影响用户继续操作
- 增加稍后提醒机制，关闭后定时重新提示可安装更新
- 优化更新浮层布局与样式，提供稍后和重启升级操作
- 简化左下角账户菜单更新入口，仅保留检查更新能力