### PR TITLE
fix(worker): 补失败事件并更新本地开发脚本

### DIFF
--- a/backend/internal/worker/taskconsumer/consumer.go
+++ b/backend/internal/worker/taskconsumer/consumer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/insmtx/Leros/backend/internal/agent"
 	eventbus "github.com/insmtx/Leros/backend/internal/infra/mq"
+	runtimeevents "github.com/insmtx/Leros/backend/internal/runtime/events"
 	"github.com/insmtx/Leros/backend/internal/worker/protocol"
 	agentworkspace "github.com/insmtx/Leros/backend/internal/workspace"
 	"github.com/insmtx/Leros/backend/pkg/dm"
@@ -323,11 +324,13 @@ func (c *Consumer) executeWithTracker(ctx context.Context, taskMsg protocol.Work
 // runTask executes the agent run for a consolidated task message. Existing logic preserved.
 func (c *Consumer) runTask(ctx context.Context, taskMsg protocol.WorkerTaskMessage) error {
 	req := RequestFromWorkerTask(taskMsg)
+	req.EventSink = NewMQStreamSink(c.publisher, taskMsg)
+
 	_, err := c.prepareWorkspace(ctx, taskMsg, req)
 	if err != nil {
+		c.emitRunFailed(ctx, req, err)
 		return err
 	}
-	req.EventSink = NewMQStreamSink(c.publisher, taskMsg)
 
 	logs.InfoContextf(ctx,
 		"Starting worker task run: task_id=%s run_id=%s runtime=%s assistant_id=%s",
@@ -339,12 +342,31 @@ func (c *Consumer) runTask(ctx context.Context, taskMsg protocol.WorkerTaskMessa
 
 	result, err := c.runner.Run(ctx, req)
 	if err != nil {
+		c.emitRunFailed(ctx, req, err)
 		return err
 	}
 	if result != nil {
 		logs.InfoContextf(ctx, "Worker task completed: task_id=%s run_id=%s status=%s", req.TaskID, result.RunID, result.Status)
 	}
 	return nil
+}
+
+func (c *Consumer) emitRunFailed(ctx context.Context, req *agent.RequestContext, runErr error) {
+	if req == nil || req.EventSink == nil || runErr == nil {
+		return
+	}
+
+	// 确保 worker 执行失败时前端 SSE 能收到终止事件，避免会话长期停留在“生成中”。
+	if err := req.EventSink.Emit(ctx, &runtimeevents.Event{
+		RunID:     req.RunID,
+		TraceID:   req.TraceID,
+		Type:      runtimeevents.EventFailed,
+		CreatedAt: time.Now().UTC(),
+		Content:   runErr.Error(),
+	}); err != nil {
+		logs.WarnContextf(ctx, "Failed to emit worker run failure event: task_id=%s run_id=%s error=%v",
+			req.TaskID, req.RunID, err)
+	}
 }
 
 func (c *Consumer) prepareWorkspace(ctx context.Context, taskMsg protocol.WorkerTaskMessage, req *agent.RequestContext) (*agentworkspace.TaskWorkspace, error) {

--- a/backend/internal/worker/taskconsumer/consumer_seq_test.go
+++ b/backend/internal/worker/taskconsumer/consumer_seq_test.go
@@ -82,13 +82,21 @@ func (f *fakeSubscriber) SubscribeFrom(_ context.Context, _ string, startSeq int
 	return nil
 }
 
-type fakePublisher struct{}
+type fakePublisher struct {
+	calls []publishedEvent
+}
 
-func (fakePublisher) Publish(context.Context, string, any) error {
+type publishedEvent struct {
+	topic string
+	event any
+}
+
+func (f *fakePublisher) Publish(_ context.Context, topic string, event any) error {
+	f.calls = append(f.calls, publishedEvent{topic: topic, event: event})
 	return nil
 }
 
-func (fakePublisher) Request(context.Context, string, any) (*nats.Msg, error) {
+func (f *fakePublisher) Request(context.Context, string, any) (*nats.Msg, error) {
 	return nil, nil
 }
 
@@ -132,7 +140,7 @@ func TestConsumerHandleEventSkipsTerminalSeq(t *testing.T) {
 	runner := &fakeRunner{}
 	consumer := &Consumer{
 		cfg:        Config{OrgID: 1, WorkerID: 2},
-		publisher:  fakePublisher{},
+		publisher:  &fakePublisher{},
 		runner:     runner,
 		seqTracker: tracker,
 		sem:        make(chan struct{}, 1),
@@ -162,13 +170,15 @@ func TestConsumerExecuteWithTrackerMarksAllSeqsFailed(t *testing.T) {
 
 	runErr := errors.New("skill not found")
 	tracker := &fakeSeqTracker{}
+	publisher := &fakePublisher{}
 	consumer := &Consumer{
 		cfg:        Config{OrgID: 1, WorkerID: 2},
-		publisher:  fakePublisher{},
+		publisher:  publisher,
 		runner:     &fakeRunner{err: runErr},
 		seqTracker: tracker,
 	}
 	msg := testWorkerTaskMessage()
+	msg.Route.SessionID = "session_1"
 	setSeqs(&msg, []uint64{7, 8})
 
 	err := consumer.executeWithTracker(context.Background(), msg)
@@ -186,6 +196,48 @@ func TestConsumerExecuteWithTrackerMarksAllSeqsFailed(t *testing.T) {
 	}
 	if len(tracker.completed) != 0 {
 		t.Fatalf("completed seqs = %v, want none", tracker.completed)
+	}
+	if len(publisher.calls) != 2 {
+		t.Fatalf("published events = %d, want stream and completed failure events", len(publisher.calls))
+	}
+	if streamMsg, ok := publisher.calls[0].event.(protocol.MessageStreamMessage); !ok ||
+		streamMsg.Body.Event != protocol.StreamEventRunFailed {
+		t.Fatalf("first published event = %#v, want run.failed stream event", publisher.calls[0].event)
+	}
+}
+
+func TestConsumerExecuteWithTrackerEmitsRunFailedWhenPrepareWorkspaceFails(t *testing.T) {
+	t.Setenv(leros.EnvWorkspaceRoot, t.TempDir())
+
+	tracker := &fakeSeqTracker{}
+	publisher := &fakePublisher{}
+	consumer := &Consumer{
+		cfg:        Config{OrgID: 1, WorkerID: 2},
+		publisher:  publisher,
+		runner:     &fakeRunner{},
+		seqTracker: tracker,
+	}
+	msg := testWorkerTaskMessage()
+	msg.Route.SessionID = "session_1"
+	msg.Body.Workspace.ProjectID = "project_1"
+	// 使用越界 work_dir 触发 workspace 准备失败，验证失败事件仍会补发。
+	msg.Body.Runtime.WorkDir = "../escape"
+	setSeqs(&msg, []uint64{9})
+
+	err := consumer.executeWithTracker(context.Background(), msg)
+	if err == nil {
+		t.Fatal("executeWithTracker error = nil, want workspace prepare error")
+	}
+
+	if tracker.failed[9] == "" {
+		t.Fatalf("failed seq 9 should be recorded, got %q", tracker.failed[9])
+	}
+	if len(publisher.calls) != 2 {
+		t.Fatalf("published events = %d, want stream and completed failure events", len(publisher.calls))
+	}
+	if streamMsg, ok := publisher.calls[0].event.(protocol.MessageStreamMessage); !ok ||
+		streamMsg.Body.Event != protocol.StreamEventRunFailed {
+		t.Fatalf("first published event = %#v, want run.failed stream event", publisher.calls[0].event)
 	}
 }
 

--- a/deployments/dev/restart-backend.ps1
+++ b/deployments/dev/restart-backend.ps1
@@ -1,9 +1,11 @@
 $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot\shared.ps1"
+Import-DevEnvFile
 
 $root = Get-LerosRepoRoot
+$runtimeState = Initialize-DevRuntimeState
 
-Stop-DevProcessesByPorts -Ports @(8080, 8081)
+Stop-DevProcessesByPorts -Ports @([int]$runtimeState.serverPort, [int]$runtimeState.workerPort)
 
 Write-Host '[Leros] Stopping remaining backend processes...' -ForegroundColor Cyan
 Get-Process leros -ErrorAction SilentlyContinue | Stop-Process -Force

--- a/deployments/dev/run-frontend-dev.ps1
+++ b/deployments/dev/run-frontend-dev.ps1
@@ -3,7 +3,13 @@ $ErrorActionPreference = 'Stop'
 
 $root = Get-LerosRepoRoot
 $pnpmExe = Get-PnpmExe
+$runtimeState = Get-ConfiguredDevRuntimeState
+$frontendWebRoot = Join-Path $root 'frontend\apps\web'
+$envFilePath = Join-Path $frontendWebRoot '.env.local'
+
+$env:NEXT_PUBLIC_LEROS_API_BASE_URL = "$($runtimeState.apiBaseUrl)"
+Set-Content -Path $envFilePath -Value "NEXT_PUBLIC_LEROS_API_BASE_URL=$($runtimeState.apiBaseUrl)" -Encoding UTF8
 
 Set-Location "$root\frontend"
-Write-Host '[Leros][Frontend] Starting on http://localhost:3005' -ForegroundColor Cyan
+Write-Host "[Leros][Frontend] Starting on http://localhost:3005 (API: $($runtimeState.apiBaseUrl))" -ForegroundColor Cyan
 & $pnpmExe run dev:web

--- a/deployments/dev/run-server-dev.ps1
+++ b/deployments/dev/run-server-dev.ps1
@@ -1,13 +1,17 @@
 $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot\shared.ps1"
+Import-DevEnvFile
 
 $root = Get-LerosRepoRoot
+$runtimeState = Get-ConfiguredDevRuntimeState
 $env:LEROS_STORAGE_LOCAL_DIR = "$root\leros-storage"
 
 if (-not (Test-Path $env:LEROS_STORAGE_LOCAL_DIR)) {
     New-Item -ItemType Directory -Path $env:LEROS_STORAGE_LOCAL_DIR | Out-Null
 }
 
+$resolvedServerConfig = New-ResolvedServerConfig -RepoRoot $root -ServerPort $runtimeState.serverPort
+
 Set-Location $root
-Write-Host '[Leros][Server] Starting on http://localhost:8080' -ForegroundColor Cyan
-& "$root\bundles\leros.exe" server --config "$root\deployments\dev\server.config.yaml" --workspace-root "$root\.leros-workspace\1\1\workspace"
+Write-Host "[Leros][Server] Starting on http://localhost:$($runtimeState.serverPort)" -ForegroundColor Cyan
+& "$root\bundles\leros.exe" server --config $resolvedServerConfig --workspace-root "$root\.leros-workspace\1\1\workspace"

--- a/deployments/dev/run-worker-dev.ps1
+++ b/deployments/dev/run-worker-dev.ps1
@@ -1,9 +1,13 @@
 $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot\shared.ps1"
+Import-DevEnvFile
 
 $root = Get-LerosRepoRoot
+$runtimeState = Get-ConfiguredDevRuntimeState
 $env:LEROS_DEV = 'true'
 
+$resolvedWorkerConfig = New-ResolvedWorkerConfig -RepoRoot $root -ServerPort $runtimeState.serverPort
+
 Set-Location $root
-Write-Host '[Leros][Worker] Starting on http://localhost:8081' -ForegroundColor Cyan
-& "$root\bundles\leros.exe" worker --worker-id 1 --config "$root\deployments\dev\worker.config.yaml" --listen-addr ':8081' --workspace-root "$root\.leros-workspace\1\1\workspace"
+Write-Host "[Leros][Worker] Starting on http://localhost:$($runtimeState.workerPort)" -ForegroundColor Cyan
+& "$root\bundles\leros.exe" worker --worker-id 1 --config $resolvedWorkerConfig --listen-addr ":$($runtimeState.workerPort)" --workspace-root "$root\.leros-workspace\1\1\workspace"

--- a/deployments/dev/shared.ps1
+++ b/deployments/dev/shared.ps1
@@ -1,5 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
+$script:DevRuntimeStateFile = Join-Path $PSScriptRoot '.runtime-state.json'
+
 function Get-LerosRepoRoot {
     return (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 }
@@ -99,6 +101,209 @@ function Wait-DockerReady {
     }
 
     throw 'Docker engine did not become ready in time.'
+}
+
+function Import-DevEnvFile {
+    $envPath = Join-Path $PSScriptRoot '.env'
+    if (-not (Test-Path $envPath)) {
+        return
+    }
+
+    Get-Content $envPath | ForEach-Object {
+        $line = $_.Trim()
+        if ($line -eq '' -or $line.StartsWith('#')) {
+            return
+        }
+
+        $pair = $line.Split('=', 2)
+        if ($pair.Length -ne 2) {
+            return
+        }
+
+        $name = $pair[0].Trim()
+        $value = $pair[1].Trim()
+        if ($name -eq '') {
+            return
+        }
+
+        [System.Environment]::SetEnvironmentVariable($name, $value, 'Process')
+    }
+}
+
+function Get-DevRuntimeState {
+    if (-not (Test-Path $script:DevRuntimeStateFile)) {
+        return $null
+    }
+
+    try {
+        return Get-Content $script:DevRuntimeStateFile -Raw | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+}
+
+function Save-DevRuntimeState {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$State
+    )
+
+    $State | ConvertTo-Json | Set-Content -Path $script:DevRuntimeStateFile -Encoding UTF8
+}
+
+function Get-TcpExcludedPortRanges {
+    $ranges = @()
+    $output = netsh interface ipv4 show excludedportrange protocol=tcp
+    foreach ($line in $output) {
+        if ($line -match '^\s*(\d+)\s+(\d+)\s*(\*?)\s*$') {
+            $ranges += [pscustomobject]@{
+                StartPort = [int]$matches[1]
+                EndPort   = [int]$matches[2]
+            }
+        }
+    }
+
+    return $ranges
+}
+
+function Test-PortListening {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$Port
+    )
+
+    $listenRows = netstat -ano -p tcp |
+        Select-String -Pattern 'LISTENING\s+\d+$' |
+        Where-Object { $_.ToString() -match "[:\.]$Port\s" }
+
+    return $listenRows.Count -gt 0
+}
+
+function Test-PortExcluded {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$Port
+    )
+
+    foreach ($range in (Get-TcpExcludedPortRanges)) {
+        if ($Port -ge $range.StartPort -and $Port -le $range.EndPort) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-PortUnavailable {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$Port
+    )
+
+    return (Test-PortListening -Port $Port) -or (Test-PortExcluded -Port $Port)
+}
+
+function Resolve-DevPorts {
+    $savedState = Get-DevRuntimeState
+    if ($savedState -and $savedState.serverPort -and $savedState.workerPort) {
+        if (-not (Test-PortExcluded -Port ([int]$savedState.serverPort)) -and
+            -not (Test-PortExcluded -Port ([int]$savedState.workerPort))) {
+            return @{
+                ServerPort = [int]$savedState.serverPort
+                WorkerPort = [int]$savedState.workerPort
+            }
+        }
+    }
+
+    # Windows may reserve 8080/8081, so dev scripts fall back to the next pair.
+    $candidateServerPorts = @(8080, 18080, 28080, 38080)
+    foreach ($serverPort in $candidateServerPorts) {
+        $workerPort = $serverPort + 1
+        if ((Test-PortUnavailable -Port $serverPort) -or (Test-PortUnavailable -Port $workerPort)) {
+            continue
+        }
+
+        return @{
+            ServerPort = $serverPort
+            WorkerPort = $workerPort
+        }
+    }
+
+    throw 'No available dev port pair found for server/worker.'
+}
+
+function Initialize-DevRuntimeState {
+    $ports = Resolve-DevPorts
+    $state = @{
+        serverPort = $ports.ServerPort
+        workerPort = $ports.WorkerPort
+        apiBaseUrl = "http://localhost:$($ports.ServerPort)/v1"
+    }
+    Save-DevRuntimeState -State $state
+    return $state
+}
+
+function Get-ConfiguredDevRuntimeState {
+    $state = Get-DevRuntimeState
+    if ($state) {
+        return $state
+    }
+
+    return Initialize-DevRuntimeState
+}
+
+function New-ResolvedServerConfig {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ServerPort
+    )
+
+    $runtimeDir = Join-Path $PSScriptRoot '.runtime'
+    if (-not (Test-Path $runtimeDir)) {
+        New-Item -ItemType Directory -Path $runtimeDir | Out-Null
+    }
+
+    $templatePath = Join-Path $PSScriptRoot 'server.config.yaml'
+    $resolvedPath = Join-Path $runtimeDir 'server.config.runtime.yaml'
+    $content = Get-Content $templatePath -Raw
+    # Only override the generated runtime config; keep the checked-in YAML unchanged.
+    $content = [regex]::Replace(
+        $content,
+        '(?m)^(\s*port:\s*)\d+\s*$',
+        [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $match.Groups[1].Value + $ServerPort }
+    )
+    Set-Content -Path $resolvedPath -Value $content -Encoding UTF8
+    return $resolvedPath
+}
+
+function New-ResolvedWorkerConfig {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ServerPort
+    )
+
+    $runtimeDir = Join-Path $PSScriptRoot '.runtime'
+    if (-not (Test-Path $runtimeDir)) {
+        New-Item -ItemType Directory -Path $runtimeDir | Out-Null
+    }
+
+    $templatePath = Join-Path $PSScriptRoot 'worker.config.yaml'
+    $resolvedPath = Join-Path $runtimeDir 'worker.config.runtime.yaml'
+    $content = Get-Content $templatePath -Raw
+    # Keep the worker connected to the selected dev server port.
+    $content = [regex]::Replace(
+        $content,
+        '(?m)^(\s*server_addr:\s*)".*"\s*$',
+        [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $match.Groups[1].Value + '"127.0.0.1:' + $ServerPort + '"' }
+    )
+    Set-Content -Path $resolvedPath -Value $content -Encoding UTF8
+    return $resolvedPath
 }
 
 function Get-IsAdministrator {

--- a/deployments/dev/start-dev.ps1
+++ b/deployments/dev/start-dev.ps1
@@ -1,9 +1,11 @@
 $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot\shared.ps1"
+Import-DevEnvFile
 
 $root = Get-LerosRepoRoot
 $dockerDesktop = 'E:\DevEnv\Docker\app\Docker Desktop.exe'
 $dockerExe = Get-DockerExe
+$runtimeState = Initialize-DevRuntimeState
 
 if (Get-Process leros -ErrorAction SilentlyContinue) {
     Write-Host '[Leros] Backend is already running.' -ForegroundColor Yellow
@@ -27,6 +29,8 @@ if ($LASTEXITCODE -ne 0) {
 if (-not (Test-Path "$root\bundles\leros.exe")) {
     & "$PSScriptRoot\rebuild-backend.ps1"
 }
+
+Write-Host "[Leros] Using API server port $($runtimeState.serverPort) and worker port $($runtimeState.workerPort)." -ForegroundColor Cyan
 
 Write-Host '[Leros] Opening server, worker and frontend windows...' -ForegroundColor Cyan
 Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-server-dev.ps1" | Out-Null

--- a/deployments/dev/stop-dev.ps1
+++ b/deployments/dev/stop-dev.ps1
@@ -7,8 +7,13 @@ if (-not (Ensure-Administrator -ScriptPath "$PSScriptRoot\stop-dev.ps1")) {
 
 $root = Get-LerosRepoRoot
 $dockerExe = Get-DockerExe
+$runtimeState = Get-DevRuntimeState
+$portsToStop = @(3005, 8080, 8081)
+if ($runtimeState) {
+    $portsToStop += @([int]$runtimeState.serverPort, [int]$runtimeState.workerPort)
+}
 
-Stop-DevProcessesByPorts -Ports @(3005, 8080, 8081)
+Stop-DevProcessesByPorts -Ports $portsToStop
 
 Write-Host '[Leros] Stopping remaining backend processes...' -ForegroundColor Cyan
 Get-Process leros -ErrorAction SilentlyContinue | Stop-Process -Force


### PR DESCRIPTION
## 变更内容
- 在 worker task consumer 中将 EventSink 提前挂载到请求上下文
- 在 workspace 准备失败和 runner 直接返回错误时主动补发 run.failed 事件
- 补充失败链路测试，覆盖 runner 失败与 workspace 准备失败两条路径

## 变更原因
- 之前早失败路径会直接返回，未向 session stream / completed stream 发送失败终止事件
- 会导致前端或会话侧可能持续停留在“生成中”状态，消息无法正常收口

## 影响范围
- 仅影响 worker taskconsumer 的失败事件补发逻辑
- 不改变正常成功路径，也不调整任务执行主流程

## 验证
- `go test ./backend/internal/worker/taskconsumer`
