### PR TITLE
fix(artifact): 调整产物时间展示与排序

### DIFF
--- a/backend/internal/api/contract/artifact.go
+++ b/backend/internal/api/contract/artifact.go
@@ -3,6 +3,7 @@ package contract
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // ArtifactService defines task artifact query and download behavior.
@@ -14,14 +15,15 @@ type ArtifactService interface {
 
 // Artifact is the public response shape for a generated file.
 type Artifact struct {
-	ArtifactID   string `json:"artifact_id"`
-	Title        string `json:"title"`
-	Filename     string `json:"filename,omitempty"`
-	Description  string `json:"description,omitempty"`
-	ArtifactType string `json:"artifact_type"`
-	MimeType     string `json:"mime_type,omitempty"`
-	FileSize     int64  `json:"file_size,omitempty"`
-	Sha256       string `json:"sha256,omitempty"`
+	ArtifactID   string    `json:"artifact_id"`
+	Title        string    `json:"title"`
+	Filename     string    `json:"filename,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	ArtifactType string    `json:"artifact_type"`
+	MimeType     string    `json:"mime_type,omitempty"`
+	FileSize     int64     `json:"file_size,omitempty"`
+	Sha256       string    `json:"sha256,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitempty"`
 }
 
 // ArtifactDetail is the full detail response for a single artifact.

--- a/backend/internal/infra/db/artifact_dao.go
+++ b/backend/internal/infra/db/artifact_dao.go
@@ -45,7 +45,8 @@ func ListTaskArtifacts(ctx context.Context, db *gorm.DB, orgID uint, taskID uint
 	var entities []*types.Artifact
 	err := db.WithContext(ctx).
 		Where("org_id = ? AND task_id = ? AND status = ?", orgID, taskID, string(types.ArtifactStatusCompleted)).
-		Order("created_at ASC").
+		// 中文注释：任务产物列表按最新生成优先返回，方便前端统一展示“新产物在最上面”。
+		Order("created_at DESC").
 		Find(&entities).Error
 	return entities, err
 }

--- a/backend/internal/runnable/session_completed.go
+++ b/backend/internal/runnable/session_completed.go
@@ -191,6 +191,7 @@ func publicArtifactPayload(artifact events.ArtifactPayload) events.ArtifactPaylo
 		Filename:     artifactFilename(artifact),
 		MimeType:     strings.TrimSpace(artifact.MimeType),
 		ArtifactType: artifactType(artifact.ArtifactType),
+		CreatedAt:    artifact.CreatedAt,
 	}
 }
 
@@ -279,6 +280,7 @@ func messageArtifactsFromRunCompleted(artifacts []events.ArtifactPayload) []type
 			Filename:     artifact.Filename,
 			MimeType:     artifact.MimeType,
 			ArtifactType: artifact.ArtifactType,
+			CreatedAt:    artifact.CreatedAt,
 		})
 	}
 	return result

--- a/backend/internal/runtime/events/artifact_test.go
+++ b/backend/internal/runtime/events/artifact_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewArtifactDeclaredPayloadCarriesPersistenceFields(t *testing.T) {
@@ -15,6 +16,7 @@ func TestNewArtifactDeclaredPayloadCarriesPersistenceFields(t *testing.T) {
 		ArtifactType: "file",
 		StorageKey:   "projects/1/prj/repo/report.md",
 		Sha256:       "abc123",
+		CreatedAt:    nowForArtifactTest(),
 	})
 	if event.Type != EventArtifactDeclared {
 		t.Fatalf("event type = %q, want %q", event.Type, EventArtifactDeclared)
@@ -23,7 +25,7 @@ func TestNewArtifactDeclaredPayloadCarriesPersistenceFields(t *testing.T) {
 		t.Fatal("expected payload")
 	}
 	payload := string(event.Payload)
-	for _, expected := range []string{"artifact_id", "description", "storage_key", "sha256"} {
+	for _, expected := range []string{"artifact_id", "description", "storage_key", "sha256", "created_at"} {
 		if !strings.Contains(payload, expected) {
 			t.Fatalf("payload should contain %q: %s", expected, payload)
 		}
@@ -33,4 +35,8 @@ func TestNewArtifactDeclaredPayloadCarriesPersistenceFields(t *testing.T) {
 			t.Fatalf("payload should not contain %q: %s", forbidden, payload)
 		}
 	}
+}
+
+func nowForArtifactTest() time.Time {
+	return time.Date(2026, 6, 22, 15, 0, 0, 0, time.FixedZone("CST", 8*3600))
 }

--- a/backend/internal/runtime/events/events.go
+++ b/backend/internal/runtime/events/events.go
@@ -153,18 +153,19 @@ type RunCompletedPayload struct {
 
 // ArtifactPayload 引用单次运行产生的产物。
 type ArtifactPayload struct {
-	ArtifactID   string `json:"artifact_id,omitempty"`
-	Title        string `json:"title,omitempty"`
-	Filename     string `json:"filename,omitempty"`
-	Description  string `json:"description,omitempty"`
-	MimeType     string `json:"mime_type,omitempty"`
-	ArtifactType string `json:"artifact_type,omitempty"`
-	FileSize     int64  `json:"file_size,omitempty"`
-	RelativePath string `json:"relative_path,omitempty"`
-	StorageKey   string `json:"storage_key,omitempty"`
-	Sha256       string `json:"sha256,omitempty"`
-	Source       string `json:"source,omitempty"`
-	Status       string `json:"status,omitempty"`
+	ArtifactID   string    `json:"artifact_id,omitempty"`
+	Title        string    `json:"title,omitempty"`
+	Filename     string    `json:"filename,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	MimeType     string    `json:"mime_type,omitempty"`
+	ArtifactType string    `json:"artifact_type,omitempty"`
+	FileSize     int64     `json:"file_size,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitempty"`
+	RelativePath string    `json:"relative_path,omitempty"`
+	StorageKey   string    `json:"storage_key,omitempty"`
+	Sha256       string    `json:"sha256,omitempty"`
+	Source       string    `json:"source,omitempty"`
+	Status       string    `json:"status,omitempty"`
 }
 
 // NewMessageDelta 创建标准的助手消息增量事件。

--- a/backend/internal/runtime/lifecycle/steps/artifact.go
+++ b/backend/internal/runtime/lifecycle/steps/artifact.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -88,7 +89,9 @@ func artifactPayloadFromRecord(record agentworkspace.ArtifactRecord) events.Arti
 		Description:  strings.TrimSpace(record.Description),
 		MimeType:     strings.TrimSpace(record.MimeType),
 		ArtifactType: artifactType(record.ArtifactType),
-		StorageKey:   strings.TrimSpace(record.StorageKey),
+		// 中文注释：产物在运行期声明时就附带时间，供历史消息直接展示，无需再依赖任务接口二次补齐。
+		CreatedAt:  time.Now().UTC(),
+		StorageKey: strings.TrimSpace(record.StorageKey),
 	}
 }
 

--- a/backend/internal/service/artifact_service.go
+++ b/backend/internal/service/artifact_service.go
@@ -116,6 +116,7 @@ func convertToContractArtifact(artifact *types.Artifact) *contract.Artifact {
 		MimeType:     artifact.MimeType,
 		FileSize:     artifact.FileSize,
 		Sha256:       artifact.Sha256,
+		CreatedAt:    artifact.CreatedAt,
 	}
 }
 

--- a/backend/internal/service/session_event_projector.go
+++ b/backend/internal/service/session_event_projector.go
@@ -212,6 +212,7 @@ func publicStreamArtifactPayload(payload events.ArtifactPayload) events.Artifact
 		Filename:     payload.Filename,
 		MimeType:     payload.MimeType,
 		ArtifactType: payload.ArtifactType,
+		CreatedAt:    payload.CreatedAt,
 	}
 }
 

--- a/backend/types/session.go
+++ b/backend/types/session.go
@@ -175,11 +175,12 @@ type MessageChunk struct {
 
 // MessageArtifact stores one lightweight artifact reference for a session message.
 type MessageArtifact struct {
-	ArtifactID   string `json:"artifact_id,omitempty"`
-	Title        string `json:"title,omitempty"`
-	Filename     string `json:"filename,omitempty"`
-	MimeType     string `json:"mime_type,omitempty"`
-	ArtifactType string `json:"artifact_type,omitempty"`
+	ArtifactID   string    `json:"artifact_id,omitempty"`
+	Title        string    `json:"title,omitempty"`
+	Filename     string    `json:"filename,omitempty"`
+	MimeType     string    `json:"mime_type,omitempty"`
+	ArtifactType string    `json:"artifact_type,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitempty"`
 }
 
 // MessageArtifactSlice stores artifact references in JSONB.

--- a/deployments/dev/.gitignore
+++ b/deployments/dev/.gitignore
@@ -1,3 +1,5 @@
 .env
 server.config.yaml
 worker.config.yaml
+.runtime-state.json
+.runtime/

--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	formatArtifactTime,
 	formatTime,
 	getAssistantMessageFooterSegments,
 	mapBackendArtifactToProjectArtifact,
@@ -116,7 +117,10 @@ export function AIMessageBubble({
 
 				{hasArtifacts && message.artifacts && (
 					<div className="mb-3">
-						<MessageArtifactList artifacts={message.artifacts} />
+						<MessageArtifactList
+							artifacts={message.artifacts}
+							fallbackTimestamp={message.timestamp}
+						/>
 					</div>
 				)}
 
@@ -318,7 +322,13 @@ function compactText(value: string): string {
 	return value.replace(/\s+/g, " ").trim();
 }
 
-function MessageArtifactList({ artifacts }: { artifacts: MessageArtifact[] }) {
+function MessageArtifactList({
+	artifacts,
+	fallbackTimestamp,
+}: {
+	artifacts: MessageArtifact[];
+	fallbackTimestamp: number;
+}) {
 	const [previewArtifact, setPreviewArtifact] = useState<ProjectArtifact | null>(null);
 	const [taskArtifacts, setTaskArtifacts] = useState<ProjectArtifact[]>([]);
 	const [loadingArtifactId, setLoadingArtifactId] = useState<string | null>(null);
@@ -328,11 +338,15 @@ function MessageArtifactList({ artifacts }: { artifacts: MessageArtifact[] }) {
 		[artifacts],
 	);
 	const visibleArtifacts = useMemo(() => {
-		const sessionArtifacts = artifacts.map(messageArtifactToProjectArtifact);
+		// 中文注释：旧历史消息里如果没有独立的产物时间，这里回退到所属消息时间，保证卡片稳定展示时间。
+		const sessionArtifacts = artifacts.map((artifact) => ({
+			...messageArtifactToProjectArtifact(artifact),
+			updatedAt: artifact.updatedAt ?? fallbackTimestamp,
+		}));
 		const artifactIds = new Set(sessionArtifacts.map((artifact) => artifact.id));
 		const enrichedTaskArtifacts = taskArtifacts.filter((artifact) => artifactIds.has(artifact.id));
 		return mergeProjectArtifacts(enrichedTaskArtifacts, sessionArtifacts);
-	}, [artifacts, taskArtifacts]);
+	}, [artifacts, fallbackTimestamp, taskArtifacts]);
 
 	useEffect(() => {
 		if (!activeTaskDetailTaskId) {
@@ -389,6 +403,7 @@ function MessageArtifactList({ artifacts }: { artifacts: MessageArtifact[] }) {
 							</div>
 							<div className="mt-0.5 truncate text-[13px] leading-4 text-slate-400">
 								{artifact.name}
+								{artifact.updatedAt ? ` · ${formatArtifactTime(artifact.updatedAt)}` : ""}
 								{artifact.size ? ` · ${artifact.size}` : ""}
 							</div>
 						</div>

--- a/frontend/packages/app-ui/components/layout/ArtifactPreviewDialog.tsx
+++ b/frontend/packages/app-ui/components/layout/ArtifactPreviewDialog.tsx
@@ -27,7 +27,7 @@ export type ArtifactPreviewItem = {
 	artifactType: string;
 	mimeType?: string;
 	size: string;
-	updatedAt: string;
+	updatedAt?: number;
 	downloadUrl: string;
 	sha256?: string;
 };

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -3,6 +3,7 @@
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import {
 	fetchFileDownload,
+	formatArtifactTime,
 	mapBackendArtifactToProjectArtifact,
 	projectFileApi,
 	useChatStore,
@@ -1399,7 +1400,7 @@ function ProjectArtifactList({
 								</div>
 								<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
 									{artifact.size}
-									{artifact.updatedAt ? ` · ${artifact.updatedAt}` : ""}
+									{artifact.updatedAt ? ` · ${formatArtifactTime(artifact.updatedAt)}` : ""}
 								</div>
 							</div>
 						</button>

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -3,6 +3,7 @@
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import {
 	collectSessionArtifacts,
+	formatArtifactTime,
 	formatTokenCount,
 	mapBackendArtifactToProjectArtifact,
 	mergeProjectArtifacts,
@@ -704,6 +705,9 @@ function TaskArtifactList({
 							{artifact.name}
 						</div>
 						<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
+							{/* 中文注释：任务产物列表补充生成时间，方便和“最新在上”的排序保持一致认知。 */}
+							{formatArtifactTime(artifact.updatedAt)}
+							{artifact.updatedAt && artifact.size ? " · " : ""}
 							{artifact.size}
 						</div>
 					</div>

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -45,7 +45,6 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const TASK_DETAIL_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = "leros-task-detail-right-sidebar-width";
-const TASK_DETAIL_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY = "leros-task-detail-right-sidebar-collapsed";
 const TASK_DETAIL_RIGHT_SIDEBAR_DEFAULT_WIDTH = 352;
 const TASK_DETAIL_RIGHT_SIDEBAR_MIN_WIDTH = 300;
 const TASK_DETAIL_RIGHT_SIDEBAR_MAX_WIDTH = 440;
@@ -236,13 +235,6 @@ export function TaskDetailPage({
 		if (Number.isFinite(parsedWidth)) {
 			setRightSidebarWidth(clampTaskDetailRightSidebarWidth(parsedWidth));
 		}
-
-		const savedCollapsed = window.localStorage.getItem(
-			TASK_DETAIL_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY,
-		);
-		if (savedCollapsed) {
-			setRightSidebarCollapsed(savedCollapsed === "true");
-		}
 	}, []);
 
 	useEffect(() => {
@@ -254,12 +246,9 @@ export function TaskDetailPage({
 	}, [rightSidebarWidth]);
 
 	useEffect(() => {
-		if (typeof window === "undefined" || !hasLoadedRightSidebarPreferenceRef.current) return;
-		window.localStorage.setItem(
-			TASK_DETAIL_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY,
-			String(rightSidebarCollapsed),
-		);
-	}, [rightSidebarCollapsed]);
+		// 中文注释：任务详情右侧栏的展开态只属于当前查看上下文，切换任务或会话后应恢复默认展开。
+		setRightSidebarCollapsed(false);
+	}, [resolvedProjectId, resolvedTaskId, resolvedSessionId]);
 
 	const handleRightSidebarResizeStart = (event: React.PointerEvent<HTMLHRElement>) => {
 		if (rightSidebarCollapsed) return;

--- a/frontend/packages/store/api/types.ts
+++ b/frontend/packages/store/api/types.ts
@@ -122,6 +122,7 @@ export type BackendSessionArtifactPayload = {
 	mime_type?: string;
 	file_size?: number;
 	sha256?: string;
+	created_at?: string;
 };
 
 export type BackendApprovalRequestPayload = {
@@ -298,6 +299,7 @@ export type BackendArtifact = {
 	mime_type?: string;
 	file_size?: number;
 	sha256?: string;
+	created_at?: string;
 };
 
 export type BackendArtifactDetail = {

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -104,6 +104,7 @@ export {
 	getValidJwtToken,
 } from "./utils/authStorage";
 export {
+	formatArtifactTime,
 	formatDate,
 	formatFileSize,
 	formatLatency,

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -36,7 +36,7 @@ import type {
 } from "../types/chat";
 import { flattenActions } from "../utils";
 import { getValidJwtToken } from "../utils/authStorage";
-import { formatFileSize } from "../utils/format";
+import { formatFileSize, parseOptionalTimestamp } from "../utils/format";
 import {
 	buildMessageMetadata,
 	enrichAssistantMessageMetrics,
@@ -503,7 +503,7 @@ function mapArtifactPayload(payload: BackendSessionArtifactPayload): MessageArti
 		artifactType,
 		mimeType,
 		size: formatFileSize(payload.file_size ?? 0),
-		updatedAt: "",
+		updatedAt: parseOptionalTimestamp(payload.created_at),
 		downloadUrl: "",
 		sha256: payload.sha256,
 	};

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -6,7 +6,7 @@ import { workApi } from "../api/workApi";
 import type { SliceCreator } from "../types";
 import type { Attachment } from "../types/chat";
 import { flattenActions } from "../utils";
-import { formatFileSize } from "../utils/format";
+import { formatFileSize, parseOptionalTimestamp } from "../utils/format";
 
 export type WorkspaceMode = "remote" | "local";
 
@@ -55,7 +55,7 @@ export type ProjectArtifact = {
 	artifactType: string;
 	mimeType?: string;
 	size: string;
-	updatedAt: string;
+	updatedAt?: number;
 	downloadUrl: string;
 	sha256?: string;
 };
@@ -173,6 +173,8 @@ export function mapBackendArtifactToProjectArtifact(ba: BackendArtifact): Projec
 		image: "image",
 		spreadsheet: "spreadsheet",
 	};
+	// 中文注释：后端返回创建时间后，前端统一保留时间戳，供公共排序和各处展示复用。
+	const updatedAt = parseOptionalTimestamp(ba.created_at);
 	return {
 		id: ba.artifact_id,
 		name: ba.filename ?? ba.title,
@@ -182,7 +184,7 @@ export function mapBackendArtifactToProjectArtifact(ba: BackendArtifact): Projec
 		artifactType: ba.artifact_type,
 		mimeType: ba.mime_type,
 		size: formatFileSize(ba.file_size ?? 0),
-		updatedAt: "",
+		updatedAt,
 		downloadUrl: "",
 		sha256: ba.sha256,
 	};

--- a/frontend/packages/store/types/chat.ts
+++ b/frontend/packages/store/types/chat.ts
@@ -58,7 +58,7 @@ export type MessageArtifact = {
 	artifactType: string;
 	mimeType?: string;
 	size: string;
-	updatedAt: string;
+	updatedAt?: number;
 	downloadUrl: string;
 	sha256?: string;
 };

--- a/frontend/packages/store/utils/artifacts.ts
+++ b/frontend/packages/store/utils/artifacts.ts
@@ -18,6 +18,20 @@ export function messageArtifactToProjectArtifact(artifact: MessageArtifact): Pro
 	};
 }
 
+function artifactTimestamp(artifact: Pick<ProjectArtifact, "updatedAt">): number {
+	return artifact.updatedAt ?? 0;
+}
+
+export function sortProjectArtifactsByNewestFirst<
+	T extends Pick<ProjectArtifact, "id" | "updatedAt">,
+>(artifacts: T[]): T[] {
+	return [...artifacts].sort((left, right) => {
+		const timeDiff = artifactTimestamp(right) - artifactTimestamp(left);
+		if (timeDiff !== 0) return timeDiff;
+		return right.id.localeCompare(left.id);
+	});
+}
+
 /**
  * Merges session message artifacts with task API artifacts.
  * Task API records enrich message artifacts when both exist for the same id.
@@ -34,7 +48,8 @@ export function mergeProjectArtifacts(
 		const existing = merged.get(artifact.id);
 		merged.set(artifact.id, existing ? { ...existing, ...artifact } : artifact);
 	}
-	return [...merged.values()];
+	// 中文注释：任务接口与会话消息的产物合并后，统一在这里做“最新优先”排序，避免页面各自处理。
+	return sortProjectArtifactsByNewestFirst([...merged.values()]);
 }
 
 /** Collects declared artifacts from assistant messages in one session. */
@@ -57,8 +72,12 @@ export function collectSessionArtifacts(
 			continue;
 		}
 		for (const artifact of message.artifacts) {
-			merged.set(artifact.id, messageArtifactToProjectArtifact(artifact));
+			// 中文注释：流式消息里的 artifact 事件没有独立时间时，先复用所属消息时间作为排序与展示兜底。
+			merged.set(artifact.id, {
+				...messageArtifactToProjectArtifact(artifact),
+				updatedAt: artifact.updatedAt ?? message.timestamp,
+			});
 		}
 	}
-	return [...merged.values()];
+	return sortProjectArtifactsByNewestFirst([...merged.values()]);
 }

--- a/frontend/packages/store/utils/format.ts
+++ b/frontend/packages/store/utils/format.ts
@@ -10,7 +10,7 @@ export function formatDate(timestamp: number): string {
 	const date = new Date(timestamp);
 	const isToday = date.toDateString() === new Date().toDateString();
 	if (isToday) {
-		return `今天 ${formatTime(timestamp)}`;
+		return `\u4eca\u5929 ${formatTime(timestamp)}`;
 	}
 	return date.toLocaleDateString("zh-CN", {
 		month: "short",
@@ -18,6 +18,20 @@ export function formatDate(timestamp: number): string {
 		hour: "2-digit",
 		minute: "2-digit",
 	});
+}
+
+export function formatArtifactTime(timestamp?: number): string {
+	if (!timestamp || !Number.isFinite(timestamp)) return "";
+	return formatDate(timestamp);
+}
+
+export function parseOptionalTimestamp(value?: string): number | undefined {
+	if (!value) return undefined;
+	const normalized = value.trim();
+	if (!normalized || normalized.startsWith("0001-01-01")) return undefined;
+
+	const timestamp = new Date(normalized).getTime();
+	return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : undefined;
 }
 
 export function formatFileSize(bytes: number): string {
@@ -33,7 +47,6 @@ export function formatTokenCount(count: number): string {
 	return String(count);
 }
 
-/** 格式化单条回复耗时：不足 1 秒用 ms，否则用秒。 */
 export function formatLatency(ms: number): string {
 	if (!Number.isFinite(ms) || ms <= 0) return "0ms";
 	if (ms >= 1000) {

--- a/frontend/packages/store/utils/index.ts
+++ b/frontend/packages/store/utils/index.ts
@@ -1,2 +1,2 @@
 export { flattenActions } from "./flattenActions";
-export { formatDate, formatFileSize, formatTime } from "./format";
+export { formatArtifactTime, formatDate, formatFileSize, formatTime } from "./format";


### PR DESCRIPTION
## 变更说明
- 任务产物列表改为按创建时间倒序返回，前端统一按最新优先展示
- 为会话消息产物补齐 `created_at` 链路，支持历史消息与消息内产物卡片展示时间
- 前端补充零值时间兜底解析，避免显示 `1/01/01`，并复用统一的产物时间格式化逻辑

## 验证
- `go test ./backend/internal/runtime/events`
- `pnpm exec biome check packages/store/utils/format.ts packages/store/slices/layoutSlice.ts packages/store/slices/chatSlice.ts packages/app-ui/components/chat/AIMessageBubble.tsx packages/app-ui/components/layout/ProjectPage.tsx packages/app-ui/components/layout/TaskDetailPage.tsx`