### PR TITLE
fix(frontend,dev): 项目发消息后自动跳转任务详情并补充卡死修复脚本

### DIFF
--- a/deployments/dev/fix-chat-stuck.cmd
+++ b/deployments/dev/fix-chat-stuck.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0fix-chat-stuck.ps1"

--- a/deployments/dev/fix-chat-stuck.ps1
+++ b/deployments/dev/fix-chat-stuck.ps1
@@ -1,0 +1,45 @@
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\shared.ps1"
+Import-DevEnvFile
+
+$root = Get-LerosRepoRoot
+$runtimeState = Initialize-DevRuntimeState
+$dbPath = Get-WorkerRecoveryDbPath -RepoRoot $root
+$workspaceRoot = Get-WorkerWorkspaceRoot -RepoRoot $root
+
+Stop-DevProcessesByPorts -Ports @([int]$runtimeState.serverPort, [int]$runtimeState.workerPort)
+
+Write-Host '[Leros] Stopping remaining backend processes...' -ForegroundColor Cyan
+Get-Process leros -ErrorAction SilentlyContinue | Stop-Process -Force
+
+if (-not (Test-Path $dbPath)) {
+    throw "Worker recovery database not found: $dbPath"
+}
+
+$sqliteExe = Get-Sqlite3Exe
+
+# 只清理问答任务主题的恢复游标，避免旧的终态记录继续误判新消息。
+Write-Host '[Leros] Clearing worker task recovery state for chat stuck issue...' -ForegroundColor Cyan
+& $sqliteExe $dbPath "delete from task_seq where topic='org.1.worker.1.task';"
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to clear task_seq recovery state.'
+}
+
+# 这里额外打印剩余记录数，便于快速确认清理是否生效。
+$remainingCount = & $sqliteExe $dbPath "select count(*) from task_seq where topic='org.1.worker.1.task';"
+Write-Host "[Leros] Remaining recovery rows for org.1.worker.1.task: $remainingCount" -ForegroundColor Green
+
+if (-not (Test-Path "$root\bundles\leros.exe")) {
+    & "$PSScriptRoot\rebuild-backend.ps1"
+}
+
+Write-Host '[Leros] Restarting server and worker...' -ForegroundColor Cyan
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-server-dev.ps1" | Out-Null
+Start-Sleep -Seconds 2
+Start-Process powershell.exe -ArgumentList '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', "$PSScriptRoot\run-worker-dev.ps1" | Out-Null
+
+Write-Host ''
+Write-Host '[Leros] Chat stuck recovery completed.' -ForegroundColor Green
+Write-Host "[Leros] Workspace root: $workspaceRoot" -ForegroundColor DarkGray
+Write-Host '[Leros] If the page is still generating forever, refresh once and retry the question.' -ForegroundColor Green
+Read-Host 'Press Enter to exit'

--- a/deployments/dev/shared.ps1
+++ b/deployments/dev/shared.ps1
@@ -46,6 +46,10 @@ function Get-PnpmExe {
     ))
 }
 
+function Get-Sqlite3Exe {
+    return (Resolve-ToolPath -CommandName 'sqlite3')
+}
+
 function Set-OptionalGoBuildEnvironment {
     $fallbackGoroot = 'E:\DevEnv\Go\goroot'
     $fallbackGopath = 'E:\DevEnv\Go\gopath'
@@ -241,6 +245,24 @@ function Initialize-DevRuntimeState {
     }
     Save-DevRuntimeState -State $state
     return $state
+}
+
+function Get-WorkerWorkspaceRoot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    return Join-Path $RepoRoot '.leros-workspace\1\1\workspace'
+}
+
+function Get-WorkerRecoveryDbPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    return Join-Path (Get-WorkerWorkspaceRoot -RepoRoot $RepoRoot) '.leros\leros.db'
 }
 
 function Get-ConfiguredDevRuntimeState {

--- a/frontend/packages/app-ui/components/input/ChatInput.test.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.test.tsx
@@ -1,0 +1,108 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatInput } from "./ChatInput";
+
+const mockSendProjectMessage = vi.fn();
+const mockSetInputText = vi.fn();
+const mockSetInputFocused = vi.fn();
+const mockGoToTaskDetail = vi.fn();
+
+vi.mock("@leros/store", () => ({
+	useChatStore: (selector: (state: Record<string, unknown>) => unknown) =>
+		selector({
+			activeSessionId: null,
+			inputText: "项目首页首条提问",
+			inputAttachments: [],
+			isGenerating: false,
+			messagesMap: {},
+			messageIds: [],
+			selectedModel: "gpt-4.1",
+			modelOptions: [{ id: "gpt-4.1", label: "GPT-4.1" }],
+			setInputText: mockSetInputText,
+			sendMessage: vi.fn(),
+			sendProjectMessage: mockSendProjectMessage,
+			submitApprovalDecision: vi.fn(),
+			cancelGeneration: vi.fn(),
+			addAttachment: vi.fn(),
+			addUploadedAttachment: vi.fn(),
+			removeAttachment: vi.fn(),
+			setInputFocused: mockSetInputFocused,
+			setSelectedModel: vi.fn(),
+		}),
+	useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) =>
+		selector({
+			activeProjectId: "project-1",
+			currentView: "project",
+		}),
+}));
+
+vi.mock("./StructuredComposer", () => ({
+	StructuredComposer: ({
+		value,
+		onChange,
+		onSubmit,
+		onFocus,
+		onBlur,
+		placeholder,
+	}: {
+		value: string;
+		onChange: (value: string) => void;
+		onSubmit: () => void;
+		onFocus: () => void;
+		onBlur: () => void;
+		placeholder?: string;
+	}) => (
+		<div>
+			<textarea
+				aria-label="chat-input"
+				placeholder={placeholder}
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				onFocus={onFocus}
+				onBlur={onBlur}
+			/>
+			<button type="button" onClick={onSubmit}>
+				发送
+			</button>
+		</div>
+	),
+}));
+
+describe("ChatInput", () => {
+	beforeEach(() => {
+		mockSendProjectMessage.mockReset();
+		mockSetInputText.mockReset();
+		mockSetInputFocused.mockReset();
+		mockGoToTaskDetail.mockReset();
+	});
+
+	it("在项目首页发送消息后跳转到新任务详情页", async () => {
+		mockSendProjectMessage.mockResolvedValue({
+			project_id: "project-1",
+			task_id: "task-9",
+			session_id: "session-7",
+		});
+
+		const user = userEvent.setup();
+
+		render(
+			<ChatInput
+				variant="project"
+				navigation={{
+					currentPath: "/projects/project-1",
+					goToRoute: vi.fn(),
+					goToProject: vi.fn(),
+					goToTaskDetail: mockGoToTaskDetail,
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "发送" }));
+
+		expect(mockSendProjectMessage).toHaveBeenCalledWith("项目首页首条提问", "project-1", []);
+		expect(mockGoToTaskDetail).toHaveBeenCalledWith("project-1", "task-9", "session-7");
+	});
+});

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import type { AppNavigation } from "../layout";
 import {
 	getProjectChatLayoutClasses,
 	type ProjectChatLayoutMode,
@@ -32,10 +33,12 @@ export const PROJECT_ATTACHMENT_ACCEPT = "image/*,.pdf,.txt,.md,.json,.xlsx,.xls
 export function ChatInput({
 	variant = "default",
 	projectLayoutMode = "sidebar-expanded",
+	navigation,
 }: {
 	variant?: "default" | "project";
 	/** 项目页聊天区布局：随右侧栏展开/收起切换宽度与留白 */
 	projectLayoutMode?: ProjectChatLayoutMode;
+	navigation?: AppNavigation;
 }) {
 	const {
 		activeSessionId,
@@ -69,16 +72,24 @@ export function ChatInput({
 	const canSend = Boolean(inputText.trim());
 	const pendingApproval = findPendingApproval(messageIds, messagesMap, activeSessionId);
 
-	const submitMessage = useCallback(() => {
+	const submitMessage = useCallback(async () => {
 		// 中文注释：输入区先做一次生成态拦截，避免回车绕过按钮态再次触发发送。
 		if (isGenerating) return;
 		// 仅上传附件而无文字时接口会报错，因此必须输入内容才可发送
 		if (inputText.trim()) {
 			if (isProjectVariant && currentView === "project") {
-				sendProjectMessage(inputText, activeProjectId, inputAttachments);
-			} else {
-				sendMessage(inputText, inputAttachments);
+				const taskEntry = await sendProjectMessage(inputText, activeProjectId, inputAttachments);
+				if (taskEntry?.project_id && taskEntry?.task_id) {
+					// 中文注释：项目首页创建出真实任务后，立即跳到任务详情页，避免仍停留在项目首页的新建任务视图。
+					navigation?.goToTaskDetail(
+						taskEntry.project_id,
+						taskEntry.task_id,
+						taskEntry.session_id ?? null,
+					);
+				}
+				return;
 			}
+			sendMessage(inputText, inputAttachments);
 		}
 	}, [
 		inputText,
@@ -87,6 +98,7 @@ export function ChatInput({
 		currentView,
 		activeProjectId,
 		isGenerating,
+		navigation,
 		sendMessage,
 		sendProjectMessage,
 	]);

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -1,1565 +1,1460 @@
-'use client'
+"use client";
 
-import type { ProjectArtifact, ProjectTask } from '@leros/store'
+import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import {
-  fetchFileDownload,
-  formatArtifactTime,
-  mapBackendArtifactToProjectArtifact,
-  projectFileApi,
-  useChatStore,
-  useLayoutStore,
-} from '@leros/store'
-import { artifactApi } from '@leros/store/api/artifactApi'
-import { cn } from '@leros/ui/lib/utils'
+	fetchFileDownload,
+	formatArtifactTime,
+	mapBackendArtifactToProjectArtifact,
+	projectFileApi,
+	useChatStore,
+	useLayoutStore,
+} from "@leros/store";
+import { artifactApi } from "@leros/store/api/artifactApi";
+import { cn } from "@leros/ui/lib/utils";
 import {
-  Bot,
-  ChevronsLeft,
-  ChevronsLeftRightEllipsis,
-  ChevronsRight,
-  Download,
-  Eye,
-  FileText,
-  LayoutPanelLeft,
-  LoaderCircle,
-  Search,
-  Settings,
-  Trash2,
-  X,
-} from 'lucide-react'
+	Bot,
+	ChevronsLeft,
+	ChevronsLeftRightEllipsis,
+	ChevronsRight,
+	Download,
+	Eye,
+	FileText,
+	LayoutPanelLeft,
+	LoaderCircle,
+	Search,
+	Settings,
+	Trash2,
+	X,
+} from "lucide-react";
 import {
-  type ChangeEvent,
-  type ComponentType,
-  type CSSProperties,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
-import { toast } from 'sonner'
-import { MessageTimeline } from '../chat/MessageTimeline'
-import { MarkdownRenderer } from '../common/MarkdownRenderer'
-import { ChatInput, PROJECT_ATTACHMENT_ACCEPT } from '../input/ChatInput'
-import { ArtifactPreviewDialog } from './ArtifactPreviewDialog'
-import type { AppNavigation } from './LeftRail'
+	type ChangeEvent,
+	type ComponentType,
+	type CSSProperties,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { toast } from "sonner";
+import { MessageTimeline } from "../chat/MessageTimeline";
+import { MarkdownRenderer } from "../common/MarkdownRenderer";
+import { ChatInput, PROJECT_ATTACHMENT_ACCEPT } from "../input/ChatInput";
+import { ArtifactPreviewDialog } from "./ArtifactPreviewDialog";
+import type { AppNavigation } from "./LeftRail";
+import { getProjectChatLayoutClasses, type ProjectChatLayoutMode } from "./project-chat-layout";
 import {
-  getProjectChatLayoutClasses,
-  type ProjectChatLayoutMode,
-} from './project-chat-layout'
+	ProjectFileTypeIcon,
+	SIDEBAR_COMPACT_LIST_CLASS,
+	TaskCardIcon,
+} from "./project-file-type-icon";
 import {
-  ProjectFileTypeIcon,
-  SIDEBAR_COMPACT_LIST_CLASS,
-  TaskCardIcon,
-} from './project-file-type-icon'
-import {
-  collectSelectableFiles,
-  normalizeProjectFileTree,
-  type ProjectFileNode,
-  sortProjectFilesByUploadedTimeDesc,
-} from './project-files'
-import { SpreadsheetPreview } from './SpreadsheetPreview'
-import { TaskDeleteDialog } from './TaskDeleteDialog'
+	collectSelectableFiles,
+	normalizeProjectFileTree,
+	type ProjectFileNode,
+	sortProjectFilesByUploadedTimeDesc,
+} from "./project-files";
+import { SpreadsheetPreview } from "./SpreadsheetPreview";
+import { TaskDeleteDialog } from "./TaskDeleteDialog";
 
 const projectTabs = [
-  { id: 'chat' as const, label: '新建任务' },
-  { id: 'tasks' as const, label: '任务' },
-  { id: 'files' as const, label: '项目文件' },
-]
+	{ id: "chat" as const, label: "新建任务" },
+	{ id: "tasks" as const, label: "任务" },
+	{ id: "files" as const, label: "项目文件" },
+];
 
-const FILE_PREVIEW_DRAWER_DEFAULT_WIDTH = 860
-const FILE_PREVIEW_DRAWER_MIN_WIDTH = 720
-const FILE_PREVIEW_DRAWER_MAX_WIDTH = 1200
-const PROJECT_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY =
-  'leros-project-right-sidebar-width'
-const PROJECT_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY =
-  'leros-project-right-sidebar-collapsed'
-const PROJECT_RIGHT_SIDEBAR_DEFAULT_WIDTH = 300
-const PROJECT_RIGHT_SIDEBAR_MIN_WIDTH = 260
-const PROJECT_RIGHT_SIDEBAR_MAX_WIDTH = 420
-const PROJECT_RIGHT_SIDEBAR_WIDE_BREAKPOINT = 360
+const FILE_PREVIEW_DRAWER_DEFAULT_WIDTH = 860;
+const FILE_PREVIEW_DRAWER_MIN_WIDTH = 720;
+const FILE_PREVIEW_DRAWER_MAX_WIDTH = 1200;
+const PROJECT_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = "leros-project-right-sidebar-width";
+const PROJECT_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY = "leros-project-right-sidebar-collapsed";
+const PROJECT_RIGHT_SIDEBAR_DEFAULT_WIDTH = 300;
+const PROJECT_RIGHT_SIDEBAR_MIN_WIDTH = 260;
+const PROJECT_RIGHT_SIDEBAR_MAX_WIDTH = 420;
+const PROJECT_RIGHT_SIDEBAR_WIDE_BREAKPOINT = 360;
 
-type ProjectTab = (typeof projectTabs)[number]['id']
+type ProjectTab = (typeof projectTabs)[number]["id"];
 
 type FilePreviewState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'error'; message: string }
-  | { status: 'docx'; buffer: ArrayBuffer }
-  | { status: 'markdown'; content: string }
-  | { status: 'text'; content: string }
-  | { status: 'spreadsheet'; buffer: ArrayBuffer }
-  | { status: 'blob'; url: string; mimeType: string }
+	| { status: "idle" }
+	| { status: "loading" }
+	| { status: "error"; message: string }
+	| { status: "docx"; buffer: ArrayBuffer }
+	| { status: "markdown"; content: string }
+	| { status: "text"; content: string }
+	| { status: "spreadsheet"; buffer: ArrayBuffer }
+	| { status: "blob"; url: string; mimeType: string };
 
 type DocxEditorComponent = ComponentType<{
-  documentBuffer?: ArrayBuffer | null
-  mode?: 'editing' | 'suggesting' | 'viewing'
-  readOnly?: boolean
-  showToolbar?: boolean
-  showZoomControl?: boolean
-  showRuler?: boolean
-  showOutline?: boolean
-  showOutlineButton?: boolean
-  disableFindReplaceShortcuts?: boolean
-  initialZoom?: number
-  className?: string
-  style?: CSSProperties
-  documentName?: string
-  documentNameEditable?: boolean
-  loadingIndicator?: React.ReactNode
-  onError?: (error: Error) => void
-}>
+	documentBuffer?: ArrayBuffer | null;
+	mode?: "editing" | "suggesting" | "viewing";
+	readOnly?: boolean;
+	showToolbar?: boolean;
+	showZoomControl?: boolean;
+	showRuler?: boolean;
+	showOutline?: boolean;
+	showOutlineButton?: boolean;
+	disableFindReplaceShortcuts?: boolean;
+	initialZoom?: number;
+	className?: string;
+	style?: CSSProperties;
+	documentName?: string;
+	documentNameEditable?: boolean;
+	loadingIndicator?: React.ReactNode;
+	onError?: (error: Error) => void;
+}>;
 
-let docxEditorComponent: DocxEditorComponent | null = null
-let docxEditorPromise: Promise<DocxEditorComponent> | null = null
+let docxEditorComponent: DocxEditorComponent | null = null;
+let docxEditorPromise: Promise<DocxEditorComponent> | null = null;
 
 function loadDocxEditor(): Promise<DocxEditorComponent> {
-  if (docxEditorComponent) return Promise.resolve(docxEditorComponent)
-  docxEditorPromise ??= import('@eigenpal/docx-editor-react').then((module) => {
-    docxEditorComponent = module.DocxEditor as DocxEditorComponent
-    return docxEditorComponent
-  })
-  return docxEditorPromise
+	if (docxEditorComponent) return Promise.resolve(docxEditorComponent);
+	docxEditorPromise ??= import("@eigenpal/docx-editor-react").then((module) => {
+		docxEditorComponent = module.DocxEditor as DocxEditorComponent;
+		return docxEditorComponent;
+	});
+	return docxEditorPromise;
 }
 
 export function ProjectPage({
-  projectId,
-  tab,
-  onTabChange,
-  navigation,
+	projectId,
+	tab,
+	onTabChange,
+	navigation,
 }: {
-  projectId?: string
-  tab?: ProjectTab
-  onTabChange?: (tab: ProjectTab) => void
-  navigation?: AppNavigation
+	projectId?: string;
+	tab?: ProjectTab;
+	onTabChange?: (tab: ProjectTab) => void;
+	navigation?: AppNavigation;
 }) {
-  const {
-    projects,
-    activeProjectId,
-    currentView,
-    activeProjectTab,
-    projectDetailLoading,
-    projectDetailError,
-    projectSessionId,
-    projectSessionProjectId,
-    activeWorkbenchProjectId,
-    activeWorkbenchTaskId,
-    activeTaskDetailProjectId,
-    activeTaskDetailSessionId,
-    fetchProjects,
-    setProjectRoute,
-    setActiveProjectTab,
-    fetchProjectDetail,
-    openTaskDetail,
-  } = useLayoutStore((s) => s)
+	const {
+		projects,
+		activeProjectId,
+		currentView,
+		activeProjectTab,
+		projectDetailLoading,
+		projectDetailError,
+		projectSessionId,
+		projectSessionProjectId,
+		activeWorkbenchProjectId,
+		activeWorkbenchTaskId,
+		activeTaskDetailProjectId,
+		activeTaskDetailSessionId,
+		fetchProjects,
+		setProjectRoute,
+		setActiveProjectTab,
+		fetchProjectDetail,
+		openTaskDetail,
+	} = useLayoutStore((s) => s);
 
-  const {
-    activeSessionId,
-    isGenerating,
-    pendingBootstrapSessionId,
-    setActiveSession,
-    loadConversationMessages,
-    resetLocalMessages,
-  } = useChatStore((s) => s)
+	const {
+		activeSessionId,
+		isGenerating,
+		pendingBootstrapSessionId,
+		setActiveSession,
+		loadConversationMessages,
+		resetLocalMessages,
+	} = useChatStore((s) => s);
 
-  const [taskArtifacts, setTaskArtifacts] = useState<ProjectArtifact[]>([])
-  const [projectFiles, setProjectFiles] = useState<ProjectFileNode[]>([])
-  const [rightSidebarWidth, setRightSidebarWidth] = useState(
-    PROJECT_RIGHT_SIDEBAR_DEFAULT_WIDTH,
-  )
-  const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState(false)
-  const hasLoadedRightSidebarPreferenceRef = useRef(false)
+	const [taskArtifacts, setTaskArtifacts] = useState<ProjectArtifact[]>([]);
+	const [projectFiles, setProjectFiles] = useState<ProjectFileNode[]>([]);
+	const [rightSidebarWidth, setRightSidebarWidth] = useState(PROJECT_RIGHT_SIDEBAR_DEFAULT_WIDTH);
+	const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState(false);
+	const hasLoadedRightSidebarPreferenceRef = useRef(false);
 
-  const resolvedProjectId = projectId ?? activeProjectId
-  const resolvedTab = tab ?? activeProjectTab
-  const project =
-    projects.find((item) => item.id === resolvedProjectId) ??
-    (resolvedProjectId ? undefined : projects[0])
+	const resolvedProjectId = projectId ?? activeProjectId;
+	const resolvedTab = tab ?? activeProjectTab;
+	const project =
+		projects.find((item) => item.id === resolvedProjectId) ??
+		(resolvedProjectId ? undefined : projects[0]);
 
-  const taskIds = useMemo(
-    () => project?.tasks.map((task) => task.id).join('|') ?? '',
-    [project],
-  )
+	const taskIds = useMemo(() => project?.tasks.map((task) => task.id).join("|") ?? "", [project]);
 
-  const selectedTaskSessionId = useMemo(() => {
-    if (
-      !project ||
-      activeWorkbenchProjectId !== project.id ||
-      !activeWorkbenchTaskId
-    )
-      return null
-    return (
-      project.tasks.find((task) => task.id === activeWorkbenchTaskId)
-        ?.sessionId ?? null
-    )
-  }, [project, activeWorkbenchProjectId, activeWorkbenchTaskId])
+	const selectedTaskSessionId = useMemo(() => {
+		if (!project || activeWorkbenchProjectId !== project.id || !activeWorkbenchTaskId) return null;
+		return project.tasks.find((task) => task.id === activeWorkbenchTaskId)?.sessionId ?? null;
+	}, [project, activeWorkbenchProjectId, activeWorkbenchTaskId]);
 
-  const currentTaskSessionId =
-    activeTaskDetailProjectId === resolvedProjectId
-      ? activeTaskDetailSessionId
-      : null
+	const currentTaskSessionId =
+		activeTaskDetailProjectId === resolvedProjectId ? activeTaskDetailSessionId : null;
 
-  const streamingTaskSessionId =
-    isGenerating &&
-    activeSessionId &&
-    activeTaskDetailProjectId === resolvedProjectId &&
-    activeTaskDetailSessionId === activeSessionId
-      ? activeTaskDetailSessionId
-      : null
-  const currentProjectSessionId =
-    projectSessionProjectId === resolvedProjectId ? projectSessionId : null
+	const streamingTaskSessionId =
+		isGenerating &&
+		activeSessionId &&
+		activeTaskDetailProjectId === resolvedProjectId &&
+		activeTaskDetailSessionId === activeSessionId
+			? activeTaskDetailSessionId
+			: null;
+	const currentProjectSessionId =
+		projectSessionProjectId === resolvedProjectId ? projectSessionId : null;
 
-  const resolvedSessionId =
-    streamingTaskSessionId ??
-    currentTaskSessionId ??
-    selectedTaskSessionId ??
-    currentProjectSessionId
+	const resolvedSessionId =
+		streamingTaskSessionId ??
+		currentTaskSessionId ??
+		selectedTaskSessionId ??
+		currentProjectSessionId;
 
-  const handleOpenTask = (task: ProjectTask) => {
-    if (!resolvedProjectId) return
-    if (navigation) {
-      navigation.goToTaskDetail(
-        resolvedProjectId,
-        task.id,
-        task.sessionId ?? null,
-      )
-      return
-    }
-    openTaskDetail(resolvedProjectId, task.id, task.sessionId ?? null)
-  }
+	const handleOpenTask = (task: ProjectTask) => {
+		if (!resolvedProjectId) return;
+		if (navigation) {
+			navigation.goToTaskDetail(resolvedProjectId, task.id, task.sessionId ?? null);
+			return;
+		}
+		openTaskDetail(resolvedProjectId, task.id, task.sessionId ?? null);
+	};
 
-  useEffect(() => {
-    fetchProjects()
-  }, [fetchProjects])
+	useEffect(() => {
+		fetchProjects();
+	}, [fetchProjects]);
 
-  useEffect(() => {
-    if (projectId) {
-      setProjectRoute(projectId, tab ?? 'chat')
-    }
-  }, [projectId, tab, setProjectRoute])
+	useEffect(() => {
+		if (projectId) {
+			setProjectRoute(projectId, tab ?? "chat");
+		}
+	}, [projectId, tab, setProjectRoute]);
 
-  useEffect(() => {
-    if (resolvedProjectId) {
-      fetchProjectDetail(resolvedProjectId)
-    }
-  }, [resolvedProjectId, fetchProjectDetail, projects.length])
+	useEffect(() => {
+		if (resolvedProjectId) {
+			fetchProjectDetail(resolvedProjectId);
+		}
+	}, [resolvedProjectId, fetchProjectDetail, projects.length]);
 
-  useEffect(() => {
-    if (!taskIds) {
-      setTaskArtifacts([])
-      return
-    }
+	useEffect(() => {
+		if (!taskIds) {
+			setTaskArtifacts([]);
+			return;
+		}
 
-    let cancelled = false
+		let cancelled = false;
 
-    async function fetchTaskArtifacts() {
-      const ids = taskIds.split('|').filter(Boolean)
-      try {
-        const responses = await Promise.all(
-          ids.map((taskId) => artifactApi.listTaskArtifacts(taskId)),
-        )
-        if (cancelled) return
+		async function fetchTaskArtifacts() {
+			const ids = taskIds.split("|").filter(Boolean);
+			try {
+				const responses = await Promise.all(
+					ids.map((taskId) => artifactApi.listTaskArtifacts(taskId)),
+				);
+				if (cancelled) return;
 
-        const merged = new Map<string, ProjectArtifact>()
-        for (const response of responses) {
-          for (const artifact of response.data.data ?? []) {
-            const item = mapBackendArtifactToProjectArtifact(artifact)
-            merged.set(item.id, item)
-          }
-        }
-        setTaskArtifacts([...merged.values()])
-      } catch (err) {
-        if (cancelled) return
-        console.error('ProjectPage fetch task artifacts error:', err)
-        setTaskArtifacts([])
-      }
-    }
+				const merged = new Map<string, ProjectArtifact>();
+				for (const response of responses) {
+					for (const artifact of response.data.data ?? []) {
+						const item = mapBackendArtifactToProjectArtifact(artifact);
+						merged.set(item.id, item);
+					}
+				}
+				setTaskArtifacts([...merged.values()]);
+			} catch (err) {
+				if (cancelled) return;
+				console.error("ProjectPage fetch task artifacts error:", err);
+				setTaskArtifacts([]);
+			}
+		}
 
-    fetchTaskArtifacts()
-    return () => {
-      cancelled = true
-    }
-  }, [taskIds])
+		fetchTaskArtifacts();
+		return () => {
+			cancelled = true;
+		};
+	}, [taskIds]);
 
-  const refreshProjectFiles = async () => {
-    if (!resolvedProjectId) return
-    const response = await projectFileApi.list({
-      projectId: resolvedProjectId,
-      depth: 3,
-    })
-    setProjectFiles(normalizeProjectFileTree(response.data.data))
-  }
+	const refreshProjectFiles = async () => {
+		if (!resolvedProjectId) return;
+		const response = await projectFileApi.list({
+			projectId: resolvedProjectId,
+			depth: 3,
+		});
+		setProjectFiles(normalizeProjectFileTree(response.data.data));
+	};
 
-  useEffect(() => {
-    if (!resolvedProjectId || resolvedTab !== 'files') {
-      setProjectFiles([])
-      return
-    }
+	useEffect(() => {
+		if (!resolvedProjectId || resolvedTab !== "files") {
+			setProjectFiles([]);
+			return;
+		}
 
-    const currentProjectId = resolvedProjectId
-    let cancelled = false
+		const currentProjectId = resolvedProjectId;
+		let cancelled = false;
 
-    async function fetchFiles() {
-      try {
-        const response = await projectFileApi.list({
-          projectId: currentProjectId,
-          depth: 3,
-        })
-        if (cancelled) return
-        setProjectFiles(normalizeProjectFileTree(response.data.data))
-      } catch (err) {
-        if (cancelled) return
-        console.error('ProjectPage fetch project files error:', err)
-        setProjectFiles([])
-      }
-    }
+		async function fetchFiles() {
+			try {
+				const response = await projectFileApi.list({
+					projectId: currentProjectId,
+					depth: 3,
+				});
+				if (cancelled) return;
+				setProjectFiles(normalizeProjectFileTree(response.data.data));
+			} catch (err) {
+				if (cancelled) return;
+				console.error("ProjectPage fetch project files error:", err);
+				setProjectFiles([]);
+			}
+		}
 
-    fetchFiles()
-    return () => {
-      cancelled = true
-    }
-  }, [resolvedProjectId, resolvedTab])
+		fetchFiles();
+		return () => {
+			cancelled = true;
+		};
+	}, [resolvedProjectId, resolvedTab]);
 
-  useEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      hasLoadedRightSidebarPreferenceRef.current
-    )
-      return
-    hasLoadedRightSidebarPreferenceRef.current = true
+	useEffect(() => {
+		if (typeof window === "undefined" || hasLoadedRightSidebarPreferenceRef.current) return;
+		hasLoadedRightSidebarPreferenceRef.current = true;
 
-    const savedWidth = window.localStorage.getItem(
-      PROJECT_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY,
-    )
-    const savedCollapsed = window.localStorage.getItem(
-      PROJECT_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY,
-    )
+		const savedWidth = window.localStorage.getItem(PROJECT_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY);
+		const savedCollapsed = window.localStorage.getItem(PROJECT_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY);
 
-    if (savedWidth) {
-      const parsedWidth = Number(savedWidth)
-      if (Number.isFinite(parsedWidth)) {
-        // 右侧栏宽度读取后立即限制范围，避免旧值把布局撑坏。
-        setRightSidebarWidth(clampProjectRightSidebarWidth(parsedWidth))
-      }
-    }
+		if (savedWidth) {
+			const parsedWidth = Number(savedWidth);
+			if (Number.isFinite(parsedWidth)) {
+				// 右侧栏宽度读取后立即限制范围，避免旧值把布局撑坏。
+				setRightSidebarWidth(clampProjectRightSidebarWidth(parsedWidth));
+			}
+		}
 
-    if (savedCollapsed) {
-      setRightSidebarCollapsed(savedCollapsed === 'true')
-    }
-  }, [])
+		if (savedCollapsed) {
+			setRightSidebarCollapsed(savedCollapsed === "true");
+		}
+	}, []);
 
-  useEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      !hasLoadedRightSidebarPreferenceRef.current
-    )
-      return
-    window.localStorage.setItem(
-      PROJECT_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY,
-      String(rightSidebarWidth),
-    )
-  }, [rightSidebarWidth])
+	useEffect(() => {
+		if (typeof window === "undefined" || !hasLoadedRightSidebarPreferenceRef.current) return;
+		window.localStorage.setItem(PROJECT_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY, String(rightSidebarWidth));
+	}, [rightSidebarWidth]);
 
-  useEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      !hasLoadedRightSidebarPreferenceRef.current
-    )
-      return
-    window.localStorage.setItem(
-      PROJECT_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY,
-      String(rightSidebarCollapsed),
-    )
-  }, [rightSidebarCollapsed])
+	useEffect(() => {
+		if (typeof window === "undefined" || !hasLoadedRightSidebarPreferenceRef.current) return;
+		window.localStorage.setItem(
+			PROJECT_RIGHT_SIDEBAR_COLLAPSED_STORAGE_KEY,
+			String(rightSidebarCollapsed),
+		);
+	}, [rightSidebarCollapsed]);
 
-  useEffect(() => {
-    if (projectDetailLoading) return
-    if (!resolvedSessionId) {
-      resetLocalMessages()
-      return
-    }
-    const nextSessionId = resolvedSessionId
-    setActiveSession(nextSessionId)
-    if (currentView === 'taskDetail' && currentTaskSessionId === nextSessionId)
-      return
-    // 项目消息刚创建 session 并准备开流时，跳过这次自动拉历史，避免旧数据覆盖 optimistic 消息。
-    if (pendingBootstrapSessionId === nextSessionId) return
-    if (isGenerating && activeSessionId === nextSessionId) return
-    loadConversationMessages(nextSessionId)
-  }, [
-    resolvedSessionId,
-    currentTaskSessionId,
-    projectDetailLoading,
-    currentView,
-    isGenerating,
-    pendingBootstrapSessionId,
-    activeSessionId,
-    setActiveSession,
-    loadConversationMessages,
-    resetLocalMessages,
-  ])
+	useEffect(() => {
+		if (projectDetailLoading) return;
+		if (!resolvedSessionId) {
+			resetLocalMessages();
+			return;
+		}
+		const nextSessionId = resolvedSessionId;
+		setActiveSession(nextSessionId);
+		if (currentView === "taskDetail" && currentTaskSessionId === nextSessionId) return;
+		// 项目消息刚创建 session 并准备开流时，跳过这次自动拉历史，避免旧数据覆盖 optimistic 消息。
+		if (pendingBootstrapSessionId === nextSessionId) return;
+		if (isGenerating && activeSessionId === nextSessionId) return;
+		loadConversationMessages(nextSessionId);
+	}, [
+		resolvedSessionId,
+		currentTaskSessionId,
+		projectDetailLoading,
+		currentView,
+		isGenerating,
+		pendingBootstrapSessionId,
+		activeSessionId,
+		setActiveSession,
+		loadConversationMessages,
+		resetLocalMessages,
+	]);
 
-  const handleRightSidebarResizeStart = (
-    event: React.PointerEvent<HTMLHRElement>,
-  ) => {
-    const startX = event.clientX
-    const startWidth = rightSidebarWidth
-    const pointerId = event.pointerId
-    const target = event.currentTarget
+	const handleRightSidebarResizeStart = (event: React.PointerEvent<HTMLHRElement>) => {
+		const startX = event.clientX;
+		const startWidth = rightSidebarWidth;
+		const pointerId = event.pointerId;
+		const target = event.currentTarget;
 
-    target.setPointerCapture(pointerId)
+		target.setPointerCapture(pointerId);
 
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      setRightSidebarWidth(
-        clampProjectRightSidebarWidth(
-          startWidth - (moveEvent.clientX - startX),
-        ),
-      )
-    }
+		const handlePointerMove = (moveEvent: PointerEvent) => {
+			setRightSidebarWidth(
+				clampProjectRightSidebarWidth(startWidth - (moveEvent.clientX - startX)),
+			);
+		};
 
-    const handlePointerUp = () => {
-      if (target.hasPointerCapture(pointerId)) {
-        target.releasePointerCapture(pointerId)
-      }
-      target.removeEventListener('pointermove', handlePointerMove)
-      target.removeEventListener('pointerup', handlePointerUp)
-      target.removeEventListener('pointercancel', handlePointerUp)
-    }
+		const handlePointerUp = () => {
+			if (target.hasPointerCapture(pointerId)) {
+				target.releasePointerCapture(pointerId);
+			}
+			target.removeEventListener("pointermove", handlePointerMove);
+			target.removeEventListener("pointerup", handlePointerUp);
+			target.removeEventListener("pointercancel", handlePointerUp);
+		};
 
-    target.addEventListener('pointermove', handlePointerMove)
-    target.addEventListener('pointerup', handlePointerUp)
-    target.addEventListener('pointercancel', handlePointerUp)
-  }
+		target.addEventListener("pointermove", handlePointerMove);
+		target.addEventListener("pointerup", handlePointerUp);
+		target.addEventListener("pointercancel", handlePointerUp);
+	};
 
-  // 中文注释：项目右侧栏只在会话 tab 使用，任务 tab 不展示展开/拖拽能力。
-  const showProjectSidebar = resolvedTab === 'chat'
-  const projectChatLayoutMode: ProjectChatLayoutMode =
-    showProjectSidebar && !rightSidebarCollapsed
-      ? 'sidebar-expanded'
-      : 'sidebar-collapsed'
-  const isWideRightSidebar =
-    rightSidebarWidth >= PROJECT_RIGHT_SIDEBAR_WIDE_BREAKPOINT
-  const rightSidebarWidthStyle = !rightSidebarCollapsed
-    ? { width: `${rightSidebarWidth}px` }
-    : undefined
+	// 中文注释：项目右侧栏只在会话 tab 使用，任务 tab 不展示展开/拖拽能力。
+	const showProjectSidebar = resolvedTab === "chat";
+	const projectChatLayoutMode: ProjectChatLayoutMode =
+		showProjectSidebar && !rightSidebarCollapsed ? "sidebar-expanded" : "sidebar-collapsed";
+	const isWideRightSidebar = rightSidebarWidth >= PROJECT_RIGHT_SIDEBAR_WIDE_BREAKPOINT;
+	const rightSidebarWidthStyle = !rightSidebarCollapsed
+		? { width: `${rightSidebarWidth}px` }
+		: undefined;
 
-  if (!project) {
-    return (
-      <div className="flex h-full flex-1 items-center justify-center bg-[var(--leros-app-bg)] text-[var(--leros-text-muted)]">
-        暂无项目
-      </div>
-    )
-  }
+	if (!project) {
+		return (
+			<div className="flex h-full flex-1 items-center justify-center bg-[var(--leros-app-bg)] text-[var(--leros-text-muted)]">
+				暂无项目
+			</div>
+		);
+	}
 
-  if (projectDetailLoading) {
-    return (
-      <div className="flex h-full flex-1 items-center justify-center bg-[var(--leros-surface)]">
-        <div className="flex flex-col items-center gap-3">
-          <LoaderCircle className="size-8 animate-spin text-[var(--leros-text-muted)]" />
-          <p className="text-sm text-[var(--leros-text-muted)]">
-            加载项目详情中...
-          </p>
-        </div>
-      </div>
-    )
-  }
+	if (projectDetailLoading) {
+		return (
+			<div className="flex h-full flex-1 items-center justify-center bg-[var(--leros-surface)]">
+				<div className="flex flex-col items-center gap-3">
+					<LoaderCircle className="size-8 animate-spin text-[var(--leros-text-muted)]" />
+					<p className="text-sm text-[var(--leros-text-muted)]">加载项目详情中...</p>
+				</div>
+			</div>
+		);
+	}
 
-  if (projectDetailError) {
-    return (
-      <div className="flex h-full flex-1 items-center justify-center bg-[var(--leros-surface)]">
-        <div className="flex flex-col items-center gap-3">
-          <p className="text-sm text-[var(--leros-text-muted)]">
-            {projectDetailError}
-          </p>
-        </div>
-      </div>
-    )
-  }
+	if (projectDetailError) {
+		return (
+			<div className="flex h-full flex-1 items-center justify-center bg-[var(--leros-surface)]">
+				<div className="flex flex-col items-center gap-3">
+					<p className="text-sm text-[var(--leros-text-muted)]">{projectDetailError}</p>
+				</div>
+			</div>
+		);
+	}
 
-  return (
-    <div
-      data-slot="project-page"
-      className="flex h-full flex-1 flex-col bg-[var(--leros-surface)]"
-    >
-      <header className="flex h-16 shrink-0 items-center justify-between border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-10">
-        <div className="flex items-center gap-3 text-[var(--leros-text-muted)]">
-          <h1 className="text-base font-bold text-[var(--leros-text-strong)]">
-            {project.name}
-          </h1>
-        </div>
-        <div className="flex items-center gap-6 text-[var(--leros-text)]">
-          <button
-            type="button"
-            className="rounded-full p-1.5 transition-colors hover:bg-[var(--leros-primary-softer)]"
-          >
-            <Search className="size-5" />
-          </button>
-          {showProjectSidebar && (
-            <button
-              type="button"
-              className="rounded-full p-1.5 transition-colors hover:bg-[var(--leros-primary-softer)]"
-              aria-label={rightSidebarCollapsed ? '展开右侧栏' : '收起右侧栏'}
-              title={rightSidebarCollapsed ? '展开右侧栏' : '收起右侧栏'}
-              onClick={() =>
-                setRightSidebarCollapsed((collapsed) => !collapsed)
-              }
-            >
-              <LayoutPanelLeft className="size-5" />
-            </button>
-          )}
-          <button
-            type="button"
-            className="rounded-full p-1.5 transition-colors hover:bg-[var(--leros-primary-softer)]"
-          >
-            <Settings className="size-5" />
-          </button>
-        </div>
-      </header>
+	return (
+		<div data-slot="project-page" className="flex h-full flex-1 flex-col bg-[var(--leros-surface)]">
+			<header className="flex h-16 shrink-0 items-center justify-between border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-10">
+				<div className="flex items-center gap-3 text-[var(--leros-text-muted)]">
+					<h1 className="text-base font-bold text-[var(--leros-text-strong)]">{project.name}</h1>
+				</div>
+				<div className="flex items-center gap-6 text-[var(--leros-text)]">
+					<button
+						type="button"
+						className="rounded-full p-1.5 transition-colors hover:bg-[var(--leros-primary-softer)]"
+					>
+						<Search className="size-5" />
+					</button>
+					{showProjectSidebar && (
+						<button
+							type="button"
+							className="rounded-full p-1.5 transition-colors hover:bg-[var(--leros-primary-softer)]"
+							aria-label={rightSidebarCollapsed ? "展开右侧栏" : "收起右侧栏"}
+							title={rightSidebarCollapsed ? "展开右侧栏" : "收起右侧栏"}
+							onClick={() => setRightSidebarCollapsed((collapsed) => !collapsed)}
+						>
+							<LayoutPanelLeft className="size-5" />
+						</button>
+					)}
+					<button
+						type="button"
+						className="rounded-full p-1.5 transition-colors hover:bg-[var(--leros-primary-softer)]"
+					>
+						<Settings className="size-5" />
+					</button>
+				</div>
+			</header>
 
-      <nav className="flex h-[48px] shrink-0 items-end gap-8 border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-10">
-        {projectTabs.map((currentTab) => (
-          <button
-            key={currentTab.id}
-            type="button"
-            onClick={() => {
-              if (onTabChange) {
-                onTabChange(currentTab.id)
-                return
-              }
-              setActiveProjectTab(currentTab.id)
-            }}
-            className={cn(
-              'relative h-full px-1 pb-2 text-sm font-semibold transition-colors',
-              resolvedTab === currentTab.id
-                ? 'text-[var(--leros-primary)]'
-                : 'text-[var(--leros-text-muted)] hover:text-[var(--leros-text-strong)]',
-            )}
-          >
-            {currentTab.label}
-            {resolvedTab === currentTab.id && (
-              <span className="absolute bottom-0 left-0 h-0.5 w-full rounded-full bg-[var(--leros-primary)]" />
-            )}
-          </button>
-        ))}
-      </nav>
+			<nav className="flex h-[48px] shrink-0 items-end gap-8 border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-10">
+				{projectTabs.map((currentTab) => (
+					<button
+						key={currentTab.id}
+						type="button"
+						onClick={() => {
+							if (onTabChange) {
+								onTabChange(currentTab.id);
+								return;
+							}
+							setActiveProjectTab(currentTab.id);
+						}}
+						className={cn(
+							"relative h-full px-1 pb-2 text-sm font-semibold transition-colors",
+							resolvedTab === currentTab.id
+								? "text-[var(--leros-primary)]"
+								: "text-[var(--leros-text-muted)] hover:text-[var(--leros-text-strong)]",
+						)}
+					>
+						{currentTab.label}
+						{resolvedTab === currentTab.id && (
+							<span className="absolute bottom-0 left-0 h-0.5 w-full rounded-full bg-[var(--leros-primary)]" />
+						)}
+					</button>
+				))}
+			</nav>
 
-      <div className="relative min-h-0 flex flex-1">
-        <main
-          className={cn(
-            'min-w-0 flex-1',
-            resolvedTab === 'chat'
-              ? 'flex min-h-0 flex-col bg-[var(--leros-surface)]'
-              : resolvedTab === 'files'
-              ? 'min-h-0 bg-[var(--leros-surface)]'
-              : 'overflow-y-auto px-10 py-8',
-          )}
-        >
-          {resolvedTab === 'chat' && (
-            <ProjectChat layoutMode={projectChatLayoutMode} />
-          )}
-          {resolvedTab === 'tasks' && (
-            <ProjectTasks tasks={project.tasks} onOpenTask={handleOpenTask} />
-          )}
-          {resolvedTab === 'files' && resolvedProjectId && (
-            <ProjectFiles
-              projectId={resolvedProjectId}
-              files={projectFiles}
-              onRefresh={refreshProjectFiles}
-            />
-          )}
-        </main>
+			<div className="relative min-h-0 flex flex-1">
+				<main
+					className={cn(
+						"min-w-0 flex-1",
+						resolvedTab === "chat"
+							? "flex min-h-0 flex-col bg-[var(--leros-surface)]"
+							: resolvedTab === "files"
+								? "min-h-0 bg-[var(--leros-surface)]"
+								: "overflow-y-auto px-10 py-8",
+					)}
+				>
+					{resolvedTab === "chat" && (
+						<ProjectChat layoutMode={projectChatLayoutMode} navigation={navigation} />
+					)}
+					{resolvedTab === "tasks" && (
+						<ProjectTasks tasks={project.tasks} onOpenTask={handleOpenTask} />
+					)}
+					{resolvedTab === "files" && resolvedProjectId && (
+						<ProjectFiles
+							projectId={resolvedProjectId}
+							files={projectFiles}
+							onRefresh={refreshProjectFiles}
+						/>
+					)}
+				</main>
 
-        {showProjectSidebar && rightSidebarCollapsed && (
-          <button
-            type="button"
-            className="absolute right-6 top-6 z-20 inline-flex size-10 items-center justify-center rounded-full border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-[var(--leros-text-muted)] shadow-sm transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
-            aria-label="展开右侧栏"
-            title="展开右侧栏"
-            onClick={() => setRightSidebarCollapsed(false)}
-          >
-            <ChevronsLeft className="size-4" />
-          </button>
-        )}
+				{showProjectSidebar && rightSidebarCollapsed && (
+					<button
+						type="button"
+						className="absolute right-6 top-6 z-20 inline-flex size-10 items-center justify-center rounded-full border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-[var(--leros-text-muted)] shadow-sm transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
+						aria-label="展开右侧栏"
+						title="展开右侧栏"
+						onClick={() => setRightSidebarCollapsed(false)}
+					>
+						<ChevronsLeft className="size-4" />
+					</button>
+				)}
 
-        {showProjectSidebar && !rightSidebarCollapsed && (
-          <aside
-            className="relative flex shrink-0 flex-col border-l border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] transition-[width] duration-200 ease-out"
-            style={rightSidebarWidthStyle}
-          >
-            <div className="min-h-0 flex-1 space-y-8 overflow-y-auto px-5 py-6 pr-4">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-sm font-semibold text-[var(--leros-text-strong)]">
-                    项目侧栏
-                  </p>
-                  <p className="mt-1 text-xs text-[var(--leros-text-muted)]">
-                    查看任务和文件概览
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  className="rounded-full p-1.5 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-text-strong)]"
-                  aria-label="收起右侧栏"
-                  title="收起右侧栏"
-                  onClick={() => setRightSidebarCollapsed(true)}
-                >
-                  <ChevronsRight className="size-4" />
-                </button>
-              </div>
-              <section>
-                <div
-                  className={cn(
-                    'mb-4 flex w-full items-center justify-between',
-                    !isWideRightSidebar && 'mx-auto max-w-[250px]',
-                  )}
-                >
-                  <h2 className="text-xs font-semibold text-[var(--leros-text-muted)]">
-                    任务
-                  </h2>
-                  <span className="rounded-md bg-[var(--leros-primary-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-primary)]">
-                    {project.tasks.length} 项
-                  </span>
-                </div>
-                <ProjectTaskList
-                  tasks={project.tasks}
-                  compact={!isWideRightSidebar}
-                  onOpen={handleOpenTask}
-                />
-              </section>
+				{showProjectSidebar && !rightSidebarCollapsed && (
+					<aside
+						className="relative flex shrink-0 flex-col border-l border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] transition-[width] duration-200 ease-out"
+						style={rightSidebarWidthStyle}
+					>
+						<div className="min-h-0 flex-1 space-y-8 overflow-y-auto px-5 py-6 pr-4">
+							<div className="flex items-start justify-between gap-3">
+								<div>
+									<p className="text-sm font-semibold text-[var(--leros-text-strong)]">项目侧栏</p>
+									<p className="mt-1 text-xs text-[var(--leros-text-muted)]">查看任务和文件概览</p>
+								</div>
+								<button
+									type="button"
+									className="rounded-full p-1.5 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-text-strong)]"
+									aria-label="收起右侧栏"
+									title="收起右侧栏"
+									onClick={() => setRightSidebarCollapsed(true)}
+								>
+									<ChevronsRight className="size-4" />
+								</button>
+							</div>
+							<section>
+								<div
+									className={cn(
+										"mb-4 flex w-full items-center justify-between",
+										!isWideRightSidebar && "mx-auto max-w-[250px]",
+									)}
+								>
+									<h2 className="text-xs font-semibold text-[var(--leros-text-muted)]">任务</h2>
+									<span className="rounded-md bg-[var(--leros-primary-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-primary)]">
+										{project.tasks.length} 项
+									</span>
+								</div>
+								<ProjectTaskList
+									tasks={project.tasks}
+									compact={!isWideRightSidebar}
+									onOpen={handleOpenTask}
+								/>
+							</section>
 
-              <section>
-                <div
-                  className={cn(
-                    'mb-4 flex w-full items-center justify-between',
-                    !isWideRightSidebar && 'mx-auto max-w-[250px]',
-                  )}
-                >
-                  <h2 className="text-xs font-semibold text-[var(--leros-text-muted)]">
-                    文件
-                  </h2>
-                  <span className="rounded-md bg-[var(--leros-primary-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-primary)]">
-                    {taskArtifacts.length} 个
-                  </span>
-                </div>
-                <ProjectArtifactList
-                  artifacts={taskArtifacts}
-                  compact={!isWideRightSidebar}
-                />
-              </section>
-            </div>
-            <hr
-              className={cn(
-                'absolute left-0 top-0 z-10 h-full -translate-x-1/2 border-0',
-                'w-3 cursor-col-resize',
-              )}
-              tabIndex={0}
-              aria-orientation="vertical"
-              aria-label="调整右侧栏宽度"
-              aria-valuemin={PROJECT_RIGHT_SIDEBAR_MIN_WIDTH}
-              aria-valuemax={PROJECT_RIGHT_SIDEBAR_MAX_WIDTH}
-              aria-valuenow={rightSidebarWidth}
-              onPointerDown={handleRightSidebarResizeStart}
-              onKeyDown={(event) => {
-                if (event.key === 'ArrowLeft') {
-                  setRightSidebarWidth(
-                    clampProjectRightSidebarWidth(rightSidebarWidth + 8),
-                  )
-                }
-                if (event.key === 'ArrowRight') {
-                  setRightSidebarWidth(
-                    clampProjectRightSidebarWidth(rightSidebarWidth - 8),
-                  )
-                }
-              }}
-            />
-          </aside>
-        )}
-      </div>
-    </div>
-  )
+							<section>
+								<div
+									className={cn(
+										"mb-4 flex w-full items-center justify-between",
+										!isWideRightSidebar && "mx-auto max-w-[250px]",
+									)}
+								>
+									<h2 className="text-xs font-semibold text-[var(--leros-text-muted)]">文件</h2>
+									<span className="rounded-md bg-[var(--leros-primary-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--leros-primary)]">
+										{taskArtifacts.length} 个
+									</span>
+								</div>
+								<ProjectArtifactList artifacts={taskArtifacts} compact={!isWideRightSidebar} />
+							</section>
+						</div>
+						<hr
+							className={cn(
+								"absolute left-0 top-0 z-10 h-full -translate-x-1/2 border-0",
+								"w-3 cursor-col-resize",
+							)}
+							tabIndex={0}
+							aria-orientation="vertical"
+							aria-label="调整右侧栏宽度"
+							aria-valuemin={PROJECT_RIGHT_SIDEBAR_MIN_WIDTH}
+							aria-valuemax={PROJECT_RIGHT_SIDEBAR_MAX_WIDTH}
+							aria-valuenow={rightSidebarWidth}
+							onPointerDown={handleRightSidebarResizeStart}
+							onKeyDown={(event) => {
+								if (event.key === "ArrowLeft") {
+									setRightSidebarWidth(clampProjectRightSidebarWidth(rightSidebarWidth + 8));
+								}
+								if (event.key === "ArrowRight") {
+									setRightSidebarWidth(clampProjectRightSidebarWidth(rightSidebarWidth - 8));
+								}
+							}}
+						/>
+					</aside>
+				)}
+			</div>
+		</div>
+	);
 }
 
-function ProjectChat({ layoutMode }: { layoutMode: ProjectChatLayoutMode }) {
-  const layout = getProjectChatLayoutClasses(layoutMode)
+function ProjectChat({
+	layoutMode,
+	navigation,
+}: {
+	layoutMode: ProjectChatLayoutMode;
+	navigation?: AppNavigation;
+}) {
+	const layout = getProjectChatLayoutClasses(layoutMode);
 
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <MessageTimeline
-        emptyState={<ProjectEmptyState layout={layout} />}
-        contentShellClassName={layout.shell}
-        contentClassName={layout.timelineInner}
-      />
-      <ChatInput variant="project" projectLayoutMode={layoutMode} />
-    </div>
-  )
+	return (
+		<div className="flex min-h-0 flex-1 flex-col">
+			<MessageTimeline
+				emptyState={<ProjectEmptyState layout={layout} />}
+				contentShellClassName={layout.shell}
+				contentClassName={layout.timelineInner}
+			/>
+			<ChatInput variant="project" projectLayoutMode={layoutMode} navigation={navigation} />
+		</div>
+	);
 }
 
-function ProjectEmptyState({
-  layout,
-}: {
-  layout: ReturnType<typeof getProjectChatLayoutClasses>
-}) {
-  return (
-    <div className={cn('flex h-full', layout.shell)}>
-      <div
-        className={cn(layout.inner, 'flex h-full items-center justify-center')}
-      >
-        <div className="flex max-w-[320px] flex-col items-center text-center">
-          <div className="flex size-12 items-center justify-center rounded-full bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
-            <Bot className="size-6" />
-          </div>
-          <h2 className="mt-5 text-lg font-semibold text-[var(--leros-text-strong)]">
-            开始项目会话
-          </h2>
-          <p className="mt-2 text-sm leading-6 text-[var(--leros-text-muted)]">
-            把需求、问题或上下文发给 AI，后续讨论会沉淀在当前项目中。
-          </p>
-        </div>
-      </div>
-    </div>
-  )
+function ProjectEmptyState({ layout }: { layout: ReturnType<typeof getProjectChatLayoutClasses> }) {
+	return (
+		<div className={cn("flex h-full", layout.shell)}>
+			<div className={cn(layout.inner, "flex h-full items-center justify-center")}>
+				<div className="flex max-w-[320px] flex-col items-center text-center">
+					<div className="flex size-12 items-center justify-center rounded-full bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
+						<Bot className="size-6" />
+					</div>
+					<h2 className="mt-5 text-lg font-semibold text-[var(--leros-text-strong)]">
+						开始项目会话
+					</h2>
+					<p className="mt-2 text-sm leading-6 text-[var(--leros-text-muted)]">
+						把需求、问题或上下文发给 AI，后续讨论会沉淀在当前项目中。
+					</p>
+				</div>
+			</div>
+		</div>
+	);
 }
 
 function ProjectTasks({
-  tasks,
-  onOpenTask,
+	tasks,
+	onOpenTask,
 }: {
-  tasks: ProjectTask[]
-  onOpenTask?: (task: ProjectTask) => void
+	tasks: ProjectTask[];
+	onOpenTask?: (task: ProjectTask) => void;
 }) {
-  const [deleteTarget, setDeleteTarget] = useState<ProjectTask | null>(null)
+	const [deleteTarget, setDeleteTarget] = useState<ProjectTask | null>(null);
 
-  return (
-    // 中文注释：任务 tab 需要占用更宽的主内容区域，避免大屏下卡片挤在中间留下过多留白。
-    <div className="mx-auto w-full max-w-[1100px]">
-      <h2 className="text-lg font-semibold text-[var(--leros-text-strong)]">
-        任务
-      </h2>
-      <div className="mt-4">
-        <ProjectTaskList
-          tasks={tasks}
-          onDelete={setDeleteTarget}
-          onOpen={onOpenTask}
-        />
-      </div>
-      {deleteTarget && (
-        <TaskDeleteDialog
-          task={deleteTarget}
-          open={true}
-          onOpenChange={(open) => {
-            if (!open) setDeleteTarget(null)
-          }}
-        />
-      )}
-    </div>
-  )
+	return (
+		// 中文注释：任务 tab 需要占用更宽的主内容区域，避免大屏下卡片挤在中间留下过多留白。
+		<div className="mx-auto w-full max-w-[1100px]">
+			<h2 className="text-lg font-semibold text-[var(--leros-text-strong)]">任务</h2>
+			<div className="mt-4">
+				<ProjectTaskList tasks={tasks} onDelete={setDeleteTarget} onOpen={onOpenTask} />
+			</div>
+			{deleteTarget && (
+				<TaskDeleteDialog
+					task={deleteTarget}
+					open={true}
+					onOpenChange={(open) => {
+						if (!open) setDeleteTarget(null);
+					}}
+				/>
+			)}
+		</div>
+	);
 }
 
 function ProjectTaskList({
-  tasks,
-  compact = false,
-  onDelete,
-  onOpen,
+	tasks,
+	compact = false,
+	onDelete,
+	onOpen,
 }: {
-  tasks: ProjectTask[]
-  compact?: boolean
-  onDelete?: (task: ProjectTask) => void
-  onOpen?: (task: ProjectTask) => void
+	tasks: ProjectTask[];
+	compact?: boolean;
+	onDelete?: (task: ProjectTask) => void;
+	onOpen?: (task: ProjectTask) => void;
 }) {
-  if (tasks.length === 0) {
-    return (
-      <div className="rounded-lg border border-dashed border-[var(--leros-control-border)] px-4 py-8 text-center text-xs text-[var(--leros-text-muted)]">
-        暂无任务
-      </div>
-    )
-  }
+	if (tasks.length === 0) {
+		return (
+			<div className="rounded-lg border border-dashed border-[var(--leros-control-border)] px-4 py-8 text-center text-xs text-[var(--leros-text-muted)]">
+				暂无任务
+			</div>
+		);
+	}
 
-  return (
-    <div className={cn('w-full', compact && 'mx-auto max-w-[250px]')}>
-      <div className={cn(compact ? SIDEBAR_COMPACT_LIST_CLASS : 'space-y-3')}>
-        {tasks.map((task) => {
-          const cardClassName = cn(
-            'group flex w-full items-start border border-[var(--leros-control-border)] bg-[var(--leros-surface)] shadow-sm',
-            onOpen &&
-              'cursor-pointer transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35',
-            compact
-              ? 'gap-3 rounded-lg px-3.5 py-3'
-              : 'gap-3.5 rounded-lg px-4 py-3.5',
-          )
-          const content = (
-            <>
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
-                {/* 主列表和右侧列表统一使用固定任务图标，避免状态图标和语义图标混用。 */}
-                <TaskCardIcon className="size-5" />
-              </div>
-              <div className="min-w-0 flex-1 text-left">
-                <div
-                  className={cn(
-                    'text-sm font-normal leading-5 text-[var(--leros-text-strong)]',
-                    'line-clamp-2',
-                  )}
-                >
-                  {task.title}
-                </div>
-              </div>
-            </>
-          )
+	return (
+		<div className={cn("w-full", compact && "mx-auto max-w-[250px]")}>
+			<div className={cn(compact ? SIDEBAR_COMPACT_LIST_CLASS : "space-y-3")}>
+				{tasks.map((task) => {
+					const cardClassName = cn(
+						"group flex w-full items-start border border-[var(--leros-control-border)] bg-[var(--leros-surface)] shadow-sm",
+						onOpen &&
+							"cursor-pointer transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
+						compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
+					);
+					const content = (
+						<>
+							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
+								{/* 主列表和右侧列表统一使用固定任务图标，避免状态图标和语义图标混用。 */}
+								<TaskCardIcon className="size-5" />
+							</div>
+							<div className="min-w-0 flex-1 text-left">
+								<div
+									className={cn(
+										"text-sm font-normal leading-5 text-[var(--leros-text-strong)]",
+										"line-clamp-2",
+									)}
+								>
+									{task.title}
+								</div>
+							</div>
+						</>
+					);
 
-          if (!onDelete) {
-            return (
-              <button
-                key={task.id}
-                type="button"
-                className={cardClassName}
-                onClick={() => onOpen?.(task)}
-                disabled={!onOpen}
-                title={onOpen ? '打开任务会话' : undefined}
-              >
-                {content}
-              </button>
-            )
-          }
+					if (!onDelete) {
+						return (
+							<button
+								key={task.id}
+								type="button"
+								className={cardClassName}
+								onClick={() => onOpen?.(task)}
+								disabled={!onOpen}
+								title={onOpen ? "打开任务会话" : undefined}
+							>
+								{content}
+							</button>
+						);
+					}
 
-          return (
-            <div key={task.id} className={cardClassName}>
-              <button
-                type="button"
-                className="flex min-w-0 flex-1 items-start gap-3.5 text-left"
-                onClick={() => onOpen?.(task)}
-                disabled={!onOpen}
-                title={onOpen ? '打开任务会话' : undefined}
-              >
-                {content}
-              </button>
-              {!compact && (
-                <button
-                  type="button"
-                  className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--leros-text-muted)] opacity-0 transition-opacity hover:bg-[var(--leros-danger-softer)] hover:text-[var(--leros-danger)] group-hover:opacity-100"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onDelete(task)
-                  }}
-                  title="删除任务"
-                >
-                  <Trash2 className="size-4" />
-                </button>
-              )}
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
+					return (
+						<div key={task.id} className={cardClassName}>
+							<button
+								type="button"
+								className="flex min-w-0 flex-1 items-start gap-3.5 text-left"
+								onClick={() => onOpen?.(task)}
+								disabled={!onOpen}
+								title={onOpen ? "打开任务会话" : undefined}
+							>
+								{content}
+							</button>
+							{!compact && (
+								<button
+									type="button"
+									className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--leros-text-muted)] opacity-0 transition-opacity hover:bg-[var(--leros-danger-softer)] hover:text-[var(--leros-danger)] group-hover:opacity-100"
+									onClick={(event) => {
+										event.stopPropagation();
+										onDelete(task);
+									}}
+									title="删除任务"
+								>
+									<Trash2 className="size-4" />
+								</button>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
 }
 
 function ProjectFiles({
-  projectId,
-  files,
-  onRefresh,
+	projectId,
+	files,
+	onRefresh,
 }: {
-  projectId: string
-  files: ProjectFileNode[]
-  onRefresh: () => Promise<void>
+	projectId: string;
+	files: ProjectFileNode[];
+	onRefresh: () => Promise<void>;
 }) {
-  const selectableFiles = useMemo(() => collectSelectableFiles(files), [files])
-  const [previewFile, setPreviewFile] = useState<ProjectFileNode | null>(null)
-  const [previewState, setPreviewState] = useState<FilePreviewState>({
-    status: 'idle',
-  })
-  const [uploading, setUploading] = useState(false)
-  const [uploadError, setUploadError] = useState<string | null>(null)
-  const [searchKeyword, setSearchKeyword] = useState('')
-  const [drawerWidth, setDrawerWidth] = useState(
-    FILE_PREVIEW_DRAWER_DEFAULT_WIDTH,
-  )
-  const drawerRef = useRef<HTMLDivElement>(null)
+	const selectableFiles = useMemo(() => collectSelectableFiles(files), [files]);
+	const [previewFile, setPreviewFile] = useState<ProjectFileNode | null>(null);
+	const [previewState, setPreviewState] = useState<FilePreviewState>({
+		status: "idle",
+	});
+	const [uploading, setUploading] = useState(false);
+	const [uploadError, setUploadError] = useState<string | null>(null);
+	const [searchKeyword, setSearchKeyword] = useState("");
+	const [drawerWidth, setDrawerWidth] = useState(FILE_PREVIEW_DRAWER_DEFAULT_WIDTH);
+	const drawerRef = useRef<HTMLDivElement>(null);
 
-  const closePreview = () => {
-    setPreviewFile(null)
-    setPreviewState({ status: 'idle' })
-  }
+	const closePreview = () => {
+		setPreviewFile(null);
+		setPreviewState({ status: "idle" });
+	};
 
-  const filteredFiles = useMemo(() => {
-    const keyword = searchKeyword.trim().toLowerCase()
-    const matchedFiles = !keyword
-      ? selectableFiles
-      : selectableFiles.filter((file) =>
-          file.name.toLowerCase().includes(keyword),
-        )
-    return sortProjectFilesByUploadedTimeDesc(matchedFiles)
-  }, [searchKeyword, selectableFiles])
+	const filteredFiles = useMemo(() => {
+		const keyword = searchKeyword.trim().toLowerCase();
+		const matchedFiles = !keyword
+			? selectableFiles
+			: selectableFiles.filter((file) => file.name.toLowerCase().includes(keyword));
+		return sortProjectFilesByUploadedTimeDesc(matchedFiles);
+	}, [searchKeyword, selectableFiles]);
 
-  useEffect(() => {
-    if (!previewFile) {
-      setPreviewState({ status: 'idle' })
-      return
-    }
-    const currentFile = previewFile
+	useEffect(() => {
+		if (!previewFile) {
+			setPreviewState({ status: "idle" });
+			return;
+		}
+		const currentFile = previewFile;
 
-    let cancelled = false
-    let objectUrl: string | null = null
-    const controller = new AbortController()
+		let cancelled = false;
+		let objectUrl: string | null = null;
+		const controller = new AbortController();
 
-    async function loadPreview() {
-      if (!currentFile.publicId) {
-        setPreviewState({
-          status: 'error',
-          message: '文件缺少 public_id，无法预览',
-        })
-        return
-      }
+		async function loadPreview() {
+			if (!currentFile.publicId) {
+				setPreviewState({
+					status: "error",
+					message: "文件缺少 public_id，无法预览",
+				});
+				return;
+			}
 
-      setPreviewState({ status: 'loading' })
-      try {
-        const response = await fetchFileDownload(currentFile.publicId, {
-          signal: controller.signal,
-        })
-        const mimeType =
-          response.headers.get('content-type') ??
-          currentFile.mimeType ??
-          'application/octet-stream'
+			setPreviewState({ status: "loading" });
+			try {
+				const response = await fetchFileDownload(currentFile.publicId, {
+					signal: controller.signal,
+				});
+				const mimeType =
+					response.headers.get("content-type") ??
+					currentFile.mimeType ??
+					"application/octet-stream";
 
-        if (isDocxPreviewable(currentFile.path, mimeType)) {
-          const buffer = await response.arrayBuffer()
-          if (!cancelled) {
-            setPreviewState({ status: 'docx', buffer })
-          }
-          return
-        }
+				if (isDocxPreviewable(currentFile.path, mimeType)) {
+					const buffer = await response.arrayBuffer();
+					if (!cancelled) {
+						setPreviewState({ status: "docx", buffer });
+					}
+					return;
+				}
 
-        if (isSpreadsheetPreviewable(currentFile.path, mimeType)) {
-          const buffer = await response.arrayBuffer()
-          if (!cancelled) {
-            setPreviewState({ status: 'spreadsheet', buffer })
-          }
-          return
-        }
+				if (isSpreadsheetPreviewable(currentFile.path, mimeType)) {
+					const buffer = await response.arrayBuffer();
+					if (!cancelled) {
+						setPreviewState({ status: "spreadsheet", buffer });
+					}
+					return;
+				}
 
-        if (isTextPreviewable(currentFile.path, mimeType)) {
-          const content = await response.text()
-          if (!cancelled) {
-            // markdown 需要走富文本渲染，避免在文件预览里退化成纯文本。
-            setPreviewState({
-              status: isMarkdownPreviewable(currentFile.path, mimeType)
-                ? 'markdown'
-                : 'text',
-              content,
-            })
-          }
-          return
-        }
+				if (isTextPreviewable(currentFile.path, mimeType)) {
+					const content = await response.text();
+					if (!cancelled) {
+						// markdown 需要走富文本渲染，避免在文件预览里退化成纯文本。
+						setPreviewState({
+							status: isMarkdownPreviewable(currentFile.path, mimeType) ? "markdown" : "text",
+							content,
+						});
+					}
+					return;
+				}
 
-        const blob = await response.blob()
-        objectUrl = URL.createObjectURL(blob)
-        if (!cancelled) {
-          setPreviewState({ status: 'blob', url: objectUrl, mimeType })
-        }
-      } catch (err) {
-        if (cancelled || controller.signal.aborted) return
-        setPreviewState({
-          status: 'error',
-          message: err instanceof Error ? err.message : '文件预览加载失败',
-        })
-      }
-    }
+				const blob = await response.blob();
+				objectUrl = URL.createObjectURL(blob);
+				if (!cancelled) {
+					setPreviewState({ status: "blob", url: objectUrl, mimeType });
+				}
+			} catch (err) {
+				if (cancelled || controller.signal.aborted) return;
+				setPreviewState({
+					status: "error",
+					message: err instanceof Error ? err.message : "文件预览加载失败",
+				});
+			}
+		}
 
-    loadPreview()
-    return () => {
-      cancelled = true
-      controller.abort()
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl)
-      }
-    }
-  }, [previewFile])
+		loadPreview();
+		return () => {
+			cancelled = true;
+			controller.abort();
+			if (objectUrl) {
+				URL.revokeObjectURL(objectUrl);
+			}
+		};
+	}, [previewFile]);
 
-  useEffect(() => {
-    if (!previewFile) return
+	useEffect(() => {
+		if (!previewFile) return;
 
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target
-      if (!(target instanceof Element)) return
-      if (drawerRef.current?.contains(target)) return
-      if (target.closest('[data-file-preview-trigger]')) return
-      closePreview()
-    }
+		const handlePointerDown = (event: PointerEvent) => {
+			const target = event.target;
+			if (!(target instanceof Element)) return;
+			if (drawerRef.current?.contains(target)) return;
+			if (target.closest("[data-file-preview-trigger]")) return;
+			closePreview();
+		};
 
-    document.addEventListener('pointerdown', handlePointerDown)
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [previewFile])
+		document.addEventListener("pointerdown", handlePointerDown);
+		return () => document.removeEventListener("pointerdown", handlePointerDown);
+	}, [previewFile]);
 
-  const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.target.value = ''
-    if (!file) return
+	const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		event.target.value = "";
+		if (!file) return;
 
-    setUploading(true)
-    setUploadError(null)
-    try {
-      const response = await projectFileApi.upload({ projectId, file })
-      await onRefresh()
-      toast.success(response.message || '文件上传成功')
-    } catch (err) {
-      setUploadError(err instanceof Error ? err.message : '上传文件失败')
-    } finally {
-      setUploading(false)
-    }
-  }
+		setUploading(true);
+		setUploadError(null);
+		try {
+			const response = await projectFileApi.upload({ projectId, file });
+			await onRefresh();
+			toast.success(response.message || "文件上传成功");
+		} catch (err) {
+			setUploadError(err instanceof Error ? err.message : "上传文件失败");
+		} finally {
+			setUploading(false);
+		}
+	};
 
-  const handleDownload = async (file: ProjectFileNode) => {
-    if (!file.publicId) {
-      console.error('ProjectFiles download error: missing public_id')
-      return
-    }
+	const handleDownload = async (file: ProjectFileNode) => {
+		if (!file.publicId) {
+			console.error("ProjectFiles download error: missing public_id");
+			return;
+		}
 
-    try {
-      const response = await fetchFileDownload(file.publicId)
-      const blob = await response.blob()
-      const objectUrl = URL.createObjectURL(blob)
-      const link = document.createElement('a')
-      link.href = objectUrl
-      link.download = file.name
-      document.body.appendChild(link)
-      link.click()
-      link.remove()
-      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0)
-    } catch (err) {
-      console.error('ProjectFiles download error:', err)
-    }
-  }
+		try {
+			const response = await fetchFileDownload(file.publicId);
+			const blob = await response.blob();
+			const objectUrl = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = objectUrl;
+			link.download = file.name;
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+			window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+		} catch (err) {
+			console.error("ProjectFiles download error:", err);
+		}
+	};
 
-  const handleDrawerResizeStart = (event: React.PointerEvent<HTMLElement>) => {
-    event.preventDefault()
-    const startX = event.clientX
-    const startWidth = drawerWidth
+	const handleDrawerResizeStart = (event: React.PointerEvent<HTMLElement>) => {
+		event.preventDefault();
+		const startX = event.clientX;
+		const startWidth = drawerWidth;
 
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const candidateWidth = startWidth - (moveEvent.clientX - startX)
-      const maxWidth = Math.min(
-        FILE_PREVIEW_DRAWER_MAX_WIDTH,
-        window.innerWidth - 160,
-      )
-      const nextWidth = Math.min(
-        Math.max(candidateWidth, FILE_PREVIEW_DRAWER_MIN_WIDTH),
-        Math.max(FILE_PREVIEW_DRAWER_MIN_WIDTH, maxWidth),
-      )
-      setDrawerWidth(nextWidth)
-    }
+		const handlePointerMove = (moveEvent: PointerEvent) => {
+			const candidateWidth = startWidth - (moveEvent.clientX - startX);
+			const maxWidth = Math.min(FILE_PREVIEW_DRAWER_MAX_WIDTH, window.innerWidth - 160);
+			const nextWidth = Math.min(
+				Math.max(candidateWidth, FILE_PREVIEW_DRAWER_MIN_WIDTH),
+				Math.max(FILE_PREVIEW_DRAWER_MIN_WIDTH, maxWidth),
+			);
+			setDrawerWidth(nextWidth);
+		};
 
-    const handlePointerUp = () => {
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handlePointerUp)
-    }
+		const handlePointerUp = () => {
+			window.removeEventListener("pointermove", handlePointerMove);
+			window.removeEventListener("pointerup", handlePointerUp);
+		};
 
-    window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handlePointerUp)
-  }
+		window.addEventListener("pointermove", handlePointerMove);
+		window.addEventListener("pointerup", handlePointerUp);
+	};
 
-  return (
-    <div className="h-full overflow-y-auto px-10 py-8">
-      <div className="mx-auto w-full max-w-[1200px]">
-        <div className="mb-8 flex items-center justify-between gap-6">
-          <div>
-            <h2 className="text-2xl font-semibold tracking-tight text-[var(--leros-text-strong)]">
-              项目文件
-            </h2>
-            <p className="mt-1 text-sm text-[var(--leros-text-muted)]">
-              管理当前项目的所有文件资源
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--leros-text-muted)]" />
-              <input
-                value={searchKeyword}
-                onChange={(event) => setSearchKeyword(event.target.value)}
-                placeholder="搜索文件..."
-                className="h-10 w-64 rounded-xl border border-[var(--leros-control-border)] bg-white pl-9 pr-4 text-sm outline-none transition-colors focus:border-[var(--leros-primary)]"
-              />
-            </div>
-            <label className="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-[var(--leros-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90">
-              <FileText className="size-4" />
-              上传
-              <input
-                type="file"
-                className="hidden"
-                accept={PROJECT_ATTACHMENT_ACCEPT}
-                onChange={handleUpload}
-                disabled={uploading}
-              />
-            </label>
-          </div>
-        </div>
+	return (
+		<div className="h-full overflow-y-auto px-10 py-8">
+			<div className="mx-auto w-full max-w-[1200px]">
+				<div className="mb-8 flex items-center justify-between gap-6">
+					<div>
+						<h2 className="text-2xl font-semibold tracking-tight text-[var(--leros-text-strong)]">
+							项目文件
+						</h2>
+						<p className="mt-1 text-sm text-[var(--leros-text-muted)]">
+							管理当前项目的所有文件资源
+						</p>
+					</div>
+					<div className="flex items-center gap-3">
+						<div className="relative">
+							<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--leros-text-muted)]" />
+							<input
+								value={searchKeyword}
+								onChange={(event) => setSearchKeyword(event.target.value)}
+								placeholder="搜索文件..."
+								className="h-10 w-64 rounded-xl border border-[var(--leros-control-border)] bg-white pl-9 pr-4 text-sm outline-none transition-colors focus:border-[var(--leros-primary)]"
+							/>
+						</div>
+						<label className="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-[var(--leros-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90">
+							<FileText className="size-4" />
+							上传
+							<input
+								type="file"
+								className="hidden"
+								accept={PROJECT_ATTACHMENT_ACCEPT}
+								onChange={handleUpload}
+								disabled={uploading}
+							/>
+						</label>
+					</div>
+				</div>
 
-        {uploading && (
-          <div className="mb-4 rounded-xl border border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-4 py-3 text-sm text-[var(--leros-text-muted)]">
-            正在上传文件...
-          </div>
-        )}
-        {uploadError && (
-          <div className="mb-4 rounded-xl border border-[var(--leros-danger)]/20 bg-[var(--leros-danger-softer)] px-4 py-3 text-sm text-[var(--leros-danger)]">
-            {uploadError}
-          </div>
-        )}
+				{uploading && (
+					<div className="mb-4 rounded-xl border border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-4 py-3 text-sm text-[var(--leros-text-muted)]">
+						正在上传文件...
+					</div>
+				)}
+				{uploadError && (
+					<div className="mb-4 rounded-xl border border-[var(--leros-danger)]/20 bg-[var(--leros-danger-softer)] px-4 py-3 text-sm text-[var(--leros-danger)]">
+						{uploadError}
+					</div>
+				)}
 
-        <div className="overflow-hidden rounded-2xl border border-[var(--leros-control-border)] bg-white">
-          <div className="grid grid-cols-[minmax(0,1fr)_120px_180px_220px] border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-6 py-4 text-xs font-semibold uppercase tracking-wider text-[var(--leros-text-muted)]">
-            <div>名称</div>
-            <div>大小</div>
-            <div>上传时间</div>
-            <div className="text-right">操作</div>
-          </div>
+				<div className="overflow-hidden rounded-2xl border border-[var(--leros-control-border)] bg-white">
+					<div className="grid grid-cols-[minmax(0,1fr)_120px_180px_220px] border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-6 py-4 text-xs font-semibold uppercase tracking-wider text-[var(--leros-text-muted)]">
+						<div>名称</div>
+						<div>大小</div>
+						<div>上传时间</div>
+						<div className="text-right">操作</div>
+					</div>
 
-          {filteredFiles.length === 0 ? (
-            <div className="px-6 py-16 text-center text-sm text-[var(--leros-text-muted)]">
-              暂无文件
-            </div>
-          ) : (
-            <div className="divide-y divide-[var(--leros-control-border)]/60">
-              {filteredFiles.map((file) => (
-                <div
-                  key={file.path}
-                  className="grid grid-cols-[minmax(0,1fr)_120px_180px_220px] items-center px-6 py-5 transition-colors hover:bg-[var(--leros-primary-softer)]/25"
-                >
-                  <button
-                    type="button"
-                    data-file-preview-trigger
-                    onClick={() => setPreviewFile(file)}
-                    className="flex min-w-0 cursor-pointer items-center gap-3 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--leros-primary-softer)]/50"
-                    title="查看"
-                  >
-                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
-                      <ProjectFileTypeIcon fileName={file.name} />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-[var(--leros-text-strong)]">
-                        {file.name}
-                      </p>
-                      <p className="truncate text-xs text-[var(--leros-text-muted)]">
-                        /{file.path}
-                      </p>
-                    </div>
-                  </button>
-                  <div className="text-sm text-[var(--leros-text-muted)]">
-                    {formatBytes(file.size)}
-                  </div>
-                  <div className="text-sm text-[var(--leros-text-muted)]">
-                    {formatTime(file.modTime)}
-                  </div>
-                  <div className="flex items-center justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setPreviewFile(file)}
-                      className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
-                      title="查看"
-                    >
-                      <Eye className="size-4" />
-                      查看
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleDownload(file)}
-                      className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
-                      title="下载"
-                    >
-                      <Download className="size-4" />
-                      下载
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
+					{filteredFiles.length === 0 ? (
+						<div className="px-6 py-16 text-center text-sm text-[var(--leros-text-muted)]">
+							暂无文件
+						</div>
+					) : (
+						<div className="divide-y divide-[var(--leros-control-border)]/60">
+							{filteredFiles.map((file) => (
+								<div
+									key={file.path}
+									className="grid grid-cols-[minmax(0,1fr)_120px_180px_220px] items-center px-6 py-5 transition-colors hover:bg-[var(--leros-primary-softer)]/25"
+								>
+									<button
+										type="button"
+										data-file-preview-trigger
+										onClick={() => setPreviewFile(file)}
+										className="flex min-w-0 cursor-pointer items-center gap-3 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--leros-primary-softer)]/50"
+										title="查看"
+									>
+										<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
+											<ProjectFileTypeIcon fileName={file.name} />
+										</div>
+										<div className="min-w-0">
+											<p className="truncate text-sm font-semibold text-[var(--leros-text-strong)]">
+												{file.name}
+											</p>
+											<p className="truncate text-xs text-[var(--leros-text-muted)]">
+												/{file.path}
+											</p>
+										</div>
+									</button>
+									<div className="text-sm text-[var(--leros-text-muted)]">
+										{formatBytes(file.size)}
+									</div>
+									<div className="text-sm text-[var(--leros-text-muted)]">
+										{formatTime(file.modTime)}
+									</div>
+									<div className="flex items-center justify-end gap-2">
+										<button
+											type="button"
+											onClick={() => setPreviewFile(file)}
+											className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
+											title="查看"
+										>
+											<Eye className="size-4" />
+											查看
+										</button>
+										<button
+											type="button"
+											onClick={() => handleDownload(file)}
+											className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
+											title="下载"
+										>
+											<Download className="size-4" />
+											下载
+										</button>
+									</div>
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
 
-      {previewFile && (
-        <div
-          ref={drawerRef}
-          className="fixed right-0 top-16 z-40 flex h-[calc(100vh-64px)] flex-col overflow-hidden border-l border-[var(--leros-control-border)] bg-[var(--leros-surface)] p-0 shadow-2xl rounded-l-2xl"
-          style={{ width: `${drawerWidth}px`, maxWidth: `${drawerWidth}px` }}
-        >
-          <button
-            type="button"
-            aria-label="拖动调整预览宽度"
-            title="拖动调整预览宽度"
-            onPointerDown={handleDrawerResizeStart}
-            className="absolute left-0 top-0 z-10 flex h-full w-4 -translate-x-1/2 cursor-col-resize items-center justify-center"
-          >
-            <div className="flex h-16 w-2 items-center justify-center rounded-full bg-[var(--leros-surface-soft)] text-[var(--leros-text-muted)] shadow-sm ring-1 ring-[var(--leros-control-border)]">
-              <ChevronsLeftRightEllipsis className="size-3" />
-            </div>
-          </button>
-          <div className="flex items-center justify-between border-b border-[var(--leros-control-border)] px-6 py-4">
-            <div className="min-w-0">
-              <div className="truncate text-lg font-medium text-[var(--leros-text-strong)]">
-                {previewFile.name}
-              </div>
-              <div className="mt-1 truncate text-xs text-[var(--leros-text-muted)]">
-                /{previewFile.path}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => handleDownload(previewFile)}
-                className="rounded-lg p-2 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)]"
-                title="下载"
-              >
-                <Download className="size-4" />
-              </button>
-              <button
-                type="button"
-                onClick={closePreview}
-                className="rounded-lg p-2 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)]"
-                title="关闭"
-              >
-                <X className="size-4" />
-              </button>
-            </div>
-          </div>
-          <div className="min-h-0 flex-1 overflow-auto bg-[var(--leros-surface-soft)] p-6">
-            <ProjectFilePreviewBody
-              file={previewFile}
-              previewState={previewState}
-            />
-          </div>
-        </div>
-      )}
-    </div>
-  )
+			{previewFile && (
+				<div
+					ref={drawerRef}
+					className="fixed right-0 top-16 z-40 flex h-[calc(100vh-64px)] flex-col overflow-hidden border-l border-[var(--leros-control-border)] bg-[var(--leros-surface)] p-0 shadow-2xl rounded-l-2xl"
+					style={{ width: `${drawerWidth}px`, maxWidth: `${drawerWidth}px` }}
+				>
+					<button
+						type="button"
+						aria-label="拖动调整预览宽度"
+						title="拖动调整预览宽度"
+						onPointerDown={handleDrawerResizeStart}
+						className="absolute left-0 top-0 z-10 flex h-full w-4 -translate-x-1/2 cursor-col-resize items-center justify-center"
+					>
+						<div className="flex h-16 w-2 items-center justify-center rounded-full bg-[var(--leros-surface-soft)] text-[var(--leros-text-muted)] shadow-sm ring-1 ring-[var(--leros-control-border)]">
+							<ChevronsLeftRightEllipsis className="size-3" />
+						</div>
+					</button>
+					<div className="flex items-center justify-between border-b border-[var(--leros-control-border)] px-6 py-4">
+						<div className="min-w-0">
+							<div className="truncate text-lg font-medium text-[var(--leros-text-strong)]">
+								{previewFile.name}
+							</div>
+							<div className="mt-1 truncate text-xs text-[var(--leros-text-muted)]">
+								/{previewFile.path}
+							</div>
+						</div>
+						<div className="flex items-center gap-2">
+							<button
+								type="button"
+								onClick={() => handleDownload(previewFile)}
+								className="rounded-lg p-2 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)]"
+								title="下载"
+							>
+								<Download className="size-4" />
+							</button>
+							<button
+								type="button"
+								onClick={closePreview}
+								className="rounded-lg p-2 text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)]"
+								title="关闭"
+							>
+								<X className="size-4" />
+							</button>
+						</div>
+					</div>
+					<div className="min-h-0 flex-1 overflow-auto bg-[var(--leros-surface-soft)] p-6">
+						<ProjectFilePreviewBody file={previewFile} previewState={previewState} />
+					</div>
+				</div>
+			)}
+		</div>
+	);
 }
 
 function ProjectFilePreviewBody({
-  file,
-  previewState,
+	file,
+	previewState,
 }: {
-  file: ProjectFileNode
-  previewState: FilePreviewState
+	file: ProjectFileNode;
+	previewState: FilePreviewState;
 }) {
-  if (previewState.status === 'idle' || previewState.status === 'loading') {
-    return (
-      <div className="flex h-full min-h-[320px] items-center justify-center text-sm text-[var(--leros-text-muted)]">
-        <LoaderCircle className="mr-2 size-4 animate-spin" />
-        加载预览中
-      </div>
-    )
-  }
+	if (previewState.status === "idle" || previewState.status === "loading") {
+		return (
+			<div className="flex h-full min-h-[320px] items-center justify-center text-sm text-[var(--leros-text-muted)]">
+				<LoaderCircle className="mr-2 size-4 animate-spin" />
+				加载预览中
+			</div>
+		);
+	}
 
-  if (previewState.status === 'error') {
-    return (
-      <div className="flex h-full min-h-[320px] items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
-        <div>
-          <p>无法加载文件预览</p>
-          <p className="mt-1 text-xs">{previewState.message}</p>
-        </div>
-      </div>
-    )
-  }
+	if (previewState.status === "error") {
+		return (
+			<div className="flex h-full min-h-[320px] items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
+				<div>
+					<p>无法加载文件预览</p>
+					<p className="mt-1 text-xs">{previewState.message}</p>
+				</div>
+			</div>
+		);
+	}
 
-  if (previewState.status === 'text') {
-    return (
-      <pre className="overflow-auto rounded-xl bg-white p-4 text-sm leading-6 text-[var(--leros-text)] shadow-sm">
-        {previewState.content}
-      </pre>
-    )
-  }
+	if (previewState.status === "text") {
+		return (
+			<pre className="overflow-auto rounded-xl bg-white p-4 text-sm leading-6 text-[var(--leros-text)] shadow-sm">
+				{previewState.content}
+			</pre>
+		);
+	}
 
-  if (previewState.status === 'markdown') {
-    return (
-      <div className="overflow-auto rounded-xl bg-white px-8 py-7 shadow-sm">
-        <MarkdownRenderer
-          content={previewState.content}
-          className="prose prose-slate prose-sm max-w-none prose-headings:text-[var(--leros-text-strong)] prose-p:leading-7 prose-pre:rounded-lg prose-pre:bg-slate-950"
-        />
-      </div>
-    )
-  }
+	if (previewState.status === "markdown") {
+		return (
+			<div className="overflow-auto rounded-xl bg-white px-8 py-7 shadow-sm">
+				<MarkdownRenderer
+					content={previewState.content}
+					className="prose prose-slate prose-sm max-w-none prose-headings:text-[var(--leros-text-strong)] prose-p:leading-7 prose-pre:rounded-lg prose-pre:bg-slate-950"
+				/>
+			</div>
+		);
+	}
 
-  if (previewState.status === 'docx') {
-    return (
-      <div className="h-[calc(100vh-150px)] min-h-[520px] overflow-hidden rounded-xl bg-white shadow-sm">
-        <ProjectDocxPreview
-          documentName={file.name}
-          documentKey={file.path}
-          buffer={previewState.buffer}
-        />
-      </div>
-    )
-  }
+	if (previewState.status === "docx") {
+		return (
+			<div className="h-[calc(100vh-150px)] min-h-[520px] overflow-hidden rounded-xl bg-white shadow-sm">
+				<ProjectDocxPreview
+					documentName={file.name}
+					documentKey={file.path}
+					buffer={previewState.buffer}
+				/>
+			</div>
+		);
+	}
 
-  if (previewState.status === 'spreadsheet') {
-    return (
-      <div className="h-[calc(100vh-150px)] min-h-[520px] overflow-hidden rounded-xl bg-white shadow-sm">
-        <SpreadsheetPreview buffer={previewState.buffer} fileName={file.name} />
-      </div>
-    )
-  }
+	if (previewState.status === "spreadsheet") {
+		return (
+			<div className="h-[calc(100vh-150px)] min-h-[520px] overflow-hidden rounded-xl bg-white shadow-sm">
+				<SpreadsheetPreview buffer={previewState.buffer} fileName={file.name} />
+			</div>
+		);
+	}
 
-  if (previewState.mimeType.startsWith('image/')) {
-    return (
-      <div className="flex min-h-[320px] items-center justify-center rounded-xl bg-white p-4 shadow-sm">
-        <img
-          src={previewState.url}
-          alt={file.name}
-          className="max-h-full max-w-full object-contain"
-        />
-      </div>
-    )
-  }
+	if (previewState.mimeType.startsWith("image/")) {
+		return (
+			<div className="flex min-h-[320px] items-center justify-center rounded-xl bg-white p-4 shadow-sm">
+				<img
+					src={previewState.url}
+					alt={file.name}
+					className="max-h-full max-w-full object-contain"
+				/>
+			</div>
+		);
+	}
 
-  if (previewState.mimeType.includes('pdf')) {
-    return (
-      <div className="overflow-hidden rounded-xl bg-white shadow-sm">
-        <iframe
-          title={file.name}
-          src={previewState.url}
-          className="h-[calc(100vh-150px)] min-h-[760px] w-full border-0 bg-white"
-        />
-      </div>
-    )
-  }
+	if (previewState.mimeType.includes("pdf")) {
+		return (
+			<div className="overflow-hidden rounded-xl bg-white shadow-sm">
+				<iframe
+					title={file.name}
+					src={previewState.url}
+					className="h-[calc(100vh-150px)] min-h-[760px] w-full border-0 bg-white"
+				/>
+			</div>
+		);
+	}
 
-  return (
-    <div className="flex min-h-[320px] items-center justify-center rounded-xl bg-white px-8 text-center text-sm text-[var(--leros-text-muted)] shadow-sm">
-      <div>
-        <FileText className="mx-auto mb-3 size-8 text-[var(--leros-text-subtle)]" />
-        <p>此文件类型暂不支持内嵌预览</p>
-        <p className="mt-1 text-xs">请使用下载按钮在本地查看</p>
-      </div>
-    </div>
-  )
+	return (
+		<div className="flex min-h-[320px] items-center justify-center rounded-xl bg-white px-8 text-center text-sm text-[var(--leros-text-muted)] shadow-sm">
+			<div>
+				<FileText className="mx-auto mb-3 size-8 text-[var(--leros-text-subtle)]" />
+				<p>此文件类型暂不支持内嵌预览</p>
+				<p className="mt-1 text-xs">请使用下载按钮在本地查看</p>
+			</div>
+		</div>
+	);
 }
 
 function ProjectDocxPreview({
-  documentName,
-  documentKey,
-  buffer,
+	documentName,
+	documentKey,
+	buffer,
 }: {
-  documentName: string
-  documentKey: string
-  buffer: ArrayBuffer
+	documentName: string;
+	documentKey: string;
+	buffer: ArrayBuffer;
 }) {
-  const [DocxEditor, setDocxEditor] = useState<DocxEditorComponent | null>(
-    docxEditorComponent,
-  )
-  const [error, setError] = useState<string | null>(null)
+	const [DocxEditor, setDocxEditor] = useState<DocxEditorComponent | null>(docxEditorComponent);
+	const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false
-    setError(null)
-    // 这里复用和文件预览一致的懒加载模式，保证文件 tab 的 DOCX 体验对齐。
-    loadDocxEditor()
-      .then((component) => {
-        if (!cancelled) setDocxEditor(() => component)
-      })
-      .catch((err) => {
-        if (cancelled) return
-        setError(err instanceof Error ? err.message : 'DOCX 预览组件加载失败')
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
+	useEffect(() => {
+		let cancelled = false;
+		setError(null);
+		// 这里复用和文件预览一致的懒加载模式，保证文件 tab 的 DOCX 体验对齐。
+		loadDocxEditor()
+			.then((component) => {
+				if (!cancelled) setDocxEditor(() => component);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				setError(err instanceof Error ? err.message : "DOCX 预览组件加载失败");
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
-  if (error) {
-    return (
-      <div className="flex h-full items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
-        <div>
-          <p>无法加载 DOCX 预览</p>
-          <p className="mt-1 text-xs">{error}</p>
-        </div>
-      </div>
-    )
-  }
+	if (error) {
+		return (
+			<div className="flex h-full items-center justify-center px-8 text-center text-sm text-[var(--leros-text-muted)]">
+				<div>
+					<p>无法加载 DOCX 预览</p>
+					<p className="mt-1 text-xs">{error}</p>
+				</div>
+			</div>
+		);
+	}
 
-  if (!DocxEditor) {
-    return <div className="h-full bg-white" />
-  }
+	if (!DocxEditor) {
+		return <div className="h-full bg-white" />;
+	}
 
-  return (
-    <div className="h-full overflow-hidden">
-      <DocxEditor
-        key={documentKey}
-        documentBuffer={buffer}
-        mode="viewing"
-        readOnly
-        showToolbar={false}
-        showZoomControl={false}
-        showRuler={false}
-        showOutline={false}
-        showOutlineButton={false}
-        disableFindReplaceShortcuts
-        initialZoom={0.82}
-        documentName={documentName}
-        documentNameEditable={false}
-        className="leros-docx-preview h-full"
-        style={{ height: '100%', background: '#f6f7fb' }}
-        loadingIndicator={<div className="h-full bg-[#f6f7fb]" />}
-        onError={(err) => setError(err.message)}
-      />
-    </div>
-  )
+	return (
+		<div className="h-full overflow-hidden">
+			<DocxEditor
+				key={documentKey}
+				documentBuffer={buffer}
+				mode="viewing"
+				readOnly
+				showToolbar={false}
+				showZoomControl={false}
+				showRuler={false}
+				showOutline={false}
+				showOutlineButton={false}
+				disableFindReplaceShortcuts
+				initialZoom={0.82}
+				documentName={documentName}
+				documentNameEditable={false}
+				className="leros-docx-preview h-full"
+				style={{ height: "100%", background: "#f6f7fb" }}
+				loadingIndicator={<div className="h-full bg-[#f6f7fb]" />}
+				onError={(err) => setError(err.message)}
+			/>
+		</div>
+	);
 }
 
 function isTextPreviewable(path: string, mimeType: string): boolean {
-  const normalizedPath = path.toLowerCase()
-  const normalizedMimeType = mimeType.toLowerCase()
+	const normalizedPath = path.toLowerCase();
+	const normalizedMimeType = mimeType.toLowerCase();
 
-  if (normalizedMimeType.startsWith('text/')) return true
-  if (normalizedMimeType.includes('json')) return true
-  if (normalizedMimeType.includes('javascript')) return true
-  if (normalizedMimeType.includes('typescript')) return true
+	if (normalizedMimeType.startsWith("text/")) return true;
+	if (normalizedMimeType.includes("json")) return true;
+	if (normalizedMimeType.includes("javascript")) return true;
+	if (normalizedMimeType.includes("typescript")) return true;
 
-  return [
-    '.md',
-    '.markdown',
-    '.txt',
-    '.json',
-    '.js',
-    '.jsx',
-    '.ts',
-    '.tsx',
-    '.css',
-    '.html',
-    '.xml',
-    '.yml',
-    '.yaml',
-    '.go',
-    '.py',
-    '.java',
-    '.sh',
-    '.sql',
-  ].some((suffix) => normalizedPath.endsWith(suffix))
+	return [
+		".md",
+		".markdown",
+		".txt",
+		".json",
+		".js",
+		".jsx",
+		".ts",
+		".tsx",
+		".css",
+		".html",
+		".xml",
+		".yml",
+		".yaml",
+		".go",
+		".py",
+		".java",
+		".sh",
+		".sql",
+	].some((suffix) => normalizedPath.endsWith(suffix));
 }
 
 function isMarkdownPreviewable(path: string, mimeType: string): boolean {
-  const normalizedPath = path.toLowerCase()
-  const normalizedMimeType = mimeType.toLowerCase()
+	const normalizedPath = path.toLowerCase();
+	const normalizedMimeType = mimeType.toLowerCase();
 
-  return (
-    normalizedMimeType.includes('markdown') ||
-    normalizedPath.endsWith('.md') ||
-    normalizedPath.endsWith('.markdown')
-  )
+	return (
+		normalizedMimeType.includes("markdown") ||
+		normalizedPath.endsWith(".md") ||
+		normalizedPath.endsWith(".markdown")
+	);
 }
 
 function isDocxPreviewable(path: string, mimeType: string): boolean {
-  const normalizedPath = path.toLowerCase()
-  const normalizedMimeType = mimeType.toLowerCase()
+	const normalizedPath = path.toLowerCase();
+	const normalizedMimeType = mimeType.toLowerCase();
 
-  return (
-    normalizedMimeType ===
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
-    normalizedPath.endsWith('.docx')
-  )
+	return (
+		normalizedMimeType ===
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+		normalizedPath.endsWith(".docx")
+	);
 }
 
 function isSpreadsheetPreviewable(path: string, mimeType: string): boolean {
-  const normalizedPath = path.toLowerCase()
-  const normalizedMimeType = mimeType.toLowerCase()
+	const normalizedPath = path.toLowerCase();
+	const normalizedMimeType = mimeType.toLowerCase();
 
-  return (
-    normalizedMimeType.includes('spreadsheet') ||
-    normalizedMimeType.includes('excel') ||
-    normalizedMimeType === 'text/csv' ||
-    ['.xlsx', '.xls', '.csv'].some((suffix) => normalizedPath.endsWith(suffix))
-  )
+	return (
+		normalizedMimeType.includes("spreadsheet") ||
+		normalizedMimeType.includes("excel") ||
+		normalizedMimeType === "text/csv" ||
+		[".xlsx", ".xls", ".csv"].some((suffix) => normalizedPath.endsWith(suffix))
+	);
 }
 
 function formatBytes(size: number): string {
-  if (!size) return '-'
-  if (size < 1024) return `${size} B`
-  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
-  if (size < 1024 * 1024 * 1024)
-    return `${(size / (1024 * 1024)).toFixed(1)} MB`
-  return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`
+	if (!size) return "-";
+	if (size < 1024) return `${size} B`;
+	if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+	if (size < 1024 * 1024 * 1024) return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+	return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
 function formatTime(timestamp: number): string {
-  if (!timestamp) return '-'
-  return new Intl.DateTimeFormat('zh-CN', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(new Date(timestamp * 1000))
+	if (!timestamp) return "-";
+	return new Intl.DateTimeFormat("zh-CN", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+	}).format(new Date(timestamp * 1000));
 }
 
 function clampProjectRightSidebarWidth(width: number): number {
-  return Math.min(
-    PROJECT_RIGHT_SIDEBAR_MAX_WIDTH,
-    Math.max(PROJECT_RIGHT_SIDEBAR_MIN_WIDTH, Math.round(width)),
-  )
+	return Math.min(
+		PROJECT_RIGHT_SIDEBAR_MAX_WIDTH,
+		Math.max(PROJECT_RIGHT_SIDEBAR_MIN_WIDTH, Math.round(width)),
+	);
 }
 
 function ProjectArtifactList({
-  artifacts,
-  emptyText = '暂无文件',
-  compact = false,
+	artifacts,
+	emptyText = "暂无文件",
+	compact = false,
 }: {
-  artifacts: ProjectArtifact[]
-  emptyText?: string
-  compact?: boolean
+	artifacts: ProjectArtifact[];
+	emptyText?: string;
+	compact?: boolean;
 }) {
-  const [previewArtifact, setPreviewArtifact] =
-    useState<ProjectArtifact | null>(null)
+	const [previewArtifact, setPreviewArtifact] = useState<ProjectArtifact | null>(null);
 
-  if (artifacts.length === 0) {
-    return (
-      <div className="rounded-lg border border-dashed border-[var(--leros-control-border)] px-4 py-8 text-center text-xs text-[var(--leros-text-muted)]">
-        {emptyText}
-      </div>
-    )
-  }
+	if (artifacts.length === 0) {
+		return (
+			<div className="rounded-lg border border-dashed border-[var(--leros-control-border)] px-4 py-8 text-center text-xs text-[var(--leros-text-muted)]">
+				{emptyText}
+			</div>
+		);
+	}
 
-  return (
-    <>
-      <div className={cn('w-full', compact && 'mx-auto max-w-[250px]')}>
-        <div className={cn(compact ? SIDEBAR_COMPACT_LIST_CLASS : 'space-y-3')}>
-          {artifacts.map((artifact) => (
-            <button
-              type="button"
-              key={artifact.id}
-              onClick={() => setPreviewArtifact(artifact)}
-              className={cn(
-                'group relative flex w-full cursor-pointer items-center overflow-hidden border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35',
-                compact
-                  ? 'gap-3 rounded-lg px-3.5 py-3'
-                  : 'gap-3.5 rounded-lg px-4 py-3.5',
-              )}
-              title="预览文件"
-            >
-              {/* hover 时补一个轻量蒙层，明确提示当前整卡可点击预览 */}
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                <span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
-                  点击预览
-                </span>
-              </div>
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
-                <ProjectFileTypeIcon fileName={artifact.name} />
-              </div>
-              <div className="min-w-0">
-                <div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">
-                  {artifact.name}
-                </div>
-                <div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
-                  {artifact.size}
-                  {artifact.updatedAt
-                    ? ` · ${formatArtifactTime(artifact.updatedAt)}`
-                    : ''}
-                </div>
-              </div>
-            </button>
-          ))}
-        </div>
-      </div>
-      <ArtifactPreviewDialog
-        artifact={previewArtifact}
-        open={previewArtifact !== null}
-        onOpenChange={(open) => {
-          if (!open) setPreviewArtifact(null)
-        }}
-      />
-    </>
-  )
+	return (
+		<>
+			<div className={cn("w-full", compact && "mx-auto max-w-[250px]")}>
+				<div className={cn(compact ? SIDEBAR_COMPACT_LIST_CLASS : "space-y-3")}>
+					{artifacts.map((artifact) => (
+						<button
+							type="button"
+							key={artifact.id}
+							onClick={() => setPreviewArtifact(artifact)}
+							className={cn(
+								"group relative flex w-full cursor-pointer items-center overflow-hidden border border-[var(--leros-control-border)] bg-[var(--leros-surface)] text-left shadow-sm transition-colors hover:border-[var(--leros-primary-soft)] hover:bg-[var(--leros-primary-softer)]/35",
+								compact ? "gap-3 rounded-lg px-3.5 py-3" : "gap-3.5 rounded-lg px-4 py-3.5",
+							)}
+							title="预览文件"
+						>
+							{/* hover 时补一个轻量蒙层，明确提示当前整卡可点击预览 */}
+							<div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+								<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
+									点击预览
+								</span>
+							</div>
+							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)]">
+								<ProjectFileTypeIcon fileName={artifact.name} />
+							</div>
+							<div className="min-w-0">
+								<div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">
+									{artifact.name}
+								</div>
+								<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
+									{artifact.size}
+									{artifact.updatedAt ? ` · ${formatArtifactTime(artifact.updatedAt)}` : ""}
+								</div>
+							</div>
+						</button>
+					))}
+				</div>
+			</div>
+			<ArtifactPreviewDialog
+				artifact={previewArtifact}
+				open={previewArtifact !== null}
+				onOpenChange={(open) => {
+					if (!open) setPreviewArtifact(null);
+				}}
+			/>
+		</>
+	);
 }

--- a/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
@@ -545,9 +545,17 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 										size="icon"
 										onClick={handleSend}
 										disabled={isGenerating || !input.trim()}
-										className="size-9 rounded-xl bg-[var(--leros-primary)] text-white shadow-sm hover:bg-[var(--leros-primary-strong)] disabled:bg-[var(--leros-chat-control-bg)] disabled:text-[var(--leros-text-subtle)]"
+										// 中文注释：与项目任务 ChatInput 发送按钮保持一致，使用黑色主色而非品牌紫
+										className="size-9 min-w-0 rounded-xl bg-black !text-white shadow-sm hover:bg-blue-700 disabled:bg-[#f3f3f4] disabled:!text-slate-400"
 									>
-										<SendHorizonal className="size-4" />
+										<SendHorizonal
+											className={cn(
+												"size-3.5",
+												input.trim() && !isGenerating
+													? "fill-white stroke-white text-white"
+													: "fill-none stroke-current text-current",
+											)}
+										/>
 									</Button>
 								</div>
 							</div>

--- a/frontend/packages/app-ui/package.json
+++ b/frontend/packages/app-ui/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"scripts": {
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check ."
+		"lint": "biome check .",
+		"test": "vitest run --environment jsdom"
 	},
 	"exports": {
 		".": "./index.ts",
@@ -29,9 +30,14 @@
 		"react-dom": "catalog:"
 	},
 	"devDependencies": {
+		"@testing-library/jest-dom": "catalog:",
+		"@testing-library/react": "catalog:",
+		"@testing-library/user-event": "catalog:",
 		"@leros/tsconfig": "workspace:*",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
-		"typescript": "catalog:"
+		"jsdom": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
 	}
 }

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -1149,8 +1149,8 @@ export class ChatActionImpl {
 		attachments?: Attachment[],
 	) => {
 		const trimmed = content.trim();
-		if (!trimmed || !projectId) return;
-		if (this.#get().isGenerating) return;
+		if (!trimmed || !projectId) return null;
+		if (this.#get().isGenerating) return null;
 
 		try {
 			const res = await workApi.newMessage({
@@ -1159,7 +1159,7 @@ export class ChatActionImpl {
 				attachments: mapOutgoingAttachments(attachments),
 			});
 			const data = res.data.data;
-			if (!data?.project_id || !data?.task_id || !data?.session_id) return;
+			if (!data?.project_id || !data?.task_id || !data?.session_id) return null;
 
 			(this.#set as (partial: Record<string, unknown>) => void)({
 				activeProjectId: data.project_id,
@@ -1181,8 +1181,10 @@ export class ChatActionImpl {
 				fetchProjectDetail?: (projectId: string) => Promise<void>;
 			};
 			await fullState.fetchProjectDetail?.(data.project_id);
+			return data;
 		} catch (err) {
 			console.error("sendProjectMessage error:", err);
+			return null;
 		}
 	};
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,6 +12,15 @@ catalogs:
     '@tailwindcss/typography':
       specifier: ^0.5.20
       version: 0.5.20
+    '@testing-library/jest-dom':
+      specifier: ^6.9.1
+      version: 6.9.1
+    '@testing-library/react':
+      specifier: ^16.3.2
+      version: 16.3.2
+    '@testing-library/user-event':
+      specifier: ^14.6.1
+      version: 14.6.1
     '@types/react':
       specifier: ^19.2.0
       version: 19.2.17
@@ -263,15 +272,30 @@ importers:
       '@leros/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0))
 
   packages/biome: {}
 
@@ -400,6 +424,9 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -592,53 +619,53 @@ packages:
     hasBin: true
 
   '@biomejs/cli-darwin-arm64@2.4.16':
-    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==, tarball: https://registry.npmmirror.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz}
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
   '@biomejs/cli-darwin-x64@2.4.16':
-    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==, tarball: https://registry.npmmirror.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz}
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
   '@biomejs/cli-linux-arm64-musl@2.4.16':
-    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz}
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.16':
-    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz}
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.16':
-    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz}
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.16':
-    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz}
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.16':
-    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==, tarball: https://registry.npmmirror.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz}
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
   '@biomejs/cli-win32-x64@2.4.16':
-    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==, tarball: https://registry.npmmirror.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz}
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -808,174 +835,174 @@ packages:
     engines: {node: '>=16.4'}
 
   '@electron/windows-sign@1.2.2':
-    resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==, tarball: https://registry.npmmirror.com/@electron/windows-sign/-/windows-sign-1.2.2.tgz}
+    resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
 
   '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==, tarball: https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz}
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
   '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==, tarball: https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.10.0.tgz}
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.11.0':
-    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==, tarball: https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.11.0.tgz}
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==, tarball: https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==, tarball: https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz}
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==, tarball: https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==, tarball: https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz}
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==, tarball: https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==, tarball: https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==, tarball: https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==, tarball: https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==, tarball: https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==, tarball: https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==, tarball: https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz}
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==, tarball: https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz}
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==, tarball: https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz}
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==, tarball: https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz}
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==, tarball: https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz}
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==, tarball: https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz}
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==, tarball: https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz}
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==, tarball: https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==, tarball: https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==, tarball: https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==, tarball: https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==, tarball: https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==, tarball: https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==, tarball: https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==, tarball: https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz}
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==, tarball: https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz}
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==, tarball: https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz}
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1015,150 +1042,150 @@ packages:
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==, tarball: https://registry.npmmirror.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz}
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==, tarball: https://registry.npmmirror.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz}
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz}
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz}
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz}
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz}
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz}
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz}
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz}
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz}
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz}
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==, tarball: https://registry.npmmirror.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz}
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==, tarball: https://registry.npmmirror.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz}
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==, tarball: https://registry.npmmirror.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz}
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==, tarball: https://registry.npmmirror.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz}
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==, tarball: https://registry.npmmirror.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz}
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==, tarball: https://registry.npmmirror.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz}
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==, tarball: https://registry.npmmirror.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz}
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==, tarball: https://registry.npmmirror.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz}
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==, tarball: https://registry.npmmirror.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz}
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==, tarball: https://registry.npmmirror.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz}
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
   '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==, tarball: https://registry.npmmirror.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz}
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
   '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==, tarball: https://registry.npmmirror.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz}
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==, tarball: https://registry.npmmirror.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz}
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -1202,7 +1229,7 @@ packages:
         optional: true
 
   '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==, tarball: https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz}
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1211,53 +1238,53 @@ packages:
     resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
 
   '@next/swc-darwin-arm64@16.2.9':
-    resolution: {integrity: sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==, tarball: https://registry.npmmirror.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz}
+    resolution: {integrity: sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
   '@next/swc-darwin-x64@16.2.9':
-    resolution: {integrity: sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==, tarball: https://registry.npmmirror.com/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz}
+    resolution: {integrity: sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
   '@next/swc-linux-arm64-gnu@16.2.9':
-    resolution: {integrity: sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==, tarball: https://registry.npmmirror.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz}
+    resolution: {integrity: sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.9':
-    resolution: {integrity: sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==, tarball: https://registry.npmmirror.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz}
+    resolution: {integrity: sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.9':
-    resolution: {integrity: sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==, tarball: https://registry.npmmirror.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz}
+    resolution: {integrity: sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.9':
-    resolution: {integrity: sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==, tarball: https://registry.npmmirror.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz}
+    resolution: {integrity: sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.9':
-    resolution: {integrity: sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==, tarball: https://registry.npmmirror.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz}
+    resolution: {integrity: sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
   '@next/swc-win32-x64-msvc@16.2.9':
-    resolution: {integrity: sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==, tarball: https://registry.npmmirror.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz}
+    resolution: {integrity: sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1590,96 +1617,96 @@ packages:
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==, tarball: https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz}
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
   '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==, tarball: https://registry.npmmirror.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz}
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==, tarball: https://registry.npmmirror.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz}
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==, tarball: https://registry.npmmirror.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz}
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz}
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz}
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz}
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz}
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz}
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz}
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==, tarball: https://registry.npmmirror.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz}
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==, tarball: https://registry.npmmirror.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz}
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==, tarball: https://registry.npmmirror.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz}
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==, tarball: https://registry.npmmirror.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz}
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==, tarball: https://registry.npmmirror.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz}
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1716,65 +1743,65 @@ packages:
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
   '@tailwindcss/oxide-android-arm64@4.3.0':
-    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz}
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
   '@tailwindcss/oxide-darwin-arm64@4.3.0':
-    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz}
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
   '@tailwindcss/oxide-darwin-x64@4.3.0':
-    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz}
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
   '@tailwindcss/oxide-freebsd-x64@4.3.0':
-    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz}
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
-    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz}
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
-    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz}
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
-    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz}
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
-    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz}
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
-    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz}
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
-    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz}
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -1786,13 +1813,13 @@ packages:
       - tslib
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
-    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz}
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
   '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
-    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz}
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -1814,41 +1841,73 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
   '@turbo/darwin-64@2.9.18':
-    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==, tarball: https://registry.npmmirror.com/@turbo/darwin-64/-/darwin-64-2.9.18.tgz}
+    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
     cpu: [x64]
     os: [darwin]
 
   '@turbo/darwin-arm64@2.9.18':
-    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==, tarball: https://registry.npmmirror.com/@turbo/darwin-arm64/-/darwin-arm64-2.9.18.tgz}
+    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
     cpu: [arm64]
     os: [darwin]
 
   '@turbo/linux-64@2.9.18':
-    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==, tarball: https://registry.npmmirror.com/@turbo/linux-64/-/linux-64-2.9.18.tgz}
+    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
     cpu: [x64]
     os: [linux]
 
   '@turbo/linux-arm64@2.9.18':
-    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==, tarball: https://registry.npmmirror.com/@turbo/linux-arm64/-/linux-arm64-2.9.18.tgz}
+    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
     cpu: [arm64]
     os: [linux]
 
   '@turbo/windows-64@2.9.18':
-    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==, tarball: https://registry.npmmirror.com/@turbo/windows-64/-/windows-64-2.9.18.tgz}
+    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
     cpu: [x64]
     os: [win32]
 
   '@turbo/windows-arm64@2.9.18':
-    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==, tarball: https://registry.npmmirror.com/@turbo/windows-arm64/-/windows-arm64-2.9.18.tgz}
+    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
     cpu: [arm64]
     os: [win32]
 
   '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==, tarball: https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz}
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -1943,7 +2002,7 @@ packages:
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
   '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==, tarball: https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz}
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -2041,6 +2100,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   app-builder-lib@26.15.2:
     resolution: {integrity: sha512-3mYfKOjr/ZY7gFESOcq8kylBMgGPpmlQYnpBVit4p6zIg0t/8bkWBILdMMtnjFyN2jllyBf225T8dLlz3D6oBQ==}
     engines: {node: '>=14.0.0'}
@@ -2049,11 +2112,18 @@ packages:
       electron-builder-squirrel-windows: 26.15.2
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==, tarball: https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz}
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
@@ -2303,7 +2373,7 @@ packages:
     engines: {node: '>= 12'}
 
   commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==, tarball: https://registry.npmmirror.com/commander/-/commander-9.5.0.tgz}
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
   compare-version@0.1.2:
@@ -2362,7 +2432,7 @@ packages:
     hasBin: true
 
   cross-dirname@0.1.0:
-    resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==, tarball: https://registry.npmmirror.com/cross-dirname/-/cross-dirname-0.1.0.tgz}
+    resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2371,6 +2441,9 @@ packages:
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2535,6 +2608,12 @@ packages:
     resolution: {integrity: sha512-FwgeAKqY2vc9eVm2V2XGg8bq25B0OQjtSDITGi9zNnvu5GbtR4WvGjM5QNld/ALB6ZbsSuHskBPK9SvPpKhsbA==}
     engines: {node: '>=0.10'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
@@ -2570,7 +2649,7 @@ packages:
     hasBin: true
 
   electron-builder-squirrel-windows@26.15.2:
-    resolution: {integrity: sha512-PNl+SSRoma9mXhxycNGxutZPgvmK19v41mn8F9oecpAU2QNAldpB4HfMuA1LwFC2j8aRzzV5M9HKlKe6dfpvNw==, tarball: https://registry.npmmirror.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.2.tgz}
+    resolution: {integrity: sha512-PNl+SSRoma9mXhxycNGxutZPgvmK19v41mn8F9oecpAU2QNAldpB4HfMuA1LwFC2j8aRzzV5M9HKlKe6dfpvNw==}
 
   electron-builder@26.15.2:
     resolution: {integrity: sha512-veKM9+dCljaC5A74Pwc0ZWQ9arOHREXWh9hUIf8NGg49ch7x+IB4QhbMzIrV5ONZIXM2OEkaxW11cAPjPtoi4A==}
@@ -2584,7 +2663,7 @@ packages:
     resolution: {integrity: sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==}
 
   electron-updater@6.8.9:
-    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==, tarball: https://registry.npmmirror.com/electron-updater/-/electron-updater-6.8.9.tgz}
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron-vite@6.0.0-beta.1:
     resolution: {integrity: sha512-jltST77AwNxIeTTDtYhnIEA8ZM0RW9jmSJcqS8x/dQcgeeLlxlcJoYNNJ1tv7/Swor0AbXMYteBGdezoAOt+Nw==}
@@ -2598,7 +2677,7 @@ packages:
         optional: true
 
   electron-winstaller@5.4.0:
-    resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==, tarball: https://registry.npmmirror.com/electron-winstaller/-/electron-winstaller-5.4.0.tgz}
+    resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
   electron@39.8.10:
@@ -2836,7 +2915,7 @@ packages:
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==, tarball: https://registry.npmmirror.com/fs-extra/-/fs-extra-7.0.1.tgz}
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
 
   fs-extra@8.1.0:
@@ -2851,7 +2930,7 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -2910,7 +2989,7 @@ packages:
     deprecated: Glob versions prior to v9 are no longer supported
 
   global-agent@3.0.0:
-    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==, tarball: https://registry.npmmirror.com/global-agent/-/global-agent-3.0.0.tgz}
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
 
   globalthis@1.0.4:
@@ -3033,6 +3112,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3187,7 +3270,7 @@ packages:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==, tarball: https://registry.npmmirror.com/js-yaml/-/js-yaml-4.2.0.tgz}
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3255,71 +3338,71 @@ packages:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==, tarball: https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz}
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
   lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==, tarball: https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz}
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==, tarball: https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz}
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==, tarball: https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz}
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==, tarball: https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz}
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==, tarball: https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz}
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==, tarball: https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz}
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==, tarball: https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz}
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==, tarball: https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz}
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==, tarball: https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz}
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==, tarball: https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz}
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -3332,10 +3415,10 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   lodash.escaperegexp@4.1.2:
-    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==, tarball: https://registry.npmmirror.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz}
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
   lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==, tarball: https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz}
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
@@ -3371,6 +3454,10 @@ packages:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3580,6 +3667,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3607,7 +3698,7 @@ packages:
     engines: {node: '>= 18'}
 
   mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==, tarball: https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz}
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
   ms@2.1.3:
@@ -3732,7 +3823,7 @@ packages:
     engines: {node: '>=18'}
 
   orderedmap@2.1.1:
-    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==, tarball: https://registry.npmmirror.com/orderedmap/-/orderedmap-2.1.1.tgz}
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -3844,13 +3935,17 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
-    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==, tarball: https://registry.npmmirror.com/postject/-/postject-1.0.0-alpha.6.tgz}
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -3885,31 +3980,31 @@ packages:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   prosemirror-commands@1.7.1:
-    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==, tarball: https://registry.npmmirror.com/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz}
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
 
   prosemirror-dropcursor@1.8.2:
-    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==, tarball: https://registry.npmmirror.com/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz}
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
 
   prosemirror-history@1.5.0:
-    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==, tarball: https://registry.npmmirror.com/prosemirror-history/-/prosemirror-history-1.5.0.tgz}
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
 
   prosemirror-keymap@1.2.3:
-    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==, tarball: https://registry.npmmirror.com/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz}
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
 
   prosemirror-model@1.25.8:
-    resolution: {integrity: sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==, tarball: https://registry.npmmirror.com/prosemirror-model/-/prosemirror-model-1.25.8.tgz}
+    resolution: {integrity: sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==}
 
   prosemirror-state@1.4.4:
-    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==, tarball: https://registry.npmmirror.com/prosemirror-state/-/prosemirror-state-1.4.4.tgz}
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
 
   prosemirror-tables@1.8.5:
-    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==, tarball: https://registry.npmmirror.com/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz}
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
 
   prosemirror-transform@1.12.0:
-    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==, tarball: https://registry.npmmirror.com/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz}
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
 
   prosemirror-view@1.41.9:
-    resolution: {integrity: sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==, tarball: https://registry.npmmirror.com/prosemirror-view/-/prosemirror-view-1.41.9.tgz}
+    resolution: {integrity: sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -3961,6 +4056,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4061,6 +4159,10 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
 
@@ -4117,7 +4219,7 @@ packages:
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rimraf@2.6.3:
-    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==, tarball: https://registry.npmmirror.com/rimraf/-/rimraf-2.6.3.tgz}
+    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
@@ -4131,7 +4233,7 @@ packages:
     hasBin: true
 
   rope-sequence@1.3.4:
-    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==, tarball: https://registry.npmmirror.com/rope-sequence/-/rope-sequence-1.3.4.tgz}
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -4176,7 +4278,7 @@ packages:
     hasBin: true
 
   semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==, tarball: https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz}
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4211,7 +4313,7 @@ packages:
     hasBin: true
 
   sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==, tarball: https://registry.npmmirror.com/sharp/-/sharp-0.34.5.tgz}
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -4338,6 +4440,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -4386,7 +4492,7 @@ packages:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
   temp@0.9.4:
-    resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==, tarball: https://registry.npmmirror.com/temp/-/temp-0.9.4.tgz}
+    resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
 
   tiny-async-pool@1.3.0:
@@ -4396,7 +4502,7 @@ packages:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tiny-typed-emitter@2.1.0:
-    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==, tarball: https://registry.npmmirror.com/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz}
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4460,7 +4566,7 @@ packages:
     engines: {node: '>=6'}
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==, tarball: https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz}
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   turbo@2.9.18:
     resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
@@ -4687,7 +4793,7 @@ packages:
         optional: true
 
   w3c-keyname@2.2.8:
-    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==, tarball: https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz}
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4846,6 +4952,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -6093,6 +6201,40 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.16(@types/node@25.9.3)(jiti@2.7.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
@@ -6121,6 +6263,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -6307,6 +6451,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   app-builder-lib@26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2):
     dependencies:
       '@electron/asar': 3.4.1
@@ -6360,6 +6506,12 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   asn1js@3.0.10:
     dependencies:
@@ -6652,6 +6804,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -6789,6 +6943,10 @@ snapshots:
   docxtemplater@3.68.7:
     dependencies:
       '@xmldom/xmldom': 0.9.10
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -7468,6 +7626,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -7730,6 +7890,8 @@ snapshots:
   lucide-react@1.17.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -8147,6 +8309,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -8418,6 +8582,12 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -8554,6 +8724,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.3):
@@ -8679,6 +8851,11 @@ snapshots:
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   rehype-katex@7.0.1:
     dependencies:
@@ -9068,6 +9245,10 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   style-to-js@1.1.21:
     dependencies:


### PR DESCRIPTION
## 变更摘要
- 项目页在发送首条消息并成功创建任务后，自动跳转到对应任务详情页，避免仍停留在项目首页的新建任务视图
- `sendProjectMessage` 返回新建任务信息，并补充 `ChatInput` 相关测试
- 调整工作台发送按钮样式，使其与项目聊天输入区保持一致
- 新增 `fix-chat-stuck` 开发脚本，用于清理问答卡死时的 worker 恢复状态并重启后端

## 验证
- `pnpm exec biome check packages/app-ui/components/input/ChatInput.tsx packages/app-ui/components/layout/ProjectPage.tsx packages/app-ui/components/layout/WorkbenchPanel.tsx packages/store/slices/chatSlice.ts packages/app-ui/components/input/ChatInput.test.tsx`
- `pnpm --filter @leros/app-ui test`
- PowerShell 语法检查通过：
  - `deployments/dev/shared.ps1`
  - `deployments/dev/fix-chat-stuck.ps1`
