### PR TITLE
feat(skill): 增加内置翻译模型配置

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -11,10 +11,19 @@ type NATSConfig struct {
 
 // LLMConfig is the configuration structure for LLM providers
 type LLMConfig struct {
-	Provider string `yaml:"provider"`           // LLM Provider (openai, anthropic, etc.)
-	APIKey   string `yaml:"api_key"`            // API Key
-	Model    string `yaml:"model,omitempty"`    // Default model
-	BaseURL  string `yaml:"base_url,omitempty"` // Custom base URL
+	Provider    string                `yaml:"provider"`              // LLM Provider (openai, anthropic, etc.)
+	APIKey      string                `yaml:"api_key"`               // API Key
+	Model       string                `yaml:"model,omitempty"`       // Default model
+	BaseURL     string                `yaml:"base_url,omitempty"`    // Custom base URL
+	Translation *LLMTranslationConfig `yaml:"translation,omitempty"` // Built-in translation model
+}
+
+// LLMTranslationConfig configures the built-in fast translation model.
+type LLMTranslationConfig struct {
+	Provider string `yaml:"provider,omitempty"` // LLM Provider for translation
+	APIKey   string `yaml:"api_key,omitempty"`  // API Key for translation
+	Model    string `yaml:"model,omitempty"`    // Translation model
+	BaseURL  string `yaml:"base_url,omitempty"` // Translation base URL
 }
 
 // Config 是 Leros 的主配置结构，包含所有子系统的配置

--- a/backend/internal/infra/db/database.go
+++ b/backend/internal/infra/db/database.go
@@ -7,6 +7,7 @@ package db
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ygpkg/yg-go/dbtools"
 	"github.com/ygpkg/yg-go/encryptor/snowflake"
@@ -224,12 +225,116 @@ func InitDevData(db *gorm.DB, llmCfg *config.LLMConfig) error {
 		logs.Infof("Default LLM model created (provider=%s, model=%s)", llmCfg.Provider, modelName)
 	}
 
+	if err := seedSystemLLMModels(db, llmCfg); err != nil {
+		return err
+	}
+
 	// 初始化内置 Skill 市场条目（从 backend/skills/server/ 下的 SKILL.md 解析）
 	if err := SeedBuiltinSkillMarketplace(db); err != nil {
 		return fmt.Errorf("failed to seed builtin skill marketplace: %w", err)
 	}
 
 	return nil
+}
+
+func seedSystemLLMModels(d *gorm.DB, llmCfg *config.LLMConfig) error {
+	spec, ok := buildSystemTranslationLLMModelSpec(llmCfg)
+	if !ok {
+		logs.Warn("System translation LLM model skipped: no api_key configured")
+		return nil
+	}
+
+	var existing types.LLMModel
+	err := d.Where("org_id = ? AND code = ?", spec.OrgID, spec.Code).First(&existing).Error
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("find system translation LLM model: %w", err)
+		}
+		if err := d.Create(spec).Error; err != nil {
+			return fmt.Errorf("create system translation LLM model: %w", err)
+		}
+		logs.Infof("System translation LLM model created (provider=%s, model=%s)", spec.Provider, spec.ModelName)
+		return nil
+	}
+
+	if !existing.IsSystem {
+		logs.Warnf("System translation LLM model skipped: code %q is occupied by non-system model", spec.Code)
+		return nil
+	}
+
+	existing.Name = spec.Name
+	existing.Description = spec.Description
+	existing.Provider = spec.Provider
+	existing.ModelName = spec.ModelName
+	existing.BaseURL = spec.BaseURL
+	existing.BaseURLHasV1 = spec.BaseURLHasV1
+	existing.APIKeyEncrypted = spec.APIKeyEncrypted
+	existing.APIKeyMasked = spec.APIKeyMasked
+	existing.MaxTokens = spec.MaxTokens
+	existing.Temperature = spec.Temperature
+	existing.TimeoutSec = spec.TimeoutSec
+	existing.Status = spec.Status
+	existing.IsDefault = false
+	existing.IsSystem = true
+	existing.Config = spec.Config
+
+	if err := d.Save(&existing).Error; err != nil {
+		return fmt.Errorf("update system translation LLM model: %w", err)
+	}
+	logs.Infof("System translation LLM model updated (provider=%s, model=%s)", spec.Provider, spec.ModelName)
+	return nil
+}
+
+func buildSystemTranslationLLMModelSpec(llmCfg *config.LLMConfig) (*types.LLMModel, bool) {
+	if llmCfg == nil {
+		return nil, false
+	}
+
+	provider := strings.TrimSpace(string(types.LLMProviderDeepSeek))
+	modelName := "deepseek-flash"
+	baseURL := strings.TrimSpace(llmCfg.BaseURL)
+	apiKey := strings.TrimSpace(llmCfg.APIKey)
+
+	if llmCfg.Translation != nil {
+		if v := strings.TrimSpace(llmCfg.Translation.Provider); v != "" {
+			provider = v
+		}
+		if v := strings.TrimSpace(llmCfg.Translation.Model); v != "" {
+			modelName = v
+		}
+		if v := strings.TrimSpace(llmCfg.Translation.BaseURL); v != "" {
+			baseURL = v
+		}
+		if v := strings.TrimSpace(llmCfg.Translation.APIKey); v != "" {
+			apiKey = v
+		}
+	}
+
+	if apiKey == "" {
+		return nil, false
+	}
+
+	return &types.LLMModel{
+		OrgID:           1,
+		Code:            SystemTranslationLLMModelCode,
+		Name:            "内置翻译模型",
+		Description:     "用于 Skill 描述和文档翻译的快速系统模型",
+		Provider:        provider,
+		ModelName:       modelName,
+		BaseURL:         strings.TrimRight(baseURL, "/"),
+		BaseURLHasV1:    true,
+		APIKeyEncrypted: apiKey,
+		APIKeyMasked:    maskAPIKey(apiKey),
+		MaxTokens:       4096,
+		Temperature:     0.1,
+		TimeoutSec:      60,
+		Status:          string(types.LLMModelStatusActive),
+		IsDefault:       false,
+		IsSystem:        true,
+		Config: types.LLMModelConfig{
+			"purpose": "translation",
+		},
+	}, true
 }
 
 func seedDefaultWorkerDeployment(d *gorm.DB) error {

--- a/backend/internal/infra/db/database.go
+++ b/backend/internal/infra/db/database.go
@@ -291,7 +291,7 @@ func buildSystemTranslationLLMModelSpec(llmCfg *config.LLMConfig) (*types.LLMMod
 	}
 
 	provider := strings.TrimSpace(string(types.LLMProviderDeepSeek))
-	modelName := "deepseek-flash"
+	modelName := "deepseek-v4-flash"
 	baseURL := strings.TrimSpace(llmCfg.BaseURL)
 	apiKey := strings.TrimSpace(llmCfg.APIKey)
 

--- a/backend/internal/infra/db/llm_model_dao.go
+++ b/backend/internal/infra/db/llm_model_dao.go
@@ -12,6 +12,11 @@ import (
 	"github.com/insmtx/Leros/backend/types"
 )
 
+const (
+	// SystemTranslationLLMModelCode is the built-in LLM model code reserved for fast translation tasks.
+	SystemTranslationLLMModelCode = "llm_translation"
+)
+
 // CreateLLMModel 创建LLM模型配置
 func CreateLLMModel(ctx context.Context, db *gorm.DB, model *types.LLMModel) error {
 	baseURLHasV1 := model.BaseURLHasV1
@@ -58,6 +63,34 @@ func GetDefaultLLMModel(ctx context.Context, db *gorm.DB, orgID uint) (*types.LL
 	var entity types.LLMModel
 	err := db.WithContext(ctx).
 		Where("org_id = ? AND is_default = ? AND status = ?", orgID, true, string(types.LLMModelStatusActive)).
+		Order("updated_at DESC").
+		First(&entity).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &entity, nil
+}
+
+// GetSystemTranslationLLMModel 获取系统内置翻译模型配置。
+func GetSystemTranslationLLMModel(ctx context.Context, db *gorm.DB, orgID uint) (*types.LLMModel, error) {
+	model, err := getSystemTranslationLLMModelByOrg(ctx, db, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if model != nil || orgID == 1 {
+		return model, nil
+	}
+	return getSystemTranslationLLMModelByOrg(ctx, db, 1)
+}
+
+func getSystemTranslationLLMModelByOrg(ctx context.Context, db *gorm.DB, orgID uint) (*types.LLMModel, error) {
+	var entity types.LLMModel
+	err := db.WithContext(ctx).
+		Where("org_id = ? AND code = ? AND is_system = ? AND status = ?",
+			orgID, SystemTranslationLLMModelCode, true, string(types.LLMModelStatusActive)).
 		Order("updated_at DESC").
 		First(&entity).Error
 	if err != nil {

--- a/backend/internal/infra/db/llm_model_dao_test.go
+++ b/backend/internal/infra/db/llm_model_dao_test.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
+	"github.com/insmtx/Leros/backend/config"
 	"github.com/insmtx/Leros/backend/types"
 )
 
@@ -187,6 +188,154 @@ func TestGetDefaultLLMModel(t *testing.T) {
 	}
 	if missing != nil {
 		t.Fatalf("expected nil for inactive default model, got %#v", missing)
+	}
+}
+
+func TestGetSystemTranslationLLMModel(t *testing.T) {
+	database := setupLLMModelTestDB(t)
+	ctx := context.Background()
+
+	fallback := newTestLLMModel(1, SystemTranslationLLMModelCode)
+	fallback.IsSystem = true
+	fallback.Provider = string(types.LLMProviderDeepSeek)
+	fallback.ModelName = "deepseek-flash"
+
+	orgModel := newTestLLMModel(2, SystemTranslationLLMModelCode)
+	orgModel.IsSystem = true
+	orgModel.Provider = string(types.LLMProviderDeepSeek)
+	orgModel.ModelName = "deepseek-flash"
+
+	nonSystem := newTestLLMModel(3, SystemTranslationLLMModelCode)
+	inactive := newTestLLMModel(4, SystemTranslationLLMModelCode)
+	inactive.IsSystem = true
+	inactive.Status = string(types.LLMModelStatusInactive)
+
+	for _, model := range []*types.LLMModel{fallback, orgModel, nonSystem, inactive} {
+		if err := CreateLLMModel(ctx, database, model); err != nil {
+			t.Fatalf("CreateLLMModel failed: %v", err)
+		}
+	}
+
+	retrieved, err := GetSystemTranslationLLMModel(ctx, database, 2)
+	if err != nil {
+		t.Fatalf("GetSystemTranslationLLMModel failed: %v", err)
+	}
+	if retrieved == nil || retrieved.OrgID != 2 || retrieved.ModelName != "deepseek-flash" {
+		t.Fatalf("unexpected org translation model: %#v", retrieved)
+	}
+
+	retrieved, err = GetSystemTranslationLLMModel(ctx, database, 3)
+	if err != nil {
+		t.Fatalf("GetSystemTranslationLLMModel fallback failed: %v", err)
+	}
+	if retrieved == nil || retrieved.OrgID != 1 {
+		t.Fatalf("expected fallback system translation model, got %#v", retrieved)
+	}
+
+	missing, err := GetSystemTranslationLLMModel(ctx, database, 4)
+	if err != nil {
+		t.Fatalf("GetSystemTranslationLLMModel inactive fallback failed: %v", err)
+	}
+	if missing == nil || missing.OrgID != 1 {
+		t.Fatalf("expected fallback for inactive org model, got %#v", missing)
+	}
+}
+
+func TestSeedSystemLLMModelsCreatesTranslationModel(t *testing.T) {
+	database := setupLLMModelTestDB(t)
+
+	err := seedSystemLLMModels(database, &config.LLMConfig{
+		APIKey:  "main-key",
+		BaseURL: "https://gateway.example.com/v1/",
+		Translation: &config.LLMTranslationConfig{
+			Provider: string(types.LLMProviderDeepSeek),
+			APIKey:   "translation-key",
+			Model:    "deepseek-flash",
+			BaseURL:  "https://api.deepseek.com/v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seedSystemLLMModels failed: %v", err)
+	}
+
+	model, err := GetSystemTranslationLLMModel(context.Background(), database, 1)
+	if err != nil {
+		t.Fatalf("GetSystemTranslationLLMModel failed: %v", err)
+	}
+	if model == nil {
+		t.Fatal("expected system translation model")
+	}
+	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-flash" {
+		t.Fatalf("unexpected translation model: %#v", model)
+	}
+	if model.APIKeyEncrypted != "translation-key" || model.IsDefault || !model.IsSystem {
+		t.Fatalf("unexpected translation model flags/key: %#v", model)
+	}
+}
+
+func TestSeedSystemLLMModelsUpdatesSystemTranslationModel(t *testing.T) {
+	database := setupLLMModelTestDB(t)
+
+	existing := newTestLLMModel(1, SystemTranslationLLMModelCode)
+	existing.IsSystem = true
+	existing.Provider = string(types.LLMProviderOpenAI)
+	existing.ModelName = "old-model"
+	existing.APIKeyEncrypted = "old-key"
+	if err := CreateLLMModel(context.Background(), database, existing); err != nil {
+		t.Fatalf("CreateLLMModel failed: %v", err)
+	}
+
+	err := seedSystemLLMModels(database, &config.LLMConfig{
+		APIKey: "main-key",
+		Translation: &config.LLMTranslationConfig{
+			Provider: string(types.LLMProviderDeepSeek),
+			APIKey:   "new-key",
+			Model:    "deepseek-flash",
+			BaseURL:  "https://api.deepseek.com/v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seedSystemLLMModels failed: %v", err)
+	}
+
+	model, err := GetLLMModelByCode(context.Background(), database, 1, SystemTranslationLLMModelCode)
+	if err != nil {
+		t.Fatalf("GetLLMModelByCode failed: %v", err)
+	}
+	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-flash" || model.APIKeyEncrypted != "new-key" {
+		t.Fatalf("expected system model to be updated, got %#v", model)
+	}
+}
+
+func TestSeedSystemLLMModelsDoesNotOverwriteNonSystemModel(t *testing.T) {
+	database := setupLLMModelTestDB(t)
+
+	existing := newTestLLMModel(1, SystemTranslationLLMModelCode)
+	existing.IsSystem = false
+	existing.Provider = string(types.LLMProviderOpenAI)
+	existing.ModelName = "user-model"
+	if err := CreateLLMModel(context.Background(), database, existing); err != nil {
+		t.Fatalf("CreateLLMModel failed: %v", err)
+	}
+
+	err := seedSystemLLMModels(database, &config.LLMConfig{
+		APIKey: "main-key",
+		Translation: &config.LLMTranslationConfig{
+			Provider: string(types.LLMProviderDeepSeek),
+			APIKey:   "translation-key",
+			Model:    "deepseek-flash",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seedSystemLLMModels failed: %v", err)
+	}
+
+	model, err := GetLLMModelByCode(context.Background(), database, 1, SystemTranslationLLMModelCode)
+	if err != nil {
+		t.Fatalf("GetLLMModelByCode failed: %v", err)
+	}
+	if model.IsSystem || model.ModelName != "user-model" {
+		t.Fatalf("expected non-system model to remain unchanged, got %#v", model)
 	}
 }
 

--- a/backend/internal/infra/db/llm_model_dao_test.go
+++ b/backend/internal/infra/db/llm_model_dao_test.go
@@ -198,12 +198,12 @@ func TestGetSystemTranslationLLMModel(t *testing.T) {
 	fallback := newTestLLMModel(1, SystemTranslationLLMModelCode)
 	fallback.IsSystem = true
 	fallback.Provider = string(types.LLMProviderDeepSeek)
-	fallback.ModelName = "deepseek-flash"
+	fallback.ModelName = "deepseek-v4-flash"
 
 	orgModel := newTestLLMModel(2, SystemTranslationLLMModelCode)
 	orgModel.IsSystem = true
 	orgModel.Provider = string(types.LLMProviderDeepSeek)
-	orgModel.ModelName = "deepseek-flash"
+	orgModel.ModelName = "deepseek-v4-flash"
 
 	nonSystem := newTestLLMModel(3, SystemTranslationLLMModelCode)
 	inactive := newTestLLMModel(4, SystemTranslationLLMModelCode)
@@ -220,7 +220,7 @@ func TestGetSystemTranslationLLMModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSystemTranslationLLMModel failed: %v", err)
 	}
-	if retrieved == nil || retrieved.OrgID != 2 || retrieved.ModelName != "deepseek-flash" {
+	if retrieved == nil || retrieved.OrgID != 2 || retrieved.ModelName != "deepseek-v4-flash" {
 		t.Fatalf("unexpected org translation model: %#v", retrieved)
 	}
 
@@ -250,7 +250,7 @@ func TestSeedSystemLLMModelsCreatesTranslationModel(t *testing.T) {
 		Translation: &config.LLMTranslationConfig{
 			Provider: string(types.LLMProviderDeepSeek),
 			APIKey:   "translation-key",
-			Model:    "deepseek-flash",
+			Model:    "deepseek-v4-flash",
 			BaseURL:  "https://api.deepseek.com/v1",
 		},
 	})
@@ -265,7 +265,7 @@ func TestSeedSystemLLMModelsCreatesTranslationModel(t *testing.T) {
 	if model == nil {
 		t.Fatal("expected system translation model")
 	}
-	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-flash" {
+	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-v4-flash" {
 		t.Fatalf("unexpected translation model: %#v", model)
 	}
 	if model.APIKeyEncrypted != "translation-key" || model.IsDefault || !model.IsSystem {
@@ -290,7 +290,7 @@ func TestSeedSystemLLMModelsUpdatesSystemTranslationModel(t *testing.T) {
 		Translation: &config.LLMTranslationConfig{
 			Provider: string(types.LLMProviderDeepSeek),
 			APIKey:   "new-key",
-			Model:    "deepseek-flash",
+			Model:    "deepseek-v4-flash",
 			BaseURL:  "https://api.deepseek.com/v1",
 		},
 	})
@@ -302,7 +302,7 @@ func TestSeedSystemLLMModelsUpdatesSystemTranslationModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLLMModelByCode failed: %v", err)
 	}
-	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-flash" || model.APIKeyEncrypted != "new-key" {
+	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-v4-flash" || model.APIKeyEncrypted != "new-key" {
 		t.Fatalf("expected system model to be updated, got %#v", model)
 	}
 }
@@ -323,7 +323,7 @@ func TestSeedSystemLLMModelsDoesNotOverwriteNonSystemModel(t *testing.T) {
 		Translation: &config.LLMTranslationConfig{
 			Provider: string(types.LLMProviderDeepSeek),
 			APIKey:   "translation-key",
-			Model:    "deepseek-flash",
+			Model:    "deepseek-v4-flash",
 		},
 	})
 	if err != nil {

--- a/backend/internal/service/default_skill_description_translator.go
+++ b/backend/internal/service/default_skill_description_translator.go
@@ -60,13 +60,13 @@ func (t *defaultSkillDescriptionTranslator) Translate(ctx context.Context, items
 		return map[string]string{}, nil
 	}
 
-	model, err := infradb.GetDefaultLLMModel(ctx, t.db, caller.OrgID)
+	model, err := infradb.GetSystemTranslationLLMModel(ctx, t.db, caller.OrgID)
 	if err != nil {
-		logs.WarnContextf(ctx, "skill translator: get default LLM model: %v", err)
+		logs.WarnContextf(ctx, "skill translator: get system translation LLM model: %v", err)
 		return map[string]string{}, nil
 	}
 	if model == nil {
-		logs.WarnContextf(ctx, "skill translator: no default LLM model for org %d", caller.OrgID)
+		logs.WarnContextf(ctx, "skill translator: no system translation LLM model for org %d", caller.OrgID)
 		return map[string]string{}, nil
 	}
 
@@ -222,13 +222,13 @@ func (t *defaultSkillDescriptionTranslator) TranslateDocument(ctx context.Contex
 		return map[string]string{}, nil
 	}
 
-	model, err := infradb.GetDefaultLLMModel(ctx, t.db, caller.OrgID)
+	model, err := infradb.GetSystemTranslationLLMModel(ctx, t.db, caller.OrgID)
 	if err != nil {
-		logs.WarnContextf(ctx, "skill translator: get default LLM model: %v", err)
+		logs.WarnContextf(ctx, "skill translator: get system translation LLM model: %v", err)
 		return map[string]string{}, nil
 	}
 	if model == nil {
-		logs.WarnContextf(ctx, "skill translator: no default LLM model for org %d", caller.OrgID)
+		logs.WarnContextf(ctx, "skill translator: no system translation LLM model for org %d", caller.OrgID)
 		return map[string]string{}, nil
 	}
 

--- a/deployments/dev/server.config.example.yaml
+++ b/deployments/dev/server.config.example.yaml
@@ -21,3 +21,9 @@ llm:
   api_key: "${LLM_API_KEY}"
   model: "qwen3.6-plus"
   base_url: "https://api.yygu.cn/v3/llm.chat/"
+
+  translation:
+    provider: "deepseek"
+    api_key: "${LLM_API_KEY}"
+    model: "deepseek-v4-flash"
+    base_url: "https://api.yygu.cn/v3/llm.chat/"


### PR DESCRIPTION
## 背景

Skill 市场的描述和 SKILL.md 翻译此前复用组织默认 LLM 模型。翻译场景对模型能力要求不高，更关注速度和成本，因此需要独立的系统内置翻译模型，避免占用或依赖用户默认模型。

## 修改内容

- 新增系统翻译模型 code：`llm_translation`
- 新增 `GetSystemTranslationLLMModel`，用于查询系统内置翻译模型
  - 当前组织优先
  - 仅使用 `is_system=true` 且 `status=active` 的模型
- `default_skill_description_translator` 改为使用系统翻译模型，不再调用 `GetDefaultLLMModel`
- 新增 `llm.translation` 配置结构
- DB 初始化时幂等 seed 内置翻译模型
  - 不依赖 LLM 表是否为空
  - 已存在系统模型则更新
  - 遇到同 code 的非系统模型时跳过，避免覆盖用户数据
- 更新开发环境配置示例
- 补充 DAO 和初始化逻辑测试

## 验证

- `go test ./backend/config ./backend/internal/infra/db`
- `go test ./backend/internal/service -run '^$'`
- `git diff --check`