### PR TITLE
fix(frontend): 优化左侧列表展示并隐藏页面滚动条

### DIFF
--- a/frontend/packages/app-ui/components/chat/MessageTimeline.tsx
+++ b/frontend/packages/app-ui/components/chat/MessageTimeline.tsx
@@ -109,7 +109,7 @@ export function MessageTimeline({
 
 				autoFollowRef.current = distanceToBottom <= 120;
 			}}
-			className={cn("min-h-0 flex-1 overflow-y-auto", className)}
+			className={cn("no-scrollbar min-h-0 flex-1 overflow-y-auto", className)}
 		>
 			{isEmpty ? (
 				(emptyState ?? <WelcomeScreen />)

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -54,6 +54,7 @@ import { toast } from "sonner";
 import { APP_LOGO_SRC } from "../../assets";
 import { useAuth } from "../auth";
 import { DiceBearAvatar } from "../avatar/DiceBearAvatar";
+import { getVisibleLeftRailItems } from "./left-rail-list-utils";
 
 const LEFT_RAIL_WIDTH_STORAGE_KEY = "leros-left-rail-width";
 const LEFT_RAIL_COLLAPSED_STORAGE_KEY = "leros-left-rail-collapsed";
@@ -121,6 +122,8 @@ export function LeftRail({
 	const [renameValue, setRenameValue] = useState("");
 	const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
 	const [accountDialogOpen, setAccountDialogOpen] = useState(false);
+	const [projectsExpanded, setProjectsExpanded] = useState(false);
+	const [aiTeammatesExpanded, setAiTeammatesExpanded] = useState(false);
 
 	/* ── Desktop update notifier ── */
 	const [promptOpen, setPromptOpen] = useState(false);
@@ -413,7 +416,7 @@ export function LeftRail({
 				</button>
 			</div>
 
-			<ScrollArea className="min-h-0 flex-1 overflow-hidden">
+			<ScrollArea hideScrollbar className="min-h-0 flex-1 overflow-hidden">
 				<nav className="leros-nav" aria-label="主导航">
 					{navGroups.map((group) => {
 						return (
@@ -429,6 +432,17 @@ export function LeftRail({
 										onRenameProject={handleOpenRename}
 										onDeleteProject={setDeleteTarget}
 										collapsed={leftRailCollapsed}
+										expanded={projectsExpanded}
+										onExpand={() => setProjectsExpanded(true)}
+									/>
+								) : group.id === "ai-teammates" ? (
+									<NavItemList
+										items={group.items}
+										collapsed={leftRailCollapsed}
+										expanded={aiTeammatesExpanded}
+										onExpand={() => setAiTeammatesExpanded(true)}
+										isItemActive={isItemActive}
+										onItemClick={handleNavClick}
 									/>
 								) : (
 									<div className="space-y-1">
@@ -1191,6 +1205,8 @@ function ProjectList({
 	onRenameProject,
 	onDeleteProject,
 	collapsed,
+	expanded,
+	onExpand,
 }: {
 	projects: Project[];
 	activeProjectId: string | null;
@@ -1200,10 +1216,14 @@ function ProjectList({
 	onRenameProject: (project: Project) => void;
 	onDeleteProject: (project: Project) => void;
 	collapsed: boolean;
+	expanded: boolean;
+	onExpand: () => void;
 }) {
+	const { visibleItems, showExpandTrigger } = getVisibleLeftRailItems(projects, expanded);
+
 	return (
 		<div className="space-y-1">
-			{projects.map((project) => {
+			{visibleItems.map((project) => {
 				const active = currentPath
 					? currentPath === `/projects/${project.id}` ||
 						currentPath.startsWith(`/projects/${project.id}/`)
@@ -1261,7 +1281,58 @@ function ProjectList({
 					</div>
 				);
 			})}
+			{showExpandTrigger ? <ExpandMoreButton collapsed={collapsed} onClick={onExpand} /> : null}
 		</div>
+	);
+}
+
+function NavItemList({
+	items,
+	collapsed,
+	expanded,
+	onExpand,
+	isItemActive,
+	onItemClick,
+}: {
+	items: NavItem[];
+	collapsed: boolean;
+	expanded: boolean;
+	onExpand: () => void;
+	isItemActive: (item: NavItem) => boolean;
+	onItemClick: (item: NavItem) => void;
+}) {
+	const { visibleItems, showExpandTrigger } = getVisibleLeftRailItems(items, expanded);
+
+	return (
+		<div className="space-y-1">
+			{visibleItems.map((item) => (
+				<NavItemButton
+					key={item.id}
+					item={item}
+					active={isItemActive(item)}
+					collapsed={collapsed}
+					onClick={() => onItemClick(item)}
+				/>
+			))}
+			{showExpandTrigger ? <ExpandMoreButton collapsed={collapsed} onClick={onExpand} /> : null}
+		</div>
+	);
+}
+
+function ExpandMoreButton({ collapsed, onClick }: { collapsed: boolean; onClick: () => void }) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"leros-nav-item text-[var(--leros-text-subtle)] transition-colors hover:text-[var(--leros-text-strong)]",
+				collapsed && "justify-center",
+			)}
+			title={collapsed ? "展开更多" : undefined}
+		>
+			<span className="font-mono text-[16px] leading-none">...</span>
+			<span className={cn("min-w-0 flex-1 truncate", collapsed && "hidden")}>展开更多</span>
+		</button>
 	);
 }
 

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -522,7 +522,7 @@ export function ProjectPage({
 						className="relative flex shrink-0 flex-col border-l border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] transition-[width] duration-200 ease-out"
 						style={rightSidebarWidthStyle}
 					>
-						<div className="min-h-0 flex-1 space-y-8 overflow-y-auto px-5 py-6 pr-4">
+						<div className="no-scrollbar min-h-0 flex-1 space-y-8 overflow-y-auto px-5 py-6 pr-4">
 							<div className="flex items-start justify-between gap-3">
 								<div>
 									<p className="text-sm font-semibold text-[var(--leros-text-strong)]">项目侧栏</p>

--- a/frontend/packages/app-ui/components/layout/RightRail.tsx
+++ b/frontend/packages/app-ui/components/layout/RightRail.tsx
@@ -91,7 +91,7 @@ export function RightRail() {
 				))}
 			</div>
 
-			<ScrollArea className="flex-1">
+			<ScrollArea hideScrollbar className="flex-1">
 				<div className="p-3">
 					{activeRightTab === "shortcuts" && (
 						<div className="space-y-2">

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -416,7 +416,7 @@ export function TaskDetailPage({
 						className="relative flex shrink-0 flex-col border-l border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-5 py-6 transition-[width] duration-200 ease-out"
 						style={rightSidebarWidthStyle}
 					>
-						<div className="min-h-0 flex-1 space-y-8 overflow-y-auto pr-1">
+						<div className="no-scrollbar min-h-0 flex-1 space-y-8 overflow-y-auto pr-1">
 							<div className="flex items-start justify-between gap-3">
 								<div>
 									<p className="text-sm font-semibold text-[var(--leros-text-strong)]">任务侧栏</p>

--- a/frontend/packages/app-ui/components/layout/left-rail-list-utils.test.ts
+++ b/frontend/packages/app-ui/components/layout/left-rail-list-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getVisibleLeftRailItems, LEFT_RAIL_LIST_PREVIEW_LIMIT } from "./left-rail-list-utils";
+
+describe("getVisibleLeftRailItems", () => {
+	it("未展开时最多只返回前六项，并显示展开入口", () => {
+		const items = Array.from({ length: 8 }, (_, index) => `item-${index + 1}`);
+
+		const result = getVisibleLeftRailItems(items, false);
+
+		expect(result.visibleItems).toEqual(items.slice(0, LEFT_RAIL_LIST_PREVIEW_LIMIT));
+		expect(result.showExpandTrigger).toBe(true);
+	});
+
+	it("数量不超过六项时保持原样且不显示展开入口", () => {
+		const items = Array.from(
+			{ length: LEFT_RAIL_LIST_PREVIEW_LIMIT },
+			(_, index) => `item-${index + 1}`,
+		);
+
+		const result = getVisibleLeftRailItems(items, false);
+
+		expect(result.visibleItems).toEqual(items);
+		expect(result.showExpandTrigger).toBe(false);
+	});
+
+	it("展开后返回完整列表且隐藏展开入口", () => {
+		const items = Array.from({ length: 9 }, (_, index) => `item-${index + 1}`);
+
+		const result = getVisibleLeftRailItems(items, true);
+
+		expect(result.visibleItems).toEqual(items);
+		expect(result.showExpandTrigger).toBe(false);
+	});
+});

--- a/frontend/packages/app-ui/components/layout/left-rail-list-utils.ts
+++ b/frontend/packages/app-ui/components/layout/left-rail-list-utils.ts
@@ -1,0 +1,17 @@
+export const LEFT_RAIL_LIST_PREVIEW_LIMIT = 6;
+
+export function getVisibleLeftRailItems<T>(
+	items: T[],
+	expanded: boolean,
+	limit = LEFT_RAIL_LIST_PREVIEW_LIMIT,
+) {
+	const normalizedLimit = Math.max(0, limit);
+
+	// 中文注释：侧栏默认只预览前 N 条，展开后再一次性返回完整列表。
+	const visibleItems = expanded ? items : items.slice(0, normalizedLimit);
+
+	return {
+		visibleItems,
+		showExpandTrigger: !expanded && items.length > normalizedLimit,
+	};
+}

--- a/frontend/packages/ui/components/ui/scroll-area.tsx
+++ b/frontend/packages/ui/components/ui/scroll-area.tsx
@@ -4,7 +4,11 @@ import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 
 import { cn } from "@leros/ui/lib/utils";
 
-function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.Props) {
+type ScrollAreaProps = ScrollAreaPrimitive.Root.Props & {
+	hideScrollbar?: boolean;
+};
+
+function ScrollArea({ className, children, hideScrollbar = false, ...props }: ScrollAreaProps) {
 	return (
 		<ScrollAreaPrimitive.Root
 			data-slot="scroll-area"
@@ -13,11 +17,15 @@ function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.
 		>
 			<ScrollAreaPrimitive.Viewport
 				data-slot="scroll-area-viewport"
-				className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+				className={cn(
+					"focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1",
+					hideScrollbar && "no-scrollbar",
+				)}
 			>
 				{children}
 			</ScrollAreaPrimitive.Viewport>
-			<ScrollBar />
+			{/* 中文注释：某些侧栏只需要滚动能力，不需要额外渲染可视滚动条。 */}
+			{hideScrollbar ? null : <ScrollBar />}
 			<ScrollAreaPrimitive.Corner />
 		</ScrollAreaPrimitive.Root>
 	);

--- a/frontend/packages/ui/styles/base.css
+++ b/frontend/packages/ui/styles/base.css
@@ -28,3 +28,16 @@
 		@apply font-sans;
 	}
 }
+
+@layer utilities {
+	.no-scrollbar {
+		-ms-overflow-style: none;
+		scrollbar-width: none;
+	}
+
+	.no-scrollbar::-webkit-scrollbar {
+		display: none;
+		width: 0;
+		height: 0;
+	}
+}


### PR DESCRIPTION
## Summary
- 左侧 `项目` 与 `AI 队友` 列表默认最多展示 6 条，超出时展示 `... 展开更多`，点击后展开完整列表
- 为 `ScrollArea` 增加 `hideScrollbar` 开关，并统一隐藏左侧栏、右侧侧栏、任务/项目侧栏与问答记录区的可视滚动条，仅保留滚动能力
- 补充 `left-rail-list-utils` 及对应测试，收敛列表预览/展开逻辑

## Root Cause
- 左侧列表此前是全量渲染，项目和 AI 队友数量增多时会明显拉长侧栏
- 多处滚动区域分别使用 `ScrollArea` 或 `overflow-y-auto`，默认都会暴露可视滚动条，和当前 UI 期望不一致

## Validation
- `pnpm --filter @leros/app-ui test -- left-rail-list-utils.test.ts`
- `pnpm exec biome check packages/ui/styles/base.css packages/ui/components/ui/scroll-area.tsx packages/app-ui/components/chat/MessageTimeline.tsx packages/app-ui/components/layout/LeftRail.tsx packages/app-ui/components/layout/ProjectPage.tsx packages/app-ui/components/layout/RightRail.tsx packages/app-ui/components/layout/TaskDetailPage.tsx packages/app-ui/components/layout/left-rail-list-utils.ts packages/app-ui/components/layout/left-rail-list-utils.test.ts`