### PR TITLE
fix(frontend): 修复本地 web 开发接口跨域问题

### DIFF
--- a/deployments/dev/run-frontend-dev.ps1
+++ b/deployments/dev/run-frontend-dev.ps1
@@ -7,9 +7,11 @@ $runtimeState = Get-ConfiguredDevRuntimeState
 $frontendWebRoot = Join-Path $root 'frontend\apps\web'
 $envFilePath = Join-Path $frontendWebRoot '.env.local'
 
-$env:NEXT_PUBLIC_LEROS_API_BASE_URL = "$($runtimeState.apiBaseUrl)"
-Set-Content -Path $envFilePath -Value "NEXT_PUBLIC_LEROS_API_BASE_URL=$($runtimeState.apiBaseUrl)" -Encoding UTF8
+$webApiBaseUrl = '/v1'
+$env:NEXT_PUBLIC_LEROS_API_BASE_URL = $webApiBaseUrl
+# 中文注释：Web 本地开发走 Next 同源代理，避免浏览器直接跨端口请求本地后端时出现跨域问题。
+Set-Content -Path $envFilePath -Value "NEXT_PUBLIC_LEROS_API_BASE_URL=$webApiBaseUrl" -Encoding UTF8
 
 Set-Location "$root\frontend"
-Write-Host "[Leros][Frontend] Starting on http://localhost:3005 (API: $($runtimeState.apiBaseUrl))" -ForegroundColor Cyan
+Write-Host "[Leros][Frontend] Starting on http://localhost:3005 (API Proxy: $webApiBaseUrl -> $($runtimeState.apiBaseUrl))" -ForegroundColor Cyan
 & $pnpmExe run dev:web

--- a/frontend/apps/web/next.config.ts
+++ b/frontend/apps/web/next.config.ts
@@ -3,6 +3,15 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
 	transpilePackages: ["@leros/ui", "@leros/store", "@leros/app-ui"],
 	allowedDevOrigins: ["172.16.0.160", "*", "*.*.*.*", "192.144.198.60"],
+	async rewrites() {
+		// 中文注释：本地 Web 开发统一走同源 /v1，再由 Next dev 反代到本地后端，避免浏览器跨域干扰调试。
+		return [
+			{
+				source: "/v1/:path*",
+				destination: "http://localhost:18080/v1/:path*",
+			},
+		];
+	},
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 变更内容

- 为 `frontend/apps/web` 增加本地开发用 `/v1` 同源代理，请求转发到 `http://localhost:18080/v1`
- 调整 `deployments/dev/run-frontend-dev.ps1`，本地启动前端时写入同源 API 基址 `/v1`
- 保持后端端口和接口实现不变，仅修复本地 Web 开发时浏览器跨域导致的 `Failed to fetch`

## 变更原因

本地开发环境中，浏览器直接从 `http://localhost:3005` 跨端口访问 `http://localhost:18080/v1` 时，后端虽然已成功处理请求，但浏览器侧仍会将响应判定为跨域失败，导致登录验证码和项目列表请求报 `CORS` / `Failed to fetch`。

这次改为通过 Next dev 同源代理转发本地 API 请求，绕开浏览器跨域校验，保证本地开发链路稳定。

## 影响范围

- 仅影响本地 Web 开发链路
- 不修改后端业务接口
- 不影响线上后端行为
- `.env.local` 仍为本地文件，不纳入版本控制

## 验证

- `pnpm exec biome check apps/web/next.config.ts`
- 本地确认后端已收到并成功处理 `SendPhoneLoginCode`
- 本地开发链路改为同源 `/v1` 代理