### PR TITLE
fix(chat): 默认收起 AI 执行过程面板

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.test.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AIMessageBubble } from "./AIMessageBubble";
+
+vi.mock("@leros/store", () => ({
+	formatArtifactTime: () => "",
+	formatTime: () => "10:00",
+	getAssistantMessageFooterSegments: () => [],
+	mapBackendArtifactToProjectArtifact: vi.fn(),
+	mergeProjectArtifacts: vi.fn(),
+	messageArtifactToProjectArtifact: vi.fn(),
+	useChatStore: (selector: (state: Record<string, unknown>) => unknown) =>
+		selector({
+			resendMessage: vi.fn(),
+		}),
+	useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) =>
+		selector({
+			activeTaskDetailTaskId: null,
+		}),
+}));
+
+vi.mock("@leros/store/api/artifactApi", () => ({
+	artifactApi: {
+		listTaskArtifacts: vi.fn(),
+	},
+}));
+
+vi.mock("../common/MarkdownRenderer", () => ({
+	MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock("../layout/ArtifactPreviewDialog", () => ({
+	ArtifactPreviewDialog: () => null,
+}));
+
+vi.mock("../layout/project-file-type-icon", () => ({
+	ProjectFileTypeIcon: () => null,
+}));
+
+vi.mock("./AssistantChatAvatar", () => ({
+	AssistantChatAvatar: () => <div>avatar</div>,
+}));
+
+describe("AIMessageBubble", () => {
+	it("执行过程默认收起，且流式状态变化不会覆盖用户手动展开", async () => {
+		const user = userEvent.setup();
+		const message = {
+			id: "message-1",
+			conversationId: "conversation-1",
+			role: "assistant" as const,
+			content: "",
+			timestamp: Date.now(),
+			processSteps: [
+				{
+					id: "step-1",
+					type: "thinking" as const,
+					content: "正在分析问题",
+				},
+			],
+			toolCalls: [],
+		};
+
+		const { rerender } = render(<AIMessageBubble message={message} isStreaming={true} />);
+
+		expect(screen.getByRole("button", { name: /执行过程/i })).toBeInTheDocument();
+		expect(screen.queryByText("正在分析问题", { selector: "div" })).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: /执行过程/i }));
+
+		expect(screen.getByText("正在分析问题", { selector: "div" })).toBeInTheDocument();
+
+		rerender(<AIMessageBubble message={message} isStreaming={false} />);
+
+		expect(screen.getByText("正在分析问题", { selector: "div" })).toBeInTheDocument();
+	});
+});

--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -167,7 +167,8 @@ function ProcessTimelineBlock({
 	toolCalls: ToolCall[];
 	isStreaming: boolean;
 }) {
-	const [expanded, setExpanded] = useState(isStreaming);
+	// 中文注释：执行过程默认收起，后续只尊重用户手动展开/收起，不再被流式状态强制覆盖。
+	const [expanded, setExpanded] = useState(false);
 	const [autoFollow, setAutoFollow] = useState(true);
 	const [showBottomFade, setShowBottomFade] = useState(false);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -187,10 +188,6 @@ function ProcessTimelineBlock({
 		}
 		return "";
 	}, [steps, toolCallMap]);
-
-	useEffect(() => {
-		setExpanded(isStreaming);
-	}, [isStreaming]);
 
 	useEffect(() => {
 		const container = scrollContainerRef.current;


### PR DESCRIPTION
## 变更内容
- 将 AI 回复里的“执行过程”面板改为默认收起
- 移除流式回复期间根据 `isStreaming` 强制同步展开状态的逻辑
- 新增回归测试，覆盖默认收起以及用户手动展开后不再被流式状态覆盖

## 修改原因
- 现在的交互会在 AI 回复时默认展开执行过程，占用聊天区域空间
- 用户希望默认收起，但仍然可以按需手动展开查看

## 根因
- `ProcessTimelineBlock` 既用 `isStreaming` 作为初始展开值，又在 `useEffect` 里持续根据 `isStreaming` 覆盖展开态
- 这导致流式过程中组件会被程序强制展开，而不是只尊重用户操作

## 验证
- `pnpm --filter @leros/app-ui test -- AIMessageBubble.test.tsx`
- `pnpm exec biome check packages/app-ui/components/chat/AIMessageBubble.tsx packages/app-ui/components/chat/AIMessageBubble.test.tsx`

## 影响
- AI 聊天回复默认更紧凑
- 需要查看执行过程时，用户仍可手动展开