### PR TITLE
fix(gitea): 重命名配置字段并用 CreateRepo 替代 AdminCreateRepo

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -120,7 +120,7 @@ func (s *StorageConfig) GetStaticAPIKey() string {
 
 // GiteaConfig 外部 gitea 实例连接配置
 type GiteaConfig struct {
-	Endpoint     string `yaml:"endpoint"`
-	AdminToken   string `yaml:"admin_token"`
-	DefaultOwner string `yaml:"default_owner"`
+	Endpoint    string `yaml:"endpoint"`
+	AccessToken string `yaml:"access_token"`
+	Owner       string `yaml:"owner"`
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -46,7 +46,7 @@ func SetupRouter(cfg config.Config, eventbus eventbus.EventBus, db *gorm.DB) *gi
 	var giteaClient *gitea.Client
 	if cfg.Gitea != nil {
 		var err error
-		giteaClient, err = gitea.NewClient(cfg.Gitea.Endpoint, gitea.SetToken(cfg.Gitea.AdminToken))
+		giteaClient, err = gitea.NewClient(cfg.Gitea.Endpoint, gitea.SetToken(cfg.Gitea.AccessToken))
 		if err != nil {
 			logs.Errorf("create gitea client: %v", err)
 			giteaClient = nil

--- a/backend/internal/service/message_poster.go
+++ b/backend/internal/service/message_poster.go
@@ -216,7 +216,7 @@ func (o *newMessageOrchestrator) resolveOrCreateProject() error {
 	}
 
 	repoName := o.poster.buildRepoName(o.caller.OrgID, projectID)
-	repoInfo, _, err := o.poster.giteaClient.AdminCreateRepo(o.poster.giteaCfg.DefaultOwner, gitea.CreateRepoOption{
+	repoInfo, _, err := o.poster.giteaClient.CreateRepo(gitea.CreateRepoOption{
 		Name:        repoName,
 		Description: "",
 		Private:     true,

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -118,7 +118,7 @@ func (s *projectService) CreateProject(ctx context.Context, req *contract.Create
 	project.GiteaDefaultBranch = "main"
 
 	repoName := s.buildRepoName(caller.OrgID, publicID)
-	repoInfo, _, err := s.giteaClient.AdminCreateRepo(s.giteaCfg.DefaultOwner, gitea.CreateRepoOption{
+	repoInfo, _, err := s.giteaClient.CreateRepo(gitea.CreateRepoOption{
 		Name:        repoName,
 		Description: strings.TrimSpace(req.Description),
 		Private:     true,
@@ -623,7 +623,7 @@ func (s *projectService) DownloadProjectFile(ctx context.Context, publicID strin
 	if err != nil {
 		return nil, "", 0, fmt.Errorf("create gitea raw request: %w", err)
 	}
-	req.Header.Set("Authorization", "token "+s.giteaCfg.AdminToken)
+	req.Header.Set("Authorization", "token "+s.giteaCfg.AccessToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/backend/internal/worker/taskconsumer/consumer.go
+++ b/backend/internal/worker/taskconsumer/consumer.go
@@ -407,9 +407,9 @@ func (c *Consumer) prepareWorkspace(ctx context.Context, taskMsg protocol.Worker
 		}
 		cloneURL = fmt.Sprintf("%s://%s:%s@%s/%s/%s.git",
 			scheme,
-			c.giteaCfg.DefaultOwner, c.giteaCfg.AdminToken,
+			c.giteaCfg.Owner, c.giteaCfg.AccessToken,
 			endpoint,
-			c.giteaCfg.DefaultOwner, repoName)
+			c.giteaCfg.Owner, repoName)
 	}
 
 	plan, err := agentworkspace.PrepareTaskWorkspace(ctx, agentworkspace.TaskWorkspaceRequest{

--- a/deployments/dev/server.config.example.yaml
+++ b/deployments/dev/server.config.example.yaml
@@ -32,8 +32,8 @@ llm:
 
 gitea:
   endpoint: "<your_gitea_endpoint>"
-  admin_token: "<your_admin_token>"
-  default_owner: "admin"
+  access_token: "<your_access_token>"
+  owner: "admin"
 
 storage:
   driver: local

--- a/deployments/dev/worker.config.example.yaml
+++ b/deployments/dev/worker.config.example.yaml
@@ -17,5 +17,5 @@ cli:
 
 gitea:
   endpoint: "<your_gitea_endpoint>"
-  admin_token: "<your_admin_token>"
-  default_owner: "admin"
+  access_token: "<your_access_token>"
+  owner: "admin"


### PR DESCRIPTION
## 变更说明

1. `GiteaConfig` 配置字段重命名：
   - `admin_token` → `access_token`
   - `default_owner` → `owner`

2. 将 `AdminCreateRepo` 替换为 `CreateRepo`，减少所需 token 权限

3. 同步更新 YAML 配置示例文件