### PR TITLE
fix(worker): improve push logging and error handling in worker push paths

### DIFF
--- a/backend/internal/runtime/lifecycle/steps/push_workspace.go
+++ b/backend/internal/runtime/lifecycle/steps/push_workspace.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/ygpkg/yg-go/logs"
 )
 
 type PushWorkspaceStep struct{}
@@ -16,15 +18,21 @@ func (PushWorkspaceStep) Name() string {
 }
 
 func (s PushWorkspaceStep) Run(ctx context.Context, state *State) error {
-	if state == nil || state.Err != nil || state.Request == nil {
+	if state == nil || state.Request == nil {
+		return nil
+	}
+	if state.Err != nil {
+		logs.ErrorContextf(ctx, "push_workspace skipped: previous error: %v", state.Err)
 		return nil
 	}
 	repoDir := strings.TrimSpace(state.Request.Workspace.RepoDir)
 	if repoDir == "" {
+		logs.ErrorContextf(ctx, "push_workspace skipped: repo dir is empty")
 		return nil
 	}
 	gitDir := filepath.Join(repoDir, ".git")
 	if _, err := os.Stat(gitDir); err != nil {
+		logs.ErrorContextf(ctx, "push_workspace skipped: .git directory not found: %s", gitDir)
 		return nil
 	}
 
@@ -36,12 +44,16 @@ func (s PushWorkspaceStep) Run(ctx context.Context, state *State) error {
 
 	commitCmd := exec.CommandContext(ctx, "git", "commit", "-m", "task: agent run artifacts")
 	commitCmd.Dir = repoDir
-	commitCmd.CombinedOutput()
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		logs.ErrorContextf(ctx, "git commit artifacts: %v: %s", err, strings.TrimSpace(string(output)))
+		return nil
+	}
 
 	pushCmd := exec.CommandContext(ctx, "git", "push", "origin", "main")
 	pushCmd.Dir = repoDir
 	if output, err := pushCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git push: %w: %s", err, strings.TrimSpace(string(output)))
 	}
+	logs.InfoContextf(ctx, "push_workspace completed: repo_dir=%s", repoDir)
 	return nil
 }

--- a/backend/internal/worker/taskconsumer/consumer.go
+++ b/backend/internal/worker/taskconsumer/consumer.go
@@ -505,18 +505,23 @@ func commitAttachments(ctx context.Context, repoDir string, count int) {
 	addCmd := exec.CommandContext(ctx, "git", "add", "uploads/")
 	addCmd.Dir = repoDir
 	if output, err := addCmd.CombinedOutput(); err != nil {
-		logs.WarnContextf(ctx, "git add uploads/: %v: %s", err, strings.TrimSpace(string(output)))
+		logs.ErrorContextf(ctx, "git add uploads/: %v: %s", err, strings.TrimSpace(string(output)))
 		return
 	}
 	msg := fmt.Sprintf("task: %d user attachment(s)", count)
 	commitCmd := exec.CommandContext(ctx, "git", "commit", "-m", msg)
 	commitCmd.Dir = repoDir
-	commitCmd.CombinedOutput()
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		logs.ErrorContextf(ctx, "git commit attachments: %v: %s", err, strings.TrimSpace(string(output)))
+		return
+	}
 	pushCmd := exec.CommandContext(ctx, "git", "push", "origin", "main")
 	pushCmd.Dir = repoDir
 	if output, err := pushCmd.CombinedOutput(); err != nil {
-		logs.WarnContextf(ctx, "git push uploads/: %v: %s", err, strings.TrimSpace(string(output)))
+		logs.ErrorContextf(ctx, "git push uploads/: %v: %s", err, strings.TrimSpace(string(output)))
+		return
 	}
+	logs.InfoContextf(ctx, "git push uploads/ completed: count=%d", count)
 }
 
 // Close shuts down the consumer gracefully, waiting for all in-flight tasks.

--- a/backend/internal/workspace/workspace.go
+++ b/backend/internal/workspace/workspace.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/insmtx/Leros/backend/internal/agent"
 	"github.com/insmtx/Leros/backend/pkg/leros"
+	"github.com/ygpkg/yg-go/logs"
 )
 
 // TaskWorkspaceRequest 标识一次任务 turn 的工作区和运行目录请求。
@@ -429,10 +430,12 @@ func cleanPathID(value string) string {
 
 func PushWorkspace(ctx context.Context, plan *TaskWorkspace) error {
 	if plan == nil || plan.RepoDir == "" {
+		logs.ErrorContextf(ctx, "PushWorkspace skipped: plan is nil or repo dir is empty")
 		return nil
 	}
 	gitDir := filepath.Join(plan.RepoDir, ".git")
 	if _, err := os.Stat(gitDir); err != nil {
+		logs.ErrorContextf(ctx, "PushWorkspace skipped: .git directory not found: %s", gitDir)
 		return nil
 	}
 
@@ -444,12 +447,16 @@ func PushWorkspace(ctx context.Context, plan *TaskWorkspace) error {
 
 	commitCmd := exec.CommandContext(ctx, "git", "commit", "-m", "task: agent run artifacts")
 	commitCmd.Dir = plan.RepoDir
-	commitCmd.CombinedOutput()
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		logs.ErrorContextf(ctx, "git commit artifacts: %v: %s", err, strings.TrimSpace(string(output)))
+		return nil
+	}
 
 	pushCmd := exec.CommandContext(ctx, "git", "push", "origin", "main")
 	pushCmd.Dir = plan.RepoDir
 	if output, err := pushCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git push: %w: %s", err, strings.TrimSpace(string(output)))
 	}
+	logs.InfoContextf(ctx, "PushWorkspace completed: repo_dir=%s", plan.RepoDir)
 	return nil
 }


### PR DESCRIPTION
### Summary
Improve logging and error handling across all three worker push paths to make failures visible and auditable.

### Changes
- **consumer.go (`commitAttachments`)**: Upgrade Warn logs to Error, add missing `git commit` error check, add Info log on push success
- **push_workspace.go (`PushWorkspaceStep.Run`)**: Add Error logs for previously silent skip conditions (prior error / empty repo dir / missing .git), add `git commit` error check, add Info log on push success
- **workspace.go (`PushWorkspace`)**: Add Error logs for previously silent skip conditions (nil plan / missing .git), add `git commit` error check, add Info log on push success

### Motivation
Previously, worker push failures were either logged at Warn level (hard to monitor) or silently skipped with no log at all, making troubleshooting difficult.