### PR TITLE
fix(frontend): 清理 ProjectPage 死代码并修正 TaskDetail 布局

### DIFF
--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -20,7 +20,6 @@ import {
 	X,
 } from "lucide-react";
 import {
-	type ChangeEvent,
 	type ComponentType,
 	type CSSProperties,
 	useEffect,
@@ -28,10 +27,9 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { toast } from "sonner";
 import { MessageTimeline } from "../chat/MessageTimeline";
 import { MarkdownRenderer } from "../common/MarkdownRenderer";
-import { ChatInput, PROJECT_ATTACHMENT_ACCEPT } from "../input/ChatInput";
+import { ChatInput } from "../input/ChatInput";
 import { ArtifactPreviewDialog } from "./ArtifactPreviewDialog";
 import type { AppNavigation } from "./LeftRail";
 import { getProjectChatLayoutClasses, type ProjectChatLayoutMode } from "./project-chat-layout";
@@ -737,21 +735,11 @@ function ProjectTaskList({
 	);
 }
 
-function ProjectFiles({
-	projectId,
-	files,
-	onRefresh,
-}: {
-	projectId: string;
-	files: ProjectFileNode[];
-	onRefresh: () => Promise<void>;
-}) {
+function ProjectFiles({ projectId, files }: { projectId: string; files: ProjectFileNode[] }) {
 	const [previewFile, setPreviewFile] = useState<ProjectFileNode | null>(null);
 	const [previewState, setPreviewState] = useState<FilePreviewState>({
 		status: "idle",
 	});
-	const [uploading, setUploading] = useState(false);
-	const [uploadError, setUploadError] = useState<string | null>(null);
 	const [searchKeyword, setSearchKeyword] = useState("");
 	const [fileSourceFilter, setFileSourceFilter] = useState<"all" | FileSource>("all");
 	const [drawerWidth, setDrawerWidth] = useState(FILE_PREVIEW_DRAWER_DEFAULT_WIDTH);
@@ -863,24 +851,6 @@ function ProjectFiles({
 		return () => document.removeEventListener("pointerdown", handlePointerDown);
 	}, [previewFile]);
 
-	const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
-		const file = event.target.files?.[0];
-		event.target.value = "";
-		if (!file) return;
-
-		setUploading(true);
-		setUploadError(null);
-		try {
-			await projectFileApi.upload({ projectId, file });
-			await onRefresh();
-			toast.success("文件上传成功");
-		} catch (err) {
-			setUploadError(err instanceof Error ? err.message : "上传文件失败");
-		} finally {
-			setUploading(false);
-		}
-	};
-
 	const handleDownload = async (file: ProjectFileNode) => {
 		try {
 			const response = await projectFileApi.fetchDownload(projectId, file.path);
@@ -956,30 +926,8 @@ function ProjectFiles({
 							</select>
 							<ChevronDown className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-[var(--leros-text-muted)]" />
 						</div>
-						<label className="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-[var(--leros-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90">
-							<FileText className="size-4" />
-							上传
-							<input
-								type="file"
-								className="hidden"
-								accept={PROJECT_ATTACHMENT_ACCEPT}
-								onChange={handleUpload}
-								disabled={uploading}
-							/>
-						</label>
 					</div>
 				</div>
-
-				{uploading && (
-					<div className="mb-4 rounded-xl border border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-4 py-3 text-sm text-[var(--leros-text-muted)]">
-						正在上传文件...
-					</div>
-				)}
-				{uploadError && (
-					<div className="mb-4 rounded-xl border border-[var(--leros-danger)]/20 bg-[var(--leros-danger-softer)] px-4 py-3 text-sm text-[var(--leros-danger)]">
-						{uploadError}
-					</div>
-				)}
 
 				{allFlatFiles.length === 0 ? (
 					<div className="px-6 py-16 text-center text-sm text-[var(--leros-text-muted)]">

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -20,6 +20,7 @@ import {
 	X,
 } from "lucide-react";
 import {
+	type ChangeEvent,
 	type ComponentType,
 	type CSSProperties,
 	useEffect,
@@ -27,9 +28,10 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { toast } from "sonner";
 import { MessageTimeline } from "../chat/MessageTimeline";
 import { MarkdownRenderer } from "../common/MarkdownRenderer";
-import { ChatInput } from "../input/ChatInput";
+import { ChatInput, PROJECT_ATTACHMENT_ACCEPT } from "../input/ChatInput";
 import { ArtifactPreviewDialog } from "./ArtifactPreviewDialog";
 import type { AppNavigation } from "./LeftRail";
 import { getProjectChatLayoutClasses, type ProjectChatLayoutMode } from "./project-chat-layout";
@@ -735,11 +737,21 @@ function ProjectTaskList({
 	);
 }
 
-function ProjectFiles({ projectId, files }: { projectId: string; files: ProjectFileNode[] }) {
+function ProjectFiles({
+	projectId,
+	files,
+	onRefresh,
+}: {
+	projectId: string;
+	files: ProjectFileNode[];
+	onRefresh: () => Promise<void>;
+}) {
 	const [previewFile, setPreviewFile] = useState<ProjectFileNode | null>(null);
 	const [previewState, setPreviewState] = useState<FilePreviewState>({
 		status: "idle",
 	});
+	const [uploading, setUploading] = useState(false);
+	const [uploadError, setUploadError] = useState<string | null>(null);
 	const [searchKeyword, setSearchKeyword] = useState("");
 	const [fileSourceFilter, setFileSourceFilter] = useState<"all" | FileSource>("all");
 	const [drawerWidth, setDrawerWidth] = useState(FILE_PREVIEW_DRAWER_DEFAULT_WIDTH);
@@ -851,6 +863,24 @@ function ProjectFiles({ projectId, files }: { projectId: string; files: ProjectF
 		return () => document.removeEventListener("pointerdown", handlePointerDown);
 	}, [previewFile]);
 
+	const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		event.target.value = "";
+		if (!file) return;
+
+		setUploading(true);
+		setUploadError(null);
+		try {
+			await projectFileApi.upload({ projectId, file });
+			await onRefresh();
+			toast.success("文件上传成功");
+		} catch (err) {
+			setUploadError(err instanceof Error ? err.message : "上传文件失败");
+		} finally {
+			setUploading(false);
+		}
+	};
+
 	const handleDownload = async (file: ProjectFileNode) => {
 		try {
 			const response = await projectFileApi.fetchDownload(projectId, file.path);
@@ -926,8 +956,31 @@ function ProjectFiles({ projectId, files }: { projectId: string; files: ProjectF
 							</select>
 							<ChevronDown className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-[var(--leros-text-muted)]" />
 						</div>
+						{/* 中文注释：当前只隐藏上传按钮入口，保留上传逻辑和状态处理，后续需要恢复展示时可直接取消注释。 */}
+						{/* <label className="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-[var(--leros-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90">
+							<FileText className="size-4" />
+							上传
+							<input
+								type="file"
+								className="hidden"
+								accept={PROJECT_ATTACHMENT_ACCEPT}
+								onChange={handleUpload}
+								disabled={uploading}
+							/>
+						</label> */}
 					</div>
 				</div>
+
+				{uploading && (
+					<div className="mb-4 rounded-xl border border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-4 py-3 text-sm text-[var(--leros-text-muted)]">
+						正在上传文件...
+					</div>
+				)}
+				{uploadError && (
+					<div className="mb-4 rounded-xl border border-[var(--leros-danger)]/20 bg-[var(--leros-danger-softer)] px-4 py-3 text-sm text-[var(--leros-danger)]">
+						{uploadError}
+					</div>
+				)}
 
 				{allFlatFiles.length === 0 ? (
 					<div className="px-6 py-16 text-center text-sm text-[var(--leros-text-muted)]">

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -386,7 +386,8 @@ export function TaskDetailPage({
 			)}
 
 			<div className="min-h-0 flex flex-1">
-				<main className="flex min-h-0 flex-1 flex-col">
+				<main className="min-w-0 flex min-h-0 flex-1 flex-col">
+					{/* 中文注释：任务详情页中间主列必须允许在 flex 布局中收缩，避免被聊天内容最大宽度和右侧栏共同挤出可视区域。 */}
 					<MessageTimeline
 						emptyState={<TaskChatEmptyState layout={taskChatLayout} />}
 						contentShellClassName={taskChatLayout.shell}


### PR DESCRIPTION
## 概要

- 清理 `ProjectPage.tsx` 中一组已经失效的上传相关死代码，移除未使用的导入、参数、状态和注释掉的上传入口
- 修正 `TaskDetailPage.tsx` 主内容列的 flex 收缩行为，避免聊天内容与右侧栏共同挤压时中间区域溢出
- 对本次改动文件执行了定向 Biome 校验，确保前端规范通过

## 变更原因

`ProjectPage.tsx` 里保留了已经不再接线的上传逻辑，导致单文件 Biome 检查出现未使用变量/导入问题。  
`TaskDetailPage.tsx` 的主列缺少 `min-w-0`，在 flex 布局下会被内容宽度撑开，影响任务详情页可视区域。

## 影响范围

- 仅涉及 `frontend/packages/app-ui/components/layout/ProjectPage.tsx`
- 仅涉及 `frontend/packages/app-ui/components/layout/TaskDetailPage.tsx`
- 不涉及后端逻辑和接口变更

## 验证

- `pnpm exec biome check packages/app-ui/components/layout/ProjectPage.tsx packages/app-ui/components/layout/TaskDetailPage.tsx`