### PR TITLE
feat(skill): 支持技能中文展示名

### DIFF
--- a/backend/internal/api/contract/skill_marketplace.go
+++ b/backend/internal/api/contract/skill_marketplace.go
@@ -73,6 +73,7 @@ type SkillMarketplaceItemView struct {
 	SourceType  string   `json:"source_type"`
 	SkillID     string   `json:"skill_id"`
 	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name,omitempty"`
 	Description string   `json:"description"`
 	Version     string   `json:"version"`
 	Author      string   `json:"author"`
@@ -100,6 +101,7 @@ type InstalledSkillsRequest struct{}
 // SkillInstalledItem 表示 worker 上已安装的 Skill。
 type SkillInstalledItem struct {
 	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
 	Description string `json:"description"`
 	Category    string `json:"category"`
 	Source      string `json:"source"`
@@ -134,6 +136,7 @@ type SkillDetailResponse struct {
 	SkillID     string   `json:"skill_id"`
 	Source      string   `json:"source"`
 	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name,omitempty"`
 	Description string   `json:"description"`
 	SkillMD     string   `json:"skill_md"`
 	Version     string   `json:"version"`

--- a/backend/internal/infra/db/database.go
+++ b/backend/internal/infra/db/database.go
@@ -262,26 +262,7 @@ func seedSystemLLMModels(d *gorm.DB, llmCfg *config.LLMConfig) error {
 		return nil
 	}
 
-	existing.Name = spec.Name
-	existing.Description = spec.Description
-	existing.Provider = spec.Provider
-	existing.ModelName = spec.ModelName
-	existing.BaseURL = spec.BaseURL
-	existing.BaseURLHasV1 = spec.BaseURLHasV1
-	existing.APIKeyEncrypted = spec.APIKeyEncrypted
-	existing.APIKeyMasked = spec.APIKeyMasked
-	existing.MaxTokens = spec.MaxTokens
-	existing.Temperature = spec.Temperature
-	existing.TimeoutSec = spec.TimeoutSec
-	existing.Status = spec.Status
-	existing.IsDefault = false
-	existing.IsSystem = true
-	existing.Config = spec.Config
-
-	if err := d.Save(&existing).Error; err != nil {
-		return fmt.Errorf("update system translation LLM model: %w", err)
-	}
-	logs.Infof("System translation LLM model updated (provider=%s, model=%s)", spec.Provider, spec.ModelName)
+	logs.Infof("System translation LLM model already exists, skip initialization (provider=%s, model=%s)", existing.Provider, existing.ModelName)
 	return nil
 }
 

--- a/backend/internal/infra/db/llm_model_dao_test.go
+++ b/backend/internal/infra/db/llm_model_dao_test.go
@@ -273,7 +273,7 @@ func TestSeedSystemLLMModelsCreatesTranslationModel(t *testing.T) {
 	}
 }
 
-func TestSeedSystemLLMModelsUpdatesSystemTranslationModel(t *testing.T) {
+func TestSeedSystemLLMModelsDoesNotOverwriteExistingSystemTranslationModel(t *testing.T) {
 	database := setupLLMModelTestDB(t)
 
 	existing := newTestLLMModel(1, SystemTranslationLLMModelCode)
@@ -302,8 +302,8 @@ func TestSeedSystemLLMModelsUpdatesSystemTranslationModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLLMModelByCode failed: %v", err)
 	}
-	if model.Provider != string(types.LLMProviderDeepSeek) || model.ModelName != "deepseek-v4-flash" || model.APIKeyEncrypted != "new-key" {
-		t.Fatalf("expected system model to be updated, got %#v", model)
+	if model.Provider != string(types.LLMProviderOpenAI) || model.ModelName != "old-model" || model.APIKeyEncrypted != "old-key" {
+		t.Fatalf("expected existing system model to remain unchanged, got %#v", model)
 	}
 }
 

--- a/backend/internal/infra/db/skill_marketplace_item_dao.go
+++ b/backend/internal/infra/db/skill_marketplace_item_dao.go
@@ -92,7 +92,7 @@ func BatchUpsertSkillMarketplaceItems(ctx context.Context, db *gorm.DB, items []
 			{Name: "version"},
 		},
 		DoUpdates: clause.AssignmentColumns([]string{
-			"name", "description", "translated_description", "author",
+			"name", "translated_name", "description", "translated_description", "author",
 			"installs", "category", "tags", "package_storage_path", "updated_at",
 		}),
 	}).Create(&items).Error

--- a/backend/internal/service/default_skill_description_translator.go
+++ b/backend/internal/service/default_skill_description_translator.go
@@ -25,7 +25,7 @@ const (
 	translateMaxWorkers = 4  // 最多 4 个并发翻译
 )
 
-// defaultSkillDescriptionTranslator 使用组织默认 LLM 翻译 Skill 描述。
+// defaultSkillDescriptionTranslator 使用组织默认 LLM 翻译 Skill 市场文案。
 type defaultSkillDescriptionTranslator struct {
 	db *gorm.DB
 }
@@ -38,41 +38,43 @@ func NewDefaultSkillDescriptionTranslator(db *gorm.DB) SkillDescriptionTranslato
 // translationRequest 发送给模型的翻译请求项。
 type translationRequest struct {
 	SkillID     string `json:"skill_id"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 }
 
 // translationResponse 模型返回的翻译结果项。
 type translationResponse struct {
 	SkillID     string `json:"skill_id"`
+	DisplayName string `json:"display_name"`
 	Description string `json:"description"`
 }
 
-// Translate 批量翻译英文 Skill 描述为中文。
+// Translate 批量生成中文展示名并翻译英文 Skill 描述。
 // 将 items 按 20 条一组分批，最多 3 个并发调用 LLM。
-func (t *defaultSkillDescriptionTranslator) Translate(ctx context.Context, items []TranslateItem) (map[string]string, error) {
+func (t *defaultSkillDescriptionTranslator) Translate(ctx context.Context, items []TranslateItem) (map[string]TranslatedSkillText, error) {
 	if len(items) == 0 {
-		return map[string]string{}, nil
+		return map[string]TranslatedSkillText{}, nil
 	}
 
 	caller, _ := auth.FromContext(ctx)
 	if caller == nil || caller.OrgID == 0 {
 		logs.WarnContextf(ctx, "skill translator: no authenticated caller, skip translation")
-		return map[string]string{}, nil
+		return map[string]TranslatedSkillText{}, nil
 	}
 
 	model, err := infradb.GetSystemTranslationLLMModel(ctx, t.db, caller.OrgID)
 	if err != nil {
 		logs.WarnContextf(ctx, "skill translator: get system translation LLM model: %v", err)
-		return map[string]string{}, nil
+		return map[string]TranslatedSkillText{}, nil
 	}
 	if model == nil {
 		logs.WarnContextf(ctx, "skill translator: no system translation LLM model for org %d", caller.OrgID)
-		return map[string]string{}, nil
+		return map[string]TranslatedSkillText{}, nil
 	}
 
 	chatModel, err := t.buildChatModel(ctx, model)
 	if err != nil {
-		return map[string]string{}, nil
+		return map[string]TranslatedSkillText{}, nil
 	}
 
 	return t.translateBatches(ctx, chatModel, items)
@@ -105,7 +107,7 @@ func (t *defaultSkillDescriptionTranslator) buildChatModel(ctx context.Context, 
 }
 
 // translateBatches 将 items 按 batchSize 分组后并发翻译，合并结果。
-func (t *defaultSkillDescriptionTranslator) translateBatches(ctx context.Context, chatModel model.ToolCallingChatModel, items []TranslateItem) (map[string]string, error) {
+func (t *defaultSkillDescriptionTranslator) translateBatches(ctx context.Context, chatModel model.ToolCallingChatModel, items []TranslateItem) (map[string]TranslatedSkillText, error) {
 	var batches [][]TranslateItem
 	for i := 0; i < len(items); i += translateBatchSize {
 		end := i + translateBatchSize
@@ -120,7 +122,7 @@ func (t *defaultSkillDescriptionTranslator) translateBatches(ctx context.Context
 	}
 
 	type batchResult struct {
-		translations map[string]string
+		translations map[string]TranslatedSkillText
 		err          error
 	}
 
@@ -147,7 +149,7 @@ func (t *defaultSkillDescriptionTranslator) translateBatches(ctx context.Context
 	wg.Wait()
 	close(resultCh)
 
-	merged := make(map[string]string, len(items))
+	merged := make(map[string]TranslatedSkillText, len(items))
 	for r := range resultCh {
 		if r.err != nil {
 			logs.WarnContextf(ctx, "skill translator: batch translate failed: %v", r.err)
@@ -160,20 +162,27 @@ func (t *defaultSkillDescriptionTranslator) translateBatches(ctx context.Context
 	return merged, nil
 }
 
-// doTranslate 对一批 items 调用 LLM 翻译，返回 skill_id → 中文描述的映射。
-func (t *defaultSkillDescriptionTranslator) doTranslate(ctx context.Context, chatModel model.ToolCallingChatModel, items []TranslateItem) (map[string]string, error) {
+// doTranslate 对一批 items 调用 LLM 翻译，返回 skill_id → 中文展示文案的映射。
+func (t *defaultSkillDescriptionTranslator) doTranslate(ctx context.Context, chatModel model.ToolCallingChatModel, items []TranslateItem) (map[string]TranslatedSkillText, error) {
 	reqItems := make([]translationRequest, len(items))
 	for i, item := range items {
-		reqItems[i] = translationRequest{SkillID: item.SkillID, Description: item.Description}
+		reqItems[i] = translationRequest{SkillID: item.SkillID, Name: item.Name, Description: item.Description}
 	}
 	reqJSON, _ := json.Marshal(reqItems)
 
-	prompt := fmt.Sprintf(`Translate the following skill descriptions from English to Chinese (Simplified). Return ONLY a valid JSON array, no markdown, no code fences.
+	prompt := fmt.Sprintf(`Translate the following skill marketplace copy from English to Simplified Chinese and generate a concise Chinese display name. Return ONLY a valid JSON array, no markdown, no code fences.
 
 Format:
-[{"skill_id":"...","description":"Chinese translation..."}]
+[{"skill_id":"...","display_name":"短中文名","description":"Chinese translation..."}]
 
 The array must have exactly %d items, each skill_id must match an input skill_id.
+
+Rules for display_name:
+1. Generate it from both name and description.
+2. Prefer 2-8 Chinese characters or a short Chinese noun phrase.
+3. Do not include punctuation.
+4. Do not append "技能" unless the name would be unclear without it.
+5. Preserve product names, brand names, and file format names such as PDF, Excel, Word, Notion, GitHub.
 
 Input:
 %s`, len(items), string(reqJSON))
@@ -201,10 +210,15 @@ Input:
 		return nil, fmt.Errorf("response length %d != input length %d", len(results), len(items))
 	}
 
-	translationMap := make(map[string]string, len(results))
+	translationMap := make(map[string]TranslatedSkillText, len(results))
 	for _, r := range results {
-		if r.SkillID != "" && r.Description != "" {
-			translationMap[r.SkillID] = r.Description
+		displayName := strings.TrimSpace(r.DisplayName)
+		description := strings.TrimSpace(r.Description)
+		if r.SkillID != "" && (displayName != "" || description != "") {
+			translationMap[r.SkillID] = TranslatedSkillText{
+				DisplayName: displayName,
+				Description: description,
+			}
 		}
 	}
 	return translationMap, nil

--- a/backend/internal/service/skill_description_translator.go
+++ b/backend/internal/service/skill_description_translator.go
@@ -2,10 +2,17 @@ package service
 
 import "context"
 
-// TranslateItem 待翻译的 Skill 描述条目。
+// TranslateItem 待翻译的 Skill 市场文案条目。
 type TranslateItem struct {
 	SkillID     string
+	Name        string
 	Description string // 原始描述（通常是英文）
+}
+
+// TranslatedSkillText 是 Skill 面向中文用户展示的文案。
+type TranslatedSkillText struct {
+	DisplayName string
+	Description string
 }
 
 // TranslateDocumentItem 待翻译的整篇 SKILL.md 条目。
@@ -14,11 +21,11 @@ type TranslateDocumentItem struct {
 	Content string // 原始 SKILL.md 完整内容（含 YAML frontmatter）
 }
 
-// SkillDescriptionTranslator 将英文 Skill 描述翻译为中文。
+// SkillDescriptionTranslator 将英文 Skill 市场文案翻译为中文。
 type SkillDescriptionTranslator interface {
-	// Translate 批量翻译描述。
-	// 返回 map[skill_id]translatedDescription，出错或无法翻译时返回空 map。
-	Translate(ctx context.Context, items []TranslateItem) (map[string]string, error)
+	// Translate 批量生成中文展示名并翻译描述。
+	// 返回 map[skill_id]TranslatedSkillText，出错或无法翻译时返回空 map。
+	Translate(ctx context.Context, items []TranslateItem) (map[string]TranslatedSkillText, error)
 
 	// TranslateDocument 批量翻译整篇 SKILL.md。
 	// 保留 YAML frontmatter、标题层级、列表、代码块、链接、表格等 Markdown 结构，

--- a/backend/internal/service/skill_marketplace_service.go
+++ b/backend/internal/service/skill_marketplace_service.go
@@ -172,6 +172,7 @@ func skillMarketplaceItemView(sourceType, skillID, name, description, version, a
 		SourceType:  sourceType,
 		SkillID:     skillID,
 		Name:        name,
+		DisplayName: "",
 		Description: description,
 		Version:     version,
 		Author:      author,
@@ -192,7 +193,7 @@ func metaToView(meta fetch.SkillMeta) contract.SkillMarketplaceItemView {
 		meta.Version, meta.Author, meta.Category, meta.Tags, meta.Icon, meta.Installs)
 }
 
-// resolveCacheAndTranslation 从缓存表查找中文描述，未命中的进行翻译后写库。
+// resolveCacheAndTranslation 从缓存表查找中文展示文案，未命中的进行翻译后写库。
 func (s *skillMarketplaceService) resolveCacheAndTranslation(ctx context.Context, items []contract.SkillMarketplaceItemView) {
 	if len(items) == 0 {
 		return
@@ -214,8 +215,8 @@ func (s *skillMarketplaceService) resolveCacheAndTranslation(ctx context.Context
 	}
 
 	var (
-		alreadyChinese []types.SkillMarketplaceItem // 中文描述直接写库
-		needTranslate  []TranslateItem              // 需要模型翻译
+		alreadyChinese []types.SkillMarketplaceItem // 中文文案直接写库
+		needTranslate  []TranslateItem              // 需要模型生成中文文案
 	)
 
 	for idx := range items {
@@ -223,25 +224,30 @@ func (s *skillMarketplaceService) resolveCacheAndTranslation(ctx context.Context
 		key := fmt.Sprintf("%s|%s|%s", item.SourceType, item.SkillID, item.Version)
 		cached, hit := cacheMap[key]
 
+		if hit && cached.TranslatedName != "" {
+			item.DisplayName = cached.TranslatedName
+		}
 		if hit && cached.TranslatedDescription != "" {
-			// 缓存命中且有中文描述 → 直接替换
 			item.Description = cached.TranslatedDescription
-			continue
 		}
 
 		if item.Description == "" {
 			continue
 		}
 
-		if utils.CJKRatio(item.Description) >= cjkTranslationThreshold {
-			// 已中文 → 直接写库
-			alreadyChinese = append(alreadyChinese, itemToCacheItem(item, item.Description))
+		hasChineseDescription := utils.CJKRatio(item.Description) >= cjkTranslationThreshold
+		hasDisplayName := strings.TrimSpace(item.DisplayName) != ""
+		if hasChineseDescription && hasDisplayName {
+			alreadyChinese = append(alreadyChinese, itemToCacheItem(item, TranslatedSkillText{
+				DisplayName: item.DisplayName,
+				Description: item.Description,
+			}))
 			continue
 		}
 
-		// 需要翻译
 		needTranslate = append(needTranslate, TranslateItem{
-			SkillID:     item.SkillID,
+			SkillID:     translateItemKey(item),
+			Name:        item.Name,
 			Description: item.Description,
 		})
 	}
@@ -268,7 +274,7 @@ func (s *skillMarketplaceService) resolveCacheAndTranslation(ctx context.Context
 		upsertItems := make([]types.SkillMarketplaceItem, 0, len(translationMap))
 		for idx := range items {
 			item := items[idx]
-			if translated, ok := translationMap[item.SkillID]; ok {
+			if translated, ok := translationMap[translateItemKey(&item)]; ok {
 				upsertItems = append(upsertItems, itemToCacheItem(&item, translated))
 			}
 		}
@@ -281,31 +287,49 @@ func (s *skillMarketplaceService) resolveCacheAndTranslation(ctx context.Context
 		// 再替换返回给前端的描述
 		for idx := range items {
 			item := &items[idx]
-			if translated, ok := translationMap[item.SkillID]; ok {
-				item.Description = translated
+			if translated, ok := translationMap[translateItemKey(item)]; ok {
+				if translated.DisplayName != "" {
+					item.DisplayName = translated.DisplayName
+				}
+				if translated.Description != "" {
+					item.Description = translated.Description
+				}
 			}
 		}
 	}
 }
 
 // itemToCacheItem 将 SkillMarketplaceItemView 转为缓存表记录。
-func itemToCacheItem(item *contract.SkillMarketplaceItemView, translatedDesc string) types.SkillMarketplaceItem {
+func itemToCacheItem(item *contract.SkillMarketplaceItemView, translated TranslatedSkillText) types.SkillMarketplaceItem {
 	tags := types.SkillStringList{}
 	if item.Tags != nil {
 		tags = types.SkillStringList(item.Tags)
 	}
+	displayName := translated.DisplayName
+	if displayName == "" {
+		displayName = item.DisplayName
+	}
+	translatedDescription := translated.Description
+	if translatedDescription == "" && utils.CJKRatio(item.Description) >= cjkTranslationThreshold {
+		translatedDescription = item.Description
+	}
 	return types.SkillMarketplaceItem{
 		SkillID:               item.SkillID,
 		Name:                  item.Name,
+		TranslatedName:        displayName,
 		Source:                item.SourceType,
 		Description:           item.Description,
-		TranslatedDescription: translatedDesc,
+		TranslatedDescription: translatedDescription,
 		Author:                item.Author,
 		Installs:              0,
 		Version:               item.Version,
 		Category:              item.Category,
 		Tags:                  tags,
 	}
+}
+
+func translateItemKey(item *contract.SkillMarketplaceItemView) string {
+	return fmt.Sprintf("%s|%s|%s", item.SourceType, item.SkillID, item.Version)
 }
 
 func (s *skillMarketplaceService) DownloadBuiltinSkill(ctx context.Context, skillID string) (*contract.SkillPackageDownload, error) {
@@ -512,6 +536,7 @@ func (s *skillMarketplaceService) InstalledSkills(ctx context.Context, req *cont
 	if err := json.Unmarshal(resp.Data, &skills); err != nil {
 		return nil, fmt.Errorf("unmarshal skill list items: %w", err)
 	}
+	s.enrichInstalledSystemSkills(ctx, skills)
 
 	return &contract.InstalledSkillsResponse{Skills: skills}, nil
 }
@@ -654,6 +679,7 @@ func (s *skillMarketplaceService) readDetailFromCache(ctx context.Context, item 
 		SkillID:     item.SkillID,
 		Source:      source,
 		Name:        item.Name,
+		DisplayName: item.TranslatedName,
 		Description: description,
 		SkillMD:     skillMDBody,
 		Version:     item.Version,
@@ -712,6 +738,9 @@ func (s *skillMarketplaceService) refillMarketplaceSkillDetail(ctx context.Conte
 	// 统一 version fallback
 	if resp.Version == "" {
 		resp.Version = "latest"
+	}
+	if existingItem != nil && existingItem.TranslatedName != "" {
+		resp.DisplayName = existingItem.TranslatedName
 	}
 
 	// 统一 eager 翻译：有 translator、原文非中文时同步翻译
@@ -820,6 +849,7 @@ func (s *skillMarketplaceService) getLerosSkillDetailWithBundle(ctx context.Cont
 		SkillID:     item.SkillID,
 		Source:      "Leros",
 		Name:        item.Name,
+		DisplayName: "",
 		Description: item.Description,
 		SkillMD:     skillMDContent,
 		Version:     item.Version,
@@ -900,10 +930,11 @@ func (s *skillMarketplaceService) getInstalledSkillDetail(ctx context.Context, s
 		return nil, fmt.Errorf("unmarshal skill detail items: %w", err)
 	}
 
-	return &contract.SkillDetailResponse{
+	detailResp := &contract.SkillDetailResponse{
 		SkillID:     detail.Name,
 		Source:      "installed",
 		Name:        detail.Name,
+		DisplayName: "",
 		Description: detail.Description,
 		SkillMD:     detail.SkillMD, // already stripped by catalog.Get in handleDetail
 		Version:     detail.Version,
@@ -914,7 +945,123 @@ func (s *skillMarketplaceService) getInstalledSkillDetail(ctx context.Context, s
 		Verified:    detail.Trust == "trusted",
 		SourceType:  detail.Source,
 		Files:       detail.Files,
-	}, nil
+	}
+	s.enrichInstalledSystemSkillDetail(ctx, detailResp)
+	return detailResp, nil
+}
+
+func (s *skillMarketplaceService) enrichInstalledSystemSkills(ctx context.Context, skills []contract.SkillInstalledItem) {
+	if len(skills) == 0 || s.db == nil {
+		return
+	}
+
+	names := make([]string, 0, len(skills))
+	for _, item := range skills {
+		name := strings.TrimSpace(item.Name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	builtinByID, err := s.builtinItemsBySkillID(ctx, names)
+	if err != nil {
+		logs.WarnContextf(ctx, "enrich installed system skills: query builtin skills: %v", err)
+		return
+	}
+	if len(builtinByID) == 0 {
+		return
+	}
+
+	views := make([]contract.SkillMarketplaceItemView, 0, len(builtinByID))
+	for _, name := range names {
+		if item, ok := builtinByID[name]; ok {
+			views = append(views, builtinItemToView(item))
+		}
+	}
+	s.resolveCacheAndTranslation(ctx, views)
+
+	viewByID := make(map[string]contract.SkillMarketplaceItemView, len(views))
+	for _, view := range views {
+		viewByID[view.SkillID] = view
+	}
+
+	for idx := range skills {
+		view, ok := viewByID[skills[idx].Name]
+		if !ok {
+			continue
+		}
+		skills[idx].DisplayName = view.DisplayName
+		if view.Description != "" {
+			skills[idx].Description = view.Description
+		}
+		if skills[idx].Category == "" {
+			skills[idx].Category = view.Category
+		}
+	}
+}
+
+func (s *skillMarketplaceService) enrichInstalledSystemSkillDetail(ctx context.Context, detail *contract.SkillDetailResponse) {
+	if detail == nil || s.db == nil {
+		return
+	}
+
+	builtinByID, err := s.builtinItemsBySkillID(ctx, []string{detail.Name})
+	if err != nil {
+		logs.WarnContextf(ctx, "enrich installed system skill detail: query builtin skill: %v", err)
+		return
+	}
+	item, ok := builtinByID[detail.Name]
+	if !ok {
+		return
+	}
+
+	views := []contract.SkillMarketplaceItemView{builtinItemToView(item)}
+	s.resolveCacheAndTranslation(ctx, views)
+	if len(views) == 0 {
+		return
+	}
+	detail.DisplayName = views[0].DisplayName
+	if views[0].Description != "" {
+		detail.Description = views[0].Description
+	}
+	if detail.Category == "" {
+		detail.Category = views[0].Category
+	}
+}
+
+func (s *skillMarketplaceService) builtinItemsBySkillID(ctx context.Context, skillIDs []string) (map[string]types.BuiltinSkillMarketplaceItem, error) {
+	result := make(map[string]types.BuiltinSkillMarketplaceItem)
+	if len(skillIDs) == 0 {
+		return result, nil
+	}
+
+	unique := make([]string, 0, len(skillIDs))
+	seen := make(map[string]bool, len(skillIDs))
+	for _, id := range skillIDs {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		unique = append(unique, id)
+	}
+	if len(unique) == 0 {
+		return result, nil
+	}
+
+	var items []types.BuiltinSkillMarketplaceItem
+	if err := s.db.WithContext(ctx).
+		Where("skill_id IN ? AND status = ?", unique, "active").
+		Find(&items).Error; err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		result[item.SkillID] = item
+	}
+	return result, nil
 }
 
 // ImportSkill 从已上传文件导入 Skill，校验内容后发送给 Worker 异步安装。

--- a/backend/internal/skill/cache/skill_cache.go
+++ b/backend/internal/skill/cache/skill_cache.go
@@ -161,6 +161,7 @@ func CachePackage(ctx context.Context, st storage.Storage, bucket string,
 // ChineseWriter 提供写出 SKILL.zh-CN.md 的能力，供 CachePackage 的调用方使用。
 // 定义为接口避免 cache 包对 service 层的依赖。
 type ChineseWriter func(ctx context.Context, content string) (string, string, error)
+
 // content: 翻译后的完整 SKILL.md（含 frontmatter）
 // 返回: body（去 frontmatter）、description（frontmatter 中 description）、error
 
@@ -244,17 +245,18 @@ func upsertPackagePath(ctx context.Context, db *gorm.DB, source, skillID, versio
 	// 没有现成记录，用 BatchUpsert 创建一条
 	items := []types.SkillMarketplaceItem{
 		{
-			SkillID:             skillID,
-			Name:                "",
-			Source:              source,
-			Description:         "",
+			SkillID:               skillID,
+			Name:                  "",
+			TranslatedName:        "",
+			Source:                source,
+			Description:           "",
 			TranslatedDescription: "",
-			Author:              "",
-			Installs:            0,
-			Version:             version,
-			Category:            "",
-			Tags:                nil,
-			PackageStoragePath:  path,
+			Author:                "",
+			Installs:              0,
+			Version:               version,
+			Category:              "",
+			Tags:                  nil,
+			PackageStoragePath:    path,
 		},
 	}
 	return infradb.BatchUpsertSkillMarketplaceItems(ctx, db, items)

--- a/backend/types/skill_marketplace_item.go
+++ b/backend/types/skill_marketplace_item.go
@@ -14,6 +14,9 @@ type SkillMarketplaceItem struct {
 	// Name 是 Skill 在市场页面展示的名称。
 	Name string `gorm:"column:name;type:varchar(255);not null" json:"name"`
 
+	// TranslatedName 是模型根据名称和描述生成的中文展示名。
+	TranslatedName string `gorm:"column:translated_name;type:varchar(255)" json:"translated_name"`
+
 	// Source 是数据来源，例如 Leros、ClawHub。
 	Source string `gorm:"column:source;type:varchar(50);not null;uniqueIndex:idx_marketplace_item_source_skill_version" json:"source"`
 

--- a/deployments/dev/server.config.example.yaml
+++ b/deployments/dev/server.config.example.yaml
@@ -29,6 +29,11 @@ llm:
   api_key: "${LLM_API_KEY}"
   model: "qwen3.6-plus"
   base_url: "https://api.yygu.cn/v3/llm.chat/"
+  translation:
+    provider: "deepseek"
+    api_key: "${LLM_API_KEY}"
+    model: "deepseek-v4-flash"
+    base_url: "https://api.yygu.cn/v3/llm.chat/"
 
 gitea:
   endpoint: "<your_gitea_endpoint>"
@@ -42,8 +47,4 @@ storage:
   static_api_key: "leros-static-api-key"
   sign_secret: "leros-local-presign"
   base_url: "http://localhost:8080"
-translation:
-  provider: "deepseek"
-  api_key: "${LLM_API_KEY}"
-  model: "deepseek-v4-flash"
-  base_url: "https://api.yygu.cn/v3/llm.chat/"
+

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -121,13 +121,12 @@ function isEmptyEditorValue(value: string): boolean {
 }
 
 function installedSkillToOption(skill: SkillInstalledItem): SkillOption {
+	const label = skill.display_name || skill.name;
 	return {
 		code: skill.name,
-		label: skill.name,
+		label,
 		description: skill.description || skill.category || "已安装技能",
-		keywords: [skill.name, skill.description, skill.category, skill.source, skill.trust].filter(
-			Boolean,
-		),
+		keywords: [label, skill.name, skill.description, skill.category, skill.source, skill.trust].filter(Boolean),
 	};
 }
 
@@ -158,6 +157,7 @@ function skillItemFromValue(value: unknown): SkillInstalledItem | null {
 
 	return {
 		name,
+		display_name: stringFromValue(value.display_name),
 		description: stringFromValue(value.description),
 		category: stringFromValue(value.category),
 		source: stringFromValue(value.source || value.source_type),

--- a/frontend/packages/app-ui/components/skills/SkillCard.tsx
+++ b/frontend/packages/app-ui/components/skills/SkillCard.tsx
@@ -15,6 +15,7 @@ interface SkillCardProps {
 export function SkillCard({ skill, variant = "marketplace", onClick }: SkillCardProps) {
 	const isLerosAI = skill.author === "Lework";
 	const isMine = variant === "mine";
+	const displayName = skill.display_name || skill.name;
 
 	const handleCardClick = () => {
 		onClick?.(skill);
@@ -46,18 +47,18 @@ export function SkillCard({ skill, variant = "marketplace", onClick }: SkillCard
 					{skill.icon ? (
 						<img
 							src={skill.icon}
-							alt={skill.name}
+							alt={displayName}
 							className="h-9 w-9 shrink-0 rounded-lg object-cover"
 						/>
 					) : (
 						<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-soft)] text-[var(--leros-primary)] text-sm font-bold transition-all duration-300 group-hover:bg-[var(--leros-primary)] group-hover:text-white">
-							{skill.name.charAt(0).toUpperCase()}
+							{displayName.charAt(0).toUpperCase()}
 						</div>
 					)}
 					<div>
 						<div className="mb-0.5 flex items-center gap-1">
 							<h3 className="max-w-[140px] truncate text-sm font-semibold text-[var(--leros-text-strong)]">
-								{skill.name}
+								{displayName}
 							</h3>
 							{isLerosAI && (
 								<span className="inline-flex shrink-0 text-[var(--leros-primary)]" title="已验证">

--- a/frontend/packages/app-ui/components/skills/SkillDetailView.tsx
+++ b/frontend/packages/app-ui/components/skills/SkillDetailView.tsx
@@ -185,6 +185,8 @@ export function SkillDetailView({
 		);
 	}
 
+	const displayName = skill.display_name || skill.name;
+
 	return (
 		<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto bg-[var(--leros-app-bg)] [scrollbar-gutter:stable]">
 			{/* Top section: back + header + metrics (full width) */}
@@ -208,17 +210,17 @@ export function SkillDetailView({
 						{skill.icon ? (
 							<img
 								src={skill.icon}
-								alt={skill.name}
+								alt={displayName}
 								className="h-14 w-14 shrink-0 rounded-xl object-cover shadow-sm"
 							/>
 						) : (
 							<div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-[var(--leros-primary-soft)] text-[var(--leros-primary)] shadow-sm">
-								<span className="text-[28px] font-bold">{skill.name.charAt(0).toUpperCase()}</span>
+								<span className="text-[28px] font-bold">{displayName.charAt(0).toUpperCase()}</span>
 							</div>
 						)}
 						<div className="min-w-0">
 							<h1 className="mb-1 break-words text-xl font-bold leading-tight text-[var(--leros-text-strong)]">
-								{skill.name}
+								{displayName}
 							</h1>
 							{skill.category && (
 								<span className="inline-flex px-2 py-0.5 rounded bg-[var(--leros-surface-soft)] text-[var(--leros-text-muted)] text-[11px] font-medium border border-[var(--leros-control-border)]">
@@ -429,19 +431,19 @@ export function SkillDetailView({
 											{related.icon ? (
 												<img
 													src={related.icon}
-													alt={related.name}
+													alt={related.display_name || related.name}
 													className="h-8 w-8 shrink-0 rounded-lg object-cover"
 												/>
 											) : (
 												<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-surface-soft)] text-[var(--leros-text-muted)] group-hover:bg-[var(--leros-primary-soft)] group-hover:text-[var(--leros-primary)] transition-colors">
 													<span className="text-sm font-bold">
-														{related.name.charAt(0).toUpperCase()}
+														{(related.display_name || related.name).charAt(0).toUpperCase()}
 													</span>
 												</div>
 											)}
 											<div className="min-w-0">
 												<h6 className="text-xs font-semibold text-[var(--leros-text-strong)] truncate">
-													{related.name}
+													{related.display_name || related.name}
 												</h6>
 												<div className="flex items-center gap-1.5 mt-0.5 text-[10px] text-[var(--leros-text-subtle)]">
 													<span className="flex items-center gap-0.5">

--- a/frontend/packages/store/api/skillMarketplaceApi.ts
+++ b/frontend/packages/store/api/skillMarketplaceApi.ts
@@ -5,6 +5,7 @@ export interface SkillMarketplaceItem {
   source_type: string;
   skill_id: string;
   name: string;
+  display_name?: string;
   description: string;
   version: string;
   author: string;
@@ -40,6 +41,7 @@ export interface InstallSkillResponse {
 /** 后端返回的已安装 skill（worker 侧查询结果）。 */
 export interface SkillInstalledItem {
   name: string;
+  display_name?: string;
   description: string;
   category: string;
   source: string;
@@ -69,6 +71,7 @@ export interface SkillDetailData {
   skill_id: string;
   source: string;
   name: string;
+  display_name?: string;
   description: string;
   skill_md: string;
   version: string;
@@ -104,6 +107,7 @@ export function installedToCardItem(item: SkillInstalledItem): SkillMarketplaceI
     source_type: item.source,
     skill_id: item.name,
     name: item.name,
+    display_name: item.display_name,
     description: item.description,
     version: "",
     author: item.source,


### PR DESCRIPTION
本次变更完善 Skill 市场和技能展示的中文名称链路，保持技能原始 name 作为执行标识不变，新增 display_name 作为前端展示字段。

主要变更：
- 为 Skill 市场列表、Skill 详情、已安装 Skill 响应增加 display_name 字段
- 将市场缓存表扩展 translated_name，用于保存模型生成的中文技能名
- 调整 Skill 描述翻译器，使其根据 name + description 同时生成中文展示名和中文描述
- 市场搜索时优先使用缓存中的 translated_name / translated_description，缺失时按需调用翻译模型补齐
- 前端技能卡片、详情页、相关推荐和指令选择器优先展示 display_name，保留 name 用于安装、卸载和 worker 调用
- 已安装技能展示支持 display_name，用户自定义技能未提供时继续回退原始 name
- 调整 llm_translation 初始化逻辑：数据库中已存在系统翻译模型时不再覆盖配置

验证：
- GOCACHE=/private/tmp/leros-go-cache go test ./backend/... -run '^$'
- GOCACHE=/private/tmp/leros-go-cache go test ./backend/internal/infra/db
- GOCACHE=/private/tmp/leros-go-cache go test ./backend/internal/service ./backend/internal/api/contract -run '^$'