### PR TITLE
fix(dev): 修复本地文件预览与工作区挂载问题

### DIFF
--- a/deployments/dev/dev-server.sh
+++ b/deployments/dev/dev-server.sh
@@ -65,6 +65,8 @@ echo -e "${BLUE}Starting server (port 8080)...${NC}"
 
 LEROS_STORAGE_LOCAL_DIR="$ROOT_DIR/leros-storage"
 mkdir -p "$LEROS_STORAGE_LOCAL_DIR"
+# 中文注释：这里传 workspace 挂载根目录，后端会自行补齐 /{org}/{worker}/workspace。
+WORKSPACE_ROOT="${LEROS_WORKSPACE_ROOT:-$ROOT_DIR/.leros-workspace}"
 
 cd "$ROOT_DIR"
-LEROS_STORAGE_LOCAL_DIR="$LEROS_STORAGE_LOCAL_DIR" ./bundles/leros server --config "$CONFIG_FILE" --workspace-root "$ROOT_DIR/.leros-workspace/1/1/workspace"
+LEROS_STORAGE_LOCAL_DIR="$LEROS_STORAGE_LOCAL_DIR" ./bundles/leros server --config "$CONFIG_FILE" --workspace-root "$WORKSPACE_ROOT"

--- a/deployments/dev/dev-worker.sh
+++ b/deployments/dev/dev-worker.sh
@@ -64,5 +64,6 @@ fi
 echo -e "${BLUE}Starting worker (worker-id: 1, HTTP port 8081)...${NC}"
 
 cd "$ROOT_DIR"
-WORKSPACE_ROOT="${LEROS_WORKSPACE_ROOT:-$ROOT_DIR/.leros-workspace/1/1/workspace}"
+# 中文注释：worker 只接收 workspace 根目录，避免本地脚本把 org/worker/workspace 提前拼进去。
+WORKSPACE_ROOT="${LEROS_WORKSPACE_ROOT:-$ROOT_DIR/.leros-workspace}"
 LEROS_DEV=true ./bundles/leros worker --worker-id 1 --config "$CONFIG_FILE" --listen-addr :8081 --workspace-root "$WORKSPACE_ROOT"

--- a/deployments/dev/run-server-dev.ps1
+++ b/deployments/dev/run-server-dev.ps1
@@ -5,6 +5,7 @@ Import-DevEnvFile
 $root = Get-LerosRepoRoot
 $runtimeState = Get-ConfiguredDevRuntimeState
 $env:LEROS_STORAGE_LOCAL_DIR = "$root\leros-storage"
+$workspaceMountRoot = "$root\.leros-workspace"
 
 if (-not (Test-Path $env:LEROS_STORAGE_LOCAL_DIR)) {
     New-Item -ItemType Directory -Path $env:LEROS_STORAGE_LOCAL_DIR | Out-Null
@@ -14,4 +15,4 @@ $resolvedServerConfig = New-ResolvedServerConfig -RepoRoot $root -ServerPort $ru
 
 Set-Location $root
 Write-Host "[Leros][Server] Starting on http://localhost:$($runtimeState.serverPort)" -ForegroundColor Cyan
-& "$root\bundles\leros.exe" server --config $resolvedServerConfig --workspace-root "$root\.leros-workspace\1\1\workspace"
+& "$root\bundles\leros.exe" server --config $resolvedServerConfig --workspace-root $workspaceMountRoot

--- a/deployments/dev/run-worker-dev.ps1
+++ b/deployments/dev/run-worker-dev.ps1
@@ -5,9 +5,10 @@ Import-DevEnvFile
 $root = Get-LerosRepoRoot
 $runtimeState = Get-ConfiguredDevRuntimeState
 $env:LEROS_DEV = 'true'
+$workspaceMountRoot = "$root\.leros-workspace"
 
 $resolvedWorkerConfig = New-ResolvedWorkerConfig -RepoRoot $root -ServerPort $runtimeState.serverPort
 
 Set-Location $root
 Write-Host "[Leros][Worker] Starting on http://localhost:$($runtimeState.workerPort)" -ForegroundColor Cyan
-& "$root\bundles\leros.exe" worker --worker-id 1 --config $resolvedWorkerConfig --listen-addr ":$($runtimeState.workerPort)" --workspace-root "$root\.leros-workspace\1\1\workspace"
+& "$root\bundles\leros.exe" worker --worker-id 1 --config $resolvedWorkerConfig --listen-addr ":$($runtimeState.workerPort)" --workspace-root $workspaceMountRoot

--- a/deployments/dev/shared.ps1
+++ b/deployments/dev/shared.ps1
@@ -253,7 +253,7 @@ function Get-WorkerWorkspaceRoot {
         [string]$RepoRoot
     )
 
-    return Join-Path $RepoRoot '.leros-workspace\1\1\workspace'
+    return Join-Path $RepoRoot '.leros-workspace'
 }
 
 function Get-WorkerRecoveryDbPath {

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -908,6 +908,16 @@ function AccountManagementDialog({
 function ProfileAvatar({ user }: { user: AuthUser | null }) {
 	const displayPhone = getDisplayPhone(user);
 	const fallbackLabel = getAvatarInitial(user?.name ?? displayPhone ?? "Lework");
+	const setAuthUser = useAuthStore((s) => s.setAuthUser);
+
+	const handleProtectedAvatarNotFound = () => {
+		if (!user?.avatarUrl) return;
+		// 中文注释：头像文件如果已经失效，就把本地登录态里的旧下载地址清掉，避免每次刷新都重复命中 404。
+		setAuthUser({
+			...user,
+			avatarUrl: undefined,
+		});
+	};
 
 	return (
 		<span
@@ -918,6 +928,7 @@ function ProfileAvatar({ user }: { user: AuthUser | null }) {
 				src={user?.avatarUrl}
 				alt={user?.name ?? "Avatar"}
 				className="h-full w-full object-cover"
+				onProtectedSrcNotFound={handleProtectedAvatarNotFound}
 				fallback={
 					user ? (
 						<DiceBearAvatar
@@ -957,11 +968,13 @@ function ImageWithFallback({
 	alt,
 	className,
 	fallback,
+	onProtectedSrcNotFound,
 }: {
 	src?: string | null;
 	alt: string;
 	className: string;
 	fallback: React.ReactNode;
+	onProtectedSrcNotFound?: () => void;
 }) {
 	const [failed, setFailed] = useState(false);
 	const [imageURL, setImageURL] = useState<string | null>(() => getCachedAvatarDataURL(src));
@@ -991,14 +1004,20 @@ function ImageWithFallback({
 				cacheAvatarDataURL(src, dataURL);
 				setImageURL(dataURL);
 			})
-			.catch(() => {
-				if (!cancelled && !cachedAvatarURL) setFailed(true);
+			.catch((error) => {
+				if (cancelled) return;
+				const isNotFoundError =
+					error instanceof Error && (error.message === "HTTP 404" || error.message.includes("404"));
+				if (isNotFoundError) {
+					onProtectedSrcNotFound?.();
+				}
+				if (!cachedAvatarURL) setFailed(true);
 			});
 
 		return () => {
 			cancelled = true;
 		};
-	}, [src]);
+	}, [src, onProtectedSrcNotFound]);
 
 	if (!src || failed) return <>{fallback}</>;
 	const imageSrc = imageURL || src;

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -2,7 +2,9 @@
 
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import { formatTokenCount, projectFileApi, useChatStore, useLayoutStore } from "@leros/store";
+import { artifactApi } from "@leros/store/api/artifactApi";
 import { taskApi } from "@leros/store/api/taskApi";
+import type { ApiError } from "@leros/ui/lib/request";
 import { cn } from "@leros/ui/lib/utils";
 import {
 	ArrowDownToLine,
@@ -46,6 +48,14 @@ const TASK_DETAIL_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = "leros-task-detail-right-sid
 const TASK_DETAIL_RIGHT_SIDEBAR_DEFAULT_WIDTH = 352;
 const TASK_DETAIL_RIGHT_SIDEBAR_MIN_WIDTH = 300;
 const TASK_DETAIL_RIGHT_SIDEBAR_MAX_WIDTH = 440;
+
+function isDirectoryNotFoundError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null || !("status" in error)) {
+		return false;
+	}
+	const apiError = error as ApiError;
+	return apiError.status === 404 && apiError.message === "directory not found";
+}
 
 function truncateBreadcrumbText(text?: string | null, maxLength = 10) {
 	if (!text) {
@@ -157,18 +167,28 @@ export function TaskDetailPage({
 	const taskChatLayout = getProjectChatLayoutClasses(taskChatLayoutMode);
 
 	const fetchTaskFiles = useCallback(async () => {
-		if (!resolvedProjectId) return;
+		if (!resolvedProjectId || !resolvedTaskId) return;
 		try {
+			// 中文注释：先确认当前任务是否真的有产物；没有的话直接按空列表处理，避免对旧任务额外打 artifacts 目录 404。
+			const artifactResponse = await artifactApi.listTaskArtifacts(resolvedTaskId);
+			if ((artifactResponse.data.data ?? []).length === 0) {
+				setTaskFiles([]);
+				return;
+			}
 			const res = await projectFileApi.list({
 				projectId: resolvedProjectId,
 				path: "artifacts",
 			});
 			setTaskFiles(normalizeProjectFileTree(res.data.data));
 		} catch (err) {
+			if (isDirectoryNotFoundError(err)) {
+				setTaskFiles([]);
+				return;
+			}
 			console.error("TaskDetailPage fetch task files error:", err);
 			setTaskFiles([]);
 		}
-	}, [resolvedProjectId]);
+	}, [resolvedProjectId, resolvedTaskId]);
 
 	useEffect(() => {
 		fetchProjects();


### PR DESCRIPTION
修复本地 dev 下的文件与会话相关问题：

1. 调整 server/worker dev 脚本的 workspace-root，统一传入 `.leros-workspace` 根目录，避免本地路径被重复拼接，顺带修正 worker 恢复状态清理路径。
2. 任务详情页在没有产物文件时先按空列表处理，不再额外触发 `artifacts` 目录 404。
3. 左侧栏头像遇到失效的受保护下载地址时，自动清理本地登录态里的旧 avatarUrl，避免刷新页面持续触发 `/v1/files/:id/download` 404。

验证：
- `pnpm exec biome check packages/app-ui/components/layout/TaskDetailPage.tsx packages/app-ui/components/layout/LeftRail.tsx`