### PR TITLE
fix(app-ui): 优化左侧项目标题与输入框技能队友交互

### DIFF
--- a/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
+++ b/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
@@ -614,6 +614,27 @@ function CreateProjectDialog({
 												onValueChange={setSkillSearch}
 												placeholder="搜索技能"
 											/>
+											{selectedSkills.length > 0 && (
+												<div className="px-2 pb-2 pt-1">
+													<div className="mb-1 text-[11px] font-medium text-slate-400">
+														已选技能
+													</div>
+													<div className="flex flex-wrap gap-1.5">
+														{selectedSkills.map((skill) => (
+															<button
+																key={skill.code}
+																type="button"
+																aria-label={`移除技能 ${skill.label}`}
+																onClick={() => removeSkill(skill.code)}
+																className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
+															>
+																/{skill.label}
+																<X className="size-3" />
+															</button>
+														))}
+													</div>
+												</div>
+											)}
 											<CommandList className="max-h-64">
 												<CommandEmpty className="py-6 text-slate-400">
 													没有可继续添加的技能

--- a/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
+++ b/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
@@ -614,27 +614,6 @@ function CreateProjectDialog({
 												onValueChange={setSkillSearch}
 												placeholder="搜索技能"
 											/>
-											{selectedSkills.length > 0 && (
-												<div className="px-2 pb-2 pt-1">
-													<div className="mb-1 text-[11px] font-medium text-slate-400">
-														已选技能
-													</div>
-													<div className="flex flex-wrap gap-1.5">
-														{selectedSkills.map((skill) => (
-															<button
-																key={skill.code}
-																type="button"
-																aria-label={`移除技能 ${skill.label}`}
-																onClick={() => removeSkill(skill.code)}
-																className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-															>
-																/{skill.label}
-																<X className="size-3" />
-															</button>
-														))}
-													</div>
-												</div>
-											)}
 											<CommandList className="max-h-64">
 												<CommandEmpty className="py-6 text-slate-400">
 													没有可继续添加的技能

--- a/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
+++ b/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
@@ -599,7 +599,14 @@ function CreateProjectDialog({
 									>
 										+ 添加
 									</PopoverTrigger>
-									<PopoverContent align="end" sideOffset={10} className="w-[340px] p-1.5">
+									{/* 固定在按钮上方，避免创建项目弹窗内的技能选择层随空间动态换位。 */}
+									<PopoverContent
+										align="end"
+										side="top"
+										sideOffset={10}
+										collisionAvoidance={{ side: "none", align: "shift", fallbackAxisSide: "none" }}
+										className="w-[340px] p-1.5"
+									>
 										<Command shouldFilter={false} className="rounded-xl! bg-transparent p-0">
 											<div className="px-2 py-1 text-xs font-medium text-slate-400">选择技能</div>
 											<CommandInput
@@ -607,26 +614,6 @@ function CreateProjectDialog({
 												onValueChange={setSkillSearch}
 												placeholder="搜索技能"
 											/>
-											{selectedSkills.length > 0 && (
-												<div className="px-2 pb-2 pt-1">
-													<div className="mb-1 text-[11px] font-medium text-slate-400">
-														已选技能
-													</div>
-													<div className="flex flex-wrap gap-1.5">
-														{selectedSkills.map((skill) => (
-															<button
-																key={skill.code}
-																type="button"
-																onClick={() => removeSkill(skill.code)}
-																className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-															>
-																/{skill.label}
-																<X className="size-3" />
-															</button>
-														))}
-													</div>
-												</div>
-											)}
 											<CommandList className="max-h-64">
 												<CommandEmpty className="py-6 text-slate-400">
 													没有可继续添加的技能

--- a/frontend/packages/app-ui/components/chat/UserMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/UserMessageBubble.tsx
@@ -5,7 +5,7 @@ import type { Message, MessageAttachment } from "@leros/store/types/chat";
 import { Button } from "@leros/ui/components/ui/button";
 import { Check, Copy, ImageIcon, LoaderCircle } from "lucide-react";
 import { useEffect, useState } from "react";
-import { parseLeadingSkillDirectives, SkillDirectiveBadge } from "../common/SkillDirectiveBadge";
+import { SkillDirectiveBadge } from "../common/SkillDirectiveBadge";
 import { ProjectFileTypeIcon } from "../layout/project-file-type-icon";
 import { MessageAttachmentPreviewDialog } from "./MessageAttachmentPreviewDialog";
 
@@ -37,7 +37,6 @@ export function UserMessageBubble({
 }) {
 	const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
 	const visibleText = message.content.trim();
-	const skillContent = parseLeadingSkillDirectives(visibleText);
 	const attachments = message.attachments ?? [];
 
 	return (
@@ -69,18 +68,7 @@ export function UserMessageBubble({
 					)}
 					{visibleText && (
 						<div className="w-fit rounded-2xl rounded-tr-md text-black bg-[#f3f3f4] px-4 py-2 text-sm leading-7 shadow-sm shadow-blue-600/10">
-							{skillContent.skills.length > 0 ? (
-								<div className="flex flex-wrap items-center gap-1.5">
-									{skillContent.skills.map((skill) => (
-										<SkillDirectiveBadge key={skill} name={skill} variant="on-blue" />
-									))}
-									{skillContent.rest && (
-										<span className="whitespace-pre-wrap break-words">{skillContent.rest}</span>
-									)}
-								</div>
-							) : (
-								message.content
-							)}
+							<MessageContentWithComposerTokens message={message} />
 						</div>
 					)}
 				</div>
@@ -95,6 +83,56 @@ export function UserMessageBubble({
 			/>
 		</>
 	);
+}
+
+function MessageContentWithComposerTokens({ message }: { message: Message }) {
+	const tokens = (message.metadata?.composerTokens ?? [])
+		.filter((token) => message.content.slice(token.start, token.end) === token.label)
+		.sort((a, b) => a.start - b.start);
+
+	if (tokens.length === 0) {
+		// 中文注释：没有明确 token metadata 时，普通内容里的 @ 和 / 必须原样展示，不能靠文本猜样式。
+		return <span className="whitespace-pre-wrap break-words">{message.content}</span>;
+	}
+
+	const parts: React.ReactNode[] = [];
+	let cursor = 0;
+	tokens.forEach((token, index) => {
+		if (token.start > cursor) {
+			parts.push(
+				<span key={`text-${index}`} className="whitespace-pre-wrap break-words">
+					{message.content.slice(cursor, token.start)}
+				</span>,
+			);
+		}
+		parts.push(
+			token.kind === "skill" ? (
+				<SkillDirectiveBadge
+					key={`token-${index}`}
+					name={token.label.replace(/^\/+/, "")}
+					variant="on-blue"
+				/>
+			) : (
+				<span
+					key={`token-${index}`}
+					className="inline-flex max-w-full items-center rounded-md bg-blue-100 px-1.5 py-0.5 text-xs font-medium leading-none text-blue-700"
+				>
+					{token.label}
+				</span>
+			),
+		);
+		cursor = token.end;
+	});
+
+	if (cursor < message.content.length) {
+		parts.push(
+			<span key="text-tail" className="whitespace-pre-wrap break-words">
+				{message.content.slice(cursor)}
+			</span>,
+		);
+	}
+
+	return <div className="flex flex-wrap items-center gap-1.5">{parts}</div>;
 }
 
 function ImageAttachmentCard({

--- a/frontend/packages/app-ui/components/input/ChatInput.test.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@leros/store", () => ({
 			sendMessage: vi.fn(),
 			sendProjectMessage: mockSendProjectMessage,
 			submitApprovalDecision: vi.fn(),
+			submitQuestionAnswer: vi.fn(),
 			cancelGeneration: vi.fn(),
 			addAttachment: vi.fn(),
 			addUploadedAttachment: vi.fn(),
@@ -35,7 +36,23 @@ vi.mock("@leros/store", () => ({
 	useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) =>
 		selector({
 			activeProjectId: "project-1",
+			activeTaskDetailProjectId: null,
 			currentView: "project",
+			projects: [
+				{
+					id: "project-1",
+					name: "测试项目",
+					description: "",
+					emoji: "📁",
+					createdAt: "2026-06-26",
+					updatedAt: "2026-06-26",
+					tasks: [],
+					artifacts: [],
+					files: [],
+					messages: [],
+					skills: [],
+				},
+			],
 		}),
 }));
 
@@ -102,7 +119,12 @@ describe("ChatInput", () => {
 
 		await user.click(screen.getByRole("button", { name: "发送" }));
 
-		expect(mockSendProjectMessage).toHaveBeenCalledWith("项目首页首条提问", "project-1", []);
+		expect(mockSendProjectMessage).toHaveBeenCalledWith(
+			"项目首页首条提问",
+			"project-1",
+			[],
+			undefined,
+		);
 		expect(mockGoToTaskDetail).toHaveBeenCalledWith("project-1", "task-9", "session-7");
 	});
 });

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -5,7 +5,9 @@ import type {
 	ApprovalAction,
 	ApprovalRequest,
 	Attachment,
+	ComposerToken,
 	Message,
+	MessageMetadata,
 	QuestionRequest,
 } from "@leros/store/types/chat";
 import { Badge } from "@leros/ui/components/ui/badge";
@@ -123,9 +125,19 @@ export function ChatInput({
 		// 中文注释：输入区先做一次生成态拦截，避免回车绕过按钮态再次触发发送。
 		if (isGenerating) return;
 		// 仅上传附件而无文字时接口会报错，因此必须输入内容才可发送
-		if (inputText.trim()) {
+		const trimmedInput = inputText.trim();
+		if (trimmedInput) {
+			const composerMetadata = buildComposerMetadata(
+				inputText,
+				composerRef.current?.getComposerTokens() ?? [],
+			);
 			if (isProjectVariant && currentView === "project") {
-				const taskEntry = await sendProjectMessage(inputText, activeProjectId, inputAttachments);
+				const taskEntry = await sendProjectMessage(
+					trimmedInput,
+					activeProjectId,
+					inputAttachments,
+					composerMetadata,
+				);
 				if (taskEntry?.project_id && taskEntry?.task_id) {
 					// 中文注释：项目首页创建出真实任务后，立即跳到任务详情页，避免仍停留在项目首页的新建任务视图。
 					navigation?.goToTaskDetail(
@@ -136,7 +148,7 @@ export function ChatInput({
 				}
 				return;
 			}
-			sendMessage(inputText, inputAttachments);
+			sendMessage(trimmedInput, inputAttachments, composerMetadata);
 		}
 	}, [
 		inputText,
@@ -437,6 +449,23 @@ function findPendingQuestion(
 		if (question) return { message, question };
 	}
 	return null;
+}
+
+function buildComposerMetadata(
+	content: string,
+	tokens: ComposerToken[],
+): MessageMetadata | undefined {
+	const trimmed = content.trim();
+	if (!trimmed || tokens.length === 0) return undefined;
+	const leadingOffset = content.length - content.trimStart().length;
+	const composerTokens = tokens
+		.map((token) => ({
+			...token,
+			start: token.start - leadingOffset,
+			end: token.end - leadingOffset,
+		}))
+		.filter((token) => token.start >= 0 && trimmed.slice(token.start, token.end) === token.label);
+	return composerTokens.length > 0 ? { composerTokens } : undefined;
 }
 
 function projectSkillToComposerOption(skill: ProjectSkill): ComposerSkillOption {

--- a/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
+++ b/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@leros/ui/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@leros/ui/components/ui/popover";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Plus, Sparkles, WandSparkles } from "lucide-react";
+import { Bot, Plus, Sparkles, WandSparkles, X } from "lucide-react";
 import { type ReactNode, type RefObject, useEffect, useMemo, useState } from "react";
 import { mockAssistants } from "./mockDirectiveData";
 import type { ComposerSkillOption, StructuredComposerHandle } from "./StructuredComposer";
@@ -226,6 +226,25 @@ export function ComposerActionBar({
 					className="w-[320px] p-1.5"
 				>
 					<div className="mb-1 px-2 py-1 text-xs font-medium text-slate-400">选择 AI 队友</div>
+					{selectedAssistantNames.length > 0 && (
+						<div className="px-2 pb-2">
+							<div className="mb-1 text-[11px] font-medium text-slate-400">已选 AI 队友</div>
+							<div className="flex flex-wrap gap-1.5">
+								{selectedAssistantNames.map((name) => (
+									<button
+										key={name}
+										type="button"
+										aria-label={`移除 AI 队友 ${name}`}
+										onClick={() => composerRef.current?.removeAssistant(name)}
+										className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-[11px] text-blue-700 transition-colors hover:bg-blue-100"
+									>
+										@{name}
+										<X className="size-3" />
+									</button>
+								))}
+							</div>
+						</div>
+					)}
 					<div className="max-h-64 overflow-y-auto">
 						{filteredAssistants.length === 0 ? (
 							<div className="px-3 py-6 text-center text-sm text-slate-400">
@@ -291,6 +310,25 @@ export function ComposerActionBar({
 							onValueChange={setSkillSearch}
 							placeholder="搜索技能"
 						/>
+						{selectedSkillLabels.length > 0 && (
+							<div className="px-2 pb-2 pt-1">
+								<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
+								<div className="flex flex-wrap gap-1.5">
+									{selectedSkillLabels.map((label) => (
+										<button
+											key={label}
+											type="button"
+											aria-label={`移除技能 ${label}`}
+											onClick={() => composerRef.current?.removeSkill(label)}
+											className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
+										>
+											/{label}
+											<X className="size-3" />
+										</button>
+									))}
+								</div>
+							</div>
+						)}
 						<CommandList className="max-h-64">
 							<CommandEmpty className="py-6 text-slate-400">没有可继续添加的技能</CommandEmpty>
 							<CommandGroup className="p-0">

--- a/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
+++ b/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
@@ -24,6 +24,7 @@ type ComposerActionBarProps = {
 	children?: ReactNode;
 	className?: string;
 	projectSkillOptions?: ComposerSkillOption[];
+	disableAssistantAndSkill?: boolean;
 };
 
 type SkillOption = {
@@ -109,6 +110,7 @@ export function ComposerActionBar({
 	children,
 	className,
 	projectSkillOptions,
+	disableAssistantAndSkill = false,
 }: ComposerActionBarProps) {
 	const [assistantOpen, setAssistantOpen] = useState(false);
 	const [skillOpen, setSkillOpen] = useState(false);
@@ -139,10 +141,8 @@ export function ComposerActionBar({
 		return skillOptions.filter((skill) => {
 			if (selectedSkillLabels.includes(skill.label)) return false;
 			if (!query) return true;
-			return [skill.label, skill.code, skill.description, ...skill.keywords]
-				.join(" ")
-				.toLowerCase()
-				.includes(query);
+			// 中文注释：技能搜索只按名称/code 匹配，描述和标签不参与搜索，避免弱相关结果排在前面。
+			return [skill.label, skill.code].join(" ").toLowerCase().includes(query);
 		});
 	}, [selectedSkillLabels, skillOptions, skillSearch]);
 
@@ -176,6 +176,11 @@ export function ComposerActionBar({
 	}, [projectSkillOptions, skillOpen, skillsLoaded]);
 
 	const allowAction = () => (onBeforeAction ? onBeforeAction() : true);
+	const assistantSkillButtonClassName = cn(
+		"inline-flex items-center gap-2 rounded-full px-2 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900",
+		disableAssistantAndSkill &&
+			"cursor-not-allowed opacity-45 hover:bg-transparent hover:text-slate-600",
+	);
 
 	return (
 		<div className={cn("flex flex-wrap items-center gap-2", className)}>
@@ -195,14 +200,19 @@ export function ComposerActionBar({
 			<Popover open={assistantOpen} onOpenChange={setAssistantOpen}>
 				<PopoverTrigger
 					type="button"
+					disabled={disableAssistantAndSkill}
 					onClick={(event) => {
+						if (disableAssistantAndSkill) {
+							event.preventDefault();
+							return;
+						}
 						if (assistantOpen) return;
 						if (event.defaultPrevented) return;
 						if (!allowAction()) {
 							event.preventDefault();
 						}
 					}}
-					className="inline-flex items-center gap-2 rounded-full px-2 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
+					className={assistantSkillButtonClassName}
 				>
 					<Bot className="size-4" />
 					<span>召唤AI队友</span>
@@ -260,14 +270,19 @@ export function ComposerActionBar({
 			<Popover open={skillOpen} onOpenChange={setSkillOpen}>
 				<PopoverTrigger
 					type="button"
+					disabled={disableAssistantAndSkill}
 					onClick={(event) => {
+						if (disableAssistantAndSkill) {
+							event.preventDefault();
+							return;
+						}
 						if (skillOpen) return;
 						if (event.defaultPrevented) return;
 						if (!allowAction()) {
 							event.preventDefault();
 						}
 					}}
-					className="inline-flex items-center gap-2 rounded-full px-2 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
+					className={assistantSkillButtonClassName}
 				>
 					<WandSparkles className="size-4" />
 					<span>添加技能</span>

--- a/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
+++ b/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@leros/ui/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@leros/ui/components/ui/popover";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Plus, Sparkles, WandSparkles, X } from "lucide-react";
+import { Bot, Plus, Sparkles, WandSparkles } from "lucide-react";
 import { type ReactNode, type RefObject, useEffect, useMemo, useState } from "react";
 import { mockAssistants } from "./mockDirectiveData";
 import type { ComposerSkillOption, StructuredComposerHandle } from "./StructuredComposer";
@@ -217,26 +217,15 @@ export function ComposerActionBar({
 					<Bot className="size-4" />
 					<span>召唤AI队友</span>
 				</PopoverTrigger>
-				<PopoverContent align="start" side="top" sideOffset={10} className="w-[320px] p-1.5">
+				{/* 固定在按钮上方，避免视口碰撞策略把选择弹窗动态翻到下方。 */}
+				<PopoverContent
+					align="start"
+					side="top"
+					sideOffset={10}
+					collisionAvoidance={{ side: "none", align: "shift", fallbackAxisSide: "none" }}
+					className="w-[320px] p-1.5"
+				>
 					<div className="mb-1 px-2 py-1 text-xs font-medium text-slate-400">选择 AI 队友</div>
-					{selectedAssistantNames.length > 0 && (
-						<div className="px-2 pb-2">
-							<div className="mb-1 text-[11px] font-medium text-slate-400">已选 AI 队友</div>
-							<div className="flex flex-wrap gap-1.5">
-								{selectedAssistantNames.map((name) => (
-									<button
-										key={name}
-										type="button"
-										onClick={() => composerRef.current?.removeAssistant(name)}
-										className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-[11px] text-blue-700 transition-colors hover:bg-blue-100"
-									>
-										@{name}
-										<X className="size-3" />
-									</button>
-								))}
-							</div>
-						</div>
-					)}
 					<div className="max-h-64 overflow-y-auto">
 						{filteredAssistants.length === 0 ? (
 							<div className="px-3 py-6 text-center text-sm text-slate-400">
@@ -287,7 +276,14 @@ export function ComposerActionBar({
 					<WandSparkles className="size-4" />
 					<span>添加技能</span>
 				</PopoverTrigger>
-				<PopoverContent align="start" side="top" sideOffset={10} className="w-[340px] p-1.5">
+				{/* 固定在按钮上方，避免视口碰撞策略把选择弹窗动态翻到下方。 */}
+				<PopoverContent
+					align="start"
+					side="top"
+					sideOffset={10}
+					collisionAvoidance={{ side: "none", align: "shift", fallbackAxisSide: "none" }}
+					className="w-[340px] p-1.5"
+				>
 					<Command shouldFilter={false} className="rounded-xl! bg-transparent p-0">
 						<div className="px-2 py-1 text-xs font-medium text-slate-400">选择技能</div>
 						<CommandInput
@@ -295,24 +291,6 @@ export function ComposerActionBar({
 							onValueChange={setSkillSearch}
 							placeholder="搜索技能"
 						/>
-						{selectedSkillLabels.length > 0 && (
-							<div className="px-2 pb-2 pt-1">
-								<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
-								<div className="flex flex-wrap gap-1.5">
-									{selectedSkillLabels.map((label) => (
-										<button
-											key={label}
-											type="button"
-											onClick={() => composerRef.current?.removeSkill(label)}
-											className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-										>
-											/{label}
-											<X className="size-3" />
-										</button>
-									))}
-								</div>
-							</div>
-						)}
 						<CommandList className="max-h-64">
 							<CommandEmpty className="py-6 text-slate-400">没有可继续添加的技能</CommandEmpty>
 							<CommandGroup className="p-0">

--- a/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
@@ -1,0 +1,87 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ComposerSkillOption, StructuredComposer } from "./StructuredComposer";
+
+class ResizeObserverMock {
+	observe() {
+		// 中文注释：测试环境只需要占位实现，避免命令面板依赖浏览器原生 ResizeObserver。
+	}
+	unobserve() {
+		// 中文注释：测试环境不需要真实解绑逻辑。
+	}
+	disconnect() {
+		// 中文注释：测试环境不需要真实断开逻辑。
+	}
+}
+
+Object.defineProperty(window, "ResizeObserver", {
+	writable: true,
+	value: ResizeObserverMock,
+});
+
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+	writable: true,
+	value: vi.fn(),
+});
+
+function TestHarness({
+	projectSkillOptions,
+	onValueChange,
+}: {
+	projectSkillOptions: ComposerSkillOption[];
+	onValueChange?: (value: string) => void;
+}) {
+	const [value, setValue] = useState("");
+
+	return (
+		<StructuredComposer
+			value={value}
+			onChange={(nextValue) => {
+				// 中文注释：用受控状态承接真实输入链路，确保测试覆盖到选择技能后的最终文本结果。
+				setValue(nextValue);
+				onValueChange?.(nextValue);
+			}}
+			onSubmit={vi.fn()}
+			onPasteFiles={vi.fn()}
+			onFocus={vi.fn()}
+			onBlur={vi.fn()}
+			placeholder="请输入"
+			isProjectVariant
+			projectSkillOptions={projectSkillOptions}
+		/>
+	);
+}
+
+describe("StructuredComposer", () => {
+	it("通过 / 选择技能后会补齐尾部空格", async () => {
+		const user = userEvent.setup();
+		const handleValueChange = vi.fn();
+
+		render(
+			<TestHarness
+				onValueChange={handleValueChange}
+				projectSkillOptions={[
+					{
+						code: "doc-coauthoring",
+						label: "doc-coauthoring",
+						description: "doc",
+						keywords: [],
+					},
+				]}
+			/>,
+		);
+
+		const textbox = screen.getByRole("textbox", { name: "请输入" });
+		await user.click(textbox);
+		await user.keyboard("/");
+		await user.keyboard("{Enter}");
+
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("/doc-coauthoring ");
+		});
+	});
+});

--- a/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRef, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-
+import { ComposerActionBar } from "./ComposerActionBar";
 import {
 	type ComposerSkillOption,
 	StructuredComposer,
@@ -92,6 +92,51 @@ function ToolbarHarness({ onValueChange }: { onValueChange?: (value: string) => 
 				placeholder="请输入"
 				isProjectVariant
 				projectSkillOptions={[]}
+			/>
+		</div>
+	);
+}
+
+function ActionBarHarness({ onValueChange }: { onValueChange?: (value: string) => void }) {
+	const [value, setValue] = useState("");
+	const composerRef = useRef<StructuredComposerHandle | null>(null);
+	const projectSkillOptions: ComposerSkillOption[] = [
+		{
+			code: "anysearch",
+			label: "anysearch",
+			description: "search",
+			keywords: [],
+		},
+		{
+			code: "docx",
+			label: "docx",
+			description: "docx",
+			keywords: [],
+		},
+	];
+
+	return (
+		<div>
+			<StructuredComposer
+				ref={composerRef}
+				value={value}
+				onChange={(nextValue) => {
+					// 中文注释：用真实工具栏驱动受控输入框，覆盖弹窗已选区删除后的 token 同步。
+					setValue(nextValue);
+					onValueChange?.(nextValue);
+				}}
+				onSubmit={vi.fn()}
+				onPasteFiles={vi.fn()}
+				onFocus={vi.fn()}
+				onBlur={vi.fn()}
+				placeholder="请输入"
+				isProjectVariant
+				projectSkillOptions={projectSkillOptions}
+			/>
+			<ComposerActionBar
+				inputValue={value}
+				composerRef={composerRef}
+				projectSkillOptions={projectSkillOptions}
 			/>
 		</div>
 	);
@@ -210,6 +255,40 @@ describe("StructuredComposer", () => {
 			expect(mentions).toHaveLength(2);
 			expect(mentions[0]).toHaveAttribute("data-mention-label", "/anysearch");
 			expect(mentions[1]).toHaveAttribute("data-mention-label", "/docx");
+		});
+	});
+
+	it("工具栏弹窗已选技能可删除且剩余技能保持 mention 样式", async () => {
+		const user = userEvent.setup();
+		const handleValueChange = vi.fn();
+
+		render(<ActionBarHarness onValueChange={handleValueChange} />);
+
+		const textbox = screen.getByRole("textbox", { name: "请输入" });
+		await user.click(screen.getByRole("button", { name: "添加技能" }));
+		await user.click(await screen.findByText("/anysearch"));
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("/anysearch ");
+		});
+		expect(screen.getByRole("button", { name: "移除技能 anysearch" })).toBeInTheDocument();
+
+		await user.click(await screen.findByText("/docx"));
+		await waitFor(() => {
+			const mentions = textbox.querySelectorAll(
+				'[data-mention-node="true"][data-mention-kind="skill"]',
+			);
+			expect(mentions).toHaveLength(2);
+		});
+
+		await user.click(screen.getByRole("button", { name: "移除技能 anysearch" }));
+
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("/docx ");
+			const mentions = textbox.querySelectorAll(
+				'[data-mention-node="true"][data-mention-kind="skill"]',
+			);
+			expect(mentions).toHaveLength(1);
+			expect(mentions[0]).toHaveAttribute("data-mention-label", "/docx");
 		});
 	});
 });

--- a/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
@@ -1,10 +1,14 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { useRef, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { type ComposerSkillOption, StructuredComposer } from "./StructuredComposer";
+import {
+	type ComposerSkillOption,
+	StructuredComposer,
+	type StructuredComposerHandle,
+} from "./StructuredComposer";
 
 class ResizeObserverMock {
 	observe() {
@@ -26,6 +30,10 @@ Object.defineProperty(window, "ResizeObserver", {
 Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
 	writable: true,
 	value: vi.fn(),
+});
+
+afterEach(() => {
+	cleanup();
 });
 
 function TestHarness({
@@ -56,6 +64,39 @@ function TestHarness({
 	);
 }
 
+function ToolbarHarness({ onValueChange }: { onValueChange?: (value: string) => void }) {
+	const [value, setValue] = useState("");
+	const composerRef = useRef<StructuredComposerHandle | null>(null);
+
+	return (
+		<div>
+			<input aria-label="技能搜索" />
+			<button type="button" onClick={() => composerRef.current?.insertSkill("anysearch")}>
+				anysearch
+			</button>
+			<button type="button" onClick={() => composerRef.current?.insertSkill("docx")}>
+				docx
+			</button>
+			<StructuredComposer
+				ref={composerRef}
+				value={value}
+				onChange={(nextValue) => {
+					// 中文注释：模拟工具栏弹窗通过 ref 写入输入框，覆盖弹窗搜索框抢焦点后的插入链路。
+					setValue(nextValue);
+					onValueChange?.(nextValue);
+				}}
+				onSubmit={vi.fn()}
+				onPasteFiles={vi.fn()}
+				onFocus={vi.fn()}
+				onBlur={vi.fn()}
+				placeholder="请输入"
+				isProjectVariant
+				projectSkillOptions={[]}
+			/>
+		</div>
+	);
+}
+
 describe("StructuredComposer", () => {
 	it("通过 / 选择技能后会补齐尾部空格", async () => {
 		const user = userEvent.setup();
@@ -82,6 +123,93 @@ describe("StructuredComposer", () => {
 
 		await waitFor(() => {
 			expect(handleValueChange).toHaveBeenLastCalledWith("/doc-coauthoring ");
+		});
+		await waitFor(() => {
+			const mention = textbox.querySelector(
+				'[data-mention-node="true"][data-mention-kind="skill"]',
+			);
+			expect(mention).toBeInTheDocument();
+			expect(mention).toHaveAttribute("data-mention-label", "/doc-coauthoring");
+		});
+	});
+
+	it("连续选择多个技能时第一个技能仍保持 mention 样式", async () => {
+		const user = userEvent.setup();
+		const handleValueChange = vi.fn();
+
+		render(
+			<TestHarness
+				onValueChange={handleValueChange}
+				projectSkillOptions={[
+					{
+						code: "doc-coauthoring",
+						label: "doc-coauthoring",
+						description: "doc",
+						keywords: [],
+					},
+					{
+						code: "weather",
+						label: "weather",
+						description: "weather",
+						keywords: [],
+					},
+				]}
+			/>,
+		);
+
+		const textbox = screen.getByRole("textbox", { name: "请输入" });
+		await user.click(textbox);
+		await user.keyboard("/");
+		await user.keyboard("{Enter}");
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("/doc-coauthoring ");
+		});
+
+		await user.keyboard("/");
+		await user.click(await screen.findByText("/weather"));
+
+		await waitFor(() => {
+			const mentions = textbox.querySelectorAll(
+				'[data-mention-node="true"][data-mention-kind="skill"]',
+			);
+			// 中文注释：这里直接验证第一个技能节点仍是 mention，覆盖首个技能退化成纯文本的回归。
+			expect(mentions).toHaveLength(2);
+			expect(mentions[0]).toHaveAttribute("data-mention-label", "/doc-coauthoring");
+			expect(mentions[1]).toHaveAttribute("data-mention-label", "/weather");
+		});
+	});
+
+	it("工具栏弹窗连续添加技能时第一个技能仍保持 mention 样式", async () => {
+		const user = userEvent.setup();
+		const handleValueChange = vi.fn();
+
+		render(<ToolbarHarness onValueChange={handleValueChange} />);
+
+		const searchInput = screen.getByRole("textbox", { name: "技能搜索" });
+		const textbox = screen.getByRole("textbox", { name: "请输入" });
+		await user.click(searchInput);
+		await user.keyboard("anysearch");
+		await user.click(screen.getByRole("button", { name: "anysearch" }));
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("/anysearch ");
+		});
+		await waitFor(() => {
+			const mention = textbox.querySelector(
+				'[data-mention-node="true"][data-mention-kind="skill"]',
+			);
+			expect(mention).toHaveAttribute("data-mention-label", "/anysearch");
+		});
+
+		await user.click(searchInput);
+		await user.click(screen.getByRole("button", { name: "docx" }));
+
+		await waitFor(() => {
+			const mentions = textbox.querySelectorAll(
+				'[data-mention-node="true"][data-mention-kind="skill"]',
+			);
+			expect(mentions).toHaveLength(2);
+			expect(mentions[0]).toHaveAttribute("data-mention-label", "/anysearch");
+			expect(mentions[1]).toHaveAttribute("data-mention-label", "/docx");
 		});
 	});
 });

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -568,6 +568,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		const composingRef = useRef(false);
 		const pendingCaretRef = useRef<number | null>(null);
 		const dismissedTriggerStartRef = useRef<number | null>(null);
+		const shouldAutoScrollPickerRef = useRef(false);
 
 		const assistantOptions = useMemo<AssistantOption[]>(() => mockAssistants, []);
 		const displayTokens = useMemo(() => resolveDisplayTokens(value, tokens), [tokens, value]);
@@ -672,6 +673,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 
 		useEffect(() => {
 			if (!activePickerValue) return;
+			if (!shouldAutoScrollPickerRef.current) return;
 
 			requestAnimationFrame(() => {
 				const picker = pickerRef.current;
@@ -682,6 +684,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				).find((item) => item.dataset.pickerItemValue === activePickerValue);
 
 				activeItem?.scrollIntoView({ block: "nearest" });
+				shouldAutoScrollPickerRef.current = false;
 			});
 		}, [activePickerValue]);
 
@@ -1026,6 +1029,8 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				if (trigger) {
 					if (event.key === "ArrowDown" || event.key === "ArrowUp") {
 						event.preventDefault();
+						// 中文注释：只在键盘切换高亮项时自动滚动列表，避免鼠标移入触发 cmdk 高亮时出现列表跳动。
+						shouldAutoScrollPickerRef.current = true;
 						const direction = event.key === "ArrowDown" ? 1 : -1;
 						setActiveIndex((current) => {
 							if (pickerItemCount === 0) return 0;

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { type SkillInstalledItem, skillMarketplaceApi } from "@leros/store";
+import type { ComposerToken } from "@leros/store/types/chat";
 import {
 	Command,
 	CommandEmpty,
 	CommandGroup,
+	CommandInput,
 	CommandItem,
 	CommandList,
 } from "@leros/ui/components/ui/command";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Sparkles, TerminalSquare, X } from "lucide-react";
+import { Bot, Sparkles, X } from "lucide-react";
 import {
 	forwardRef,
 	type MouseEvent,
@@ -20,11 +22,11 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { type ChatCommand, mockAssistants, mockChatCommands } from "./mockDirectiveData";
+import { mockAssistants } from "./mockDirectiveData";
 
 type DirectiveKind = "assistant" | "command";
 type TokenKind = "assistant" | "skill";
-type SelectionKind = DirectiveKind | "skill";
+type SelectionKind = "assistant" | "skill";
 
 type ActiveTrigger = {
 	kind: DirectiveKind;
@@ -53,15 +55,10 @@ export type ComposerSkillOption = {
 	keywords: string[];
 };
 
-type CommandOption =
-	| {
-			kind: "skill";
-			item: ComposerSkillOption;
-	  }
-	| {
-			kind: "command";
-			item: ChatCommand;
-	  };
+type CommandOption = {
+	kind: "skill";
+	item: ComposerSkillOption;
+};
 
 type EditorSnapshot = {
 	text: string;
@@ -75,6 +72,7 @@ export type StructuredComposerHandle = {
 	insertSkill: (skillLabel: string) => void;
 	removeAssistant: (assistantName: string) => void;
 	removeSkill: (skillLabel: string) => void;
+	getComposerTokens: () => ComposerToken[];
 };
 
 type StructuredComposerProps = {
@@ -87,6 +85,7 @@ type StructuredComposerProps = {
 	placeholder: string;
 	isProjectVariant: boolean;
 	projectSkillOptions?: ComposerSkillOption[];
+	directivesDisabled?: boolean;
 };
 
 function findTrigger(value: string, cursor: number): ActiveTrigger | null {
@@ -147,14 +146,12 @@ function installedSkillToOption(skill: SkillInstalledItem): ComposerSkillOption 
 }
 
 function matchesCommandQuery(
-	option: Pick<ComposerSkillOption, "label" | "code" | "description" | "keywords">,
+	option: Pick<ComposerSkillOption, "label" | "code">,
 	query: string,
 ): boolean {
 	if (!query) return true;
-	return [option.label, option.code, option.description, ...option.keywords]
-		.join(" ")
-		.toLowerCase()
-		.includes(query);
+	// 中文注释：技能弹窗搜索只按技能名称匹配，避免描述里的英文命中导致结果看起来不相关。
+	return [option.label, option.code].join(" ").toLowerCase().includes(query);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -213,68 +210,9 @@ function commandPickerValue(option: CommandOption): string {
 	return `${option.kind}:${option.item.code}`;
 }
 
-function inferAssistantTokensFromValue(value: string): InsertedToken[] {
-	const tokens: InsertedToken[] = [];
-
-	for (const match of value.matchAll(/(?:^|\s)(@[^\s@/]+)/g)) {
-		const label = match[1] ?? "";
-		const start = (match.index ?? 0) + match[0].length - label.length;
-		tokens.push({
-			label,
-			start,
-			end: start + label.length,
-			kind: "assistant",
-		});
-	}
-
-	return tokens;
-}
-
-function inferSkillTokensFromValue(value: string): InsertedToken[] {
-	const tokens: InsertedToken[] = [];
-
-	for (const match of value.matchAll(/(?:^|\s)(\/[^\s@/]+)/g)) {
-		const label = match[1] ?? "";
-		const start = (match.index ?? 0) + match[0].length - label.length;
-		tokens.push({
-			label,
-			start,
-			end: start + label.length,
-			kind: "skill",
-		});
-	}
-
-	return tokens;
-}
-
-function inferTokensFromValue(value: string): InsertedToken[] {
-	return sortTokens([...inferAssistantTokensFromValue(value), ...inferSkillTokensFromValue(value)]);
-}
-
-function tokenRangesOverlap(left: InsertedToken, right: InsertedToken): boolean {
-	return !(left.end <= right.start || left.start >= right.end);
-}
-
-// 中文注释：合并 state 中已记录的 token 与从纯文本推断出的 token，避免仅有 AI 队友时已选技能丢失 pill 样式。
 function resolveDisplayTokens(value: string, tokens: InsertedToken[]): InsertedToken[] {
-	const validFromState = sortTokens(
-		tokens.filter((token) => value.slice(token.start, token.end) === token.label),
-	);
-	const inferred = inferTokensFromValue(value);
-
-	if (validFromState.length === 0) {
-		return inferred;
-	}
-
-	const merged = [...validFromState];
-	for (const token of inferred) {
-		const alreadyCovered = merged.some((existing) => tokenRangesOverlap(existing, token));
-		if (!alreadyCovered) {
-			merged.push(token);
-		}
-	}
-
-	return sortTokens(merged);
+	// 中文注释：只有通过弹窗/按钮明确选中的队友和技能才渲染成 token，普通文本里的 @ 或 / 保持原样。
+	return sortTokens(tokens.filter((token) => value.slice(token.start, token.end) === token.label));
 }
 
 function isCursorInsideToken(cursor: number, tokens: InsertedToken[]): boolean {
@@ -613,6 +551,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 			placeholder,
 			isProjectVariant,
 			projectSkillOptions,
+			directivesDisabled = false,
 		},
 		ref,
 	) {
@@ -620,6 +559,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		const pickerRef = useRef<HTMLDivElement>(null);
 		const [trigger, setTrigger] = useState<ActiveTrigger | null>(null);
 		const [activeIndex, setActiveIndex] = useState(0);
+		const [commandSearch, setCommandSearch] = useState("");
 		const [tokens, setTokens] = useState<InsertedToken[]>([]);
 		const [skillOptions, setSkillOptions] = useState<ComposerSkillOption[]>([]);
 		const [skillsLoading, setSkillsLoading] = useState(false);
@@ -627,6 +567,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		const [skillsError, setSkillsError] = useState<string | null>(null);
 		const composingRef = useRef(false);
 		const pendingCaretRef = useRef<number | null>(null);
+		const dismissedTriggerStartRef = useRef<number | null>(null);
 
 		const assistantOptions = useMemo<AssistantOption[]>(() => mockAssistants, []);
 		const displayTokens = useMemo(() => resolveDisplayTokens(value, tokens), [tokens, value]);
@@ -662,24 +603,16 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		}, [assistantOptions, selectedAssistantNames, trigger]);
 
 		const filteredSkills = useMemo(() => {
-			const query = normalizeSearchValue(trigger?.kind === "command" ? trigger.query : "");
+			const query = normalizeSearchValue(trigger?.kind === "command" ? commandSearch : "");
 			return skillOptions.filter((skill) => {
 				if (selectedSkillLabels.includes(skill.label)) return false;
 				return matchesCommandQuery(skill, query);
 			});
-		}, [selectedSkillLabels, skillOptions, trigger]);
-
-		const filteredCommands = useMemo(() => {
-			const query = normalizeSearchValue(trigger?.kind === "command" ? trigger.query : "");
-			return mockChatCommands.filter((command) => matchesCommandQuery(command, query));
-		}, [trigger]);
+		}, [commandSearch, selectedSkillLabels, skillOptions, trigger]);
 
 		const commandOptions = useMemo<CommandOption[]>(
-			() => [
-				...filteredSkills.map((item) => ({ kind: "skill" as const, item })),
-				...filteredCommands.map((item) => ({ kind: "command" as const, item })),
-			],
-			[filteredCommands, filteredSkills],
+			() => filteredSkills.map((item) => ({ kind: "skill" as const, item })),
+			[filteredSkills],
 		);
 
 		const pickerItemCount =
@@ -695,9 +628,47 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 			return option ? commandPickerValue(option) : "";
 		}, [activeIndex, commandOptions, filteredAssistants, trigger]);
 
+		const focusAt = useCallback((cursor: number) => {
+			requestAnimationFrame(() => {
+				const editor = editorRef.current;
+				if (!editor) return;
+				editor.focus();
+				setCaretOffset(editor, cursor);
+			});
+		}, []);
+
+		const getActiveTrigger = useCallback((text: string, caret: number) => {
+			const nextTrigger = findTrigger(text, caret);
+			if (!nextTrigger) return null;
+			if (nextTrigger.start === dismissedTriggerStartRef.current) return null;
+			return nextTrigger;
+		}, []);
+
+		const dismissTrigger = useCallback((rememberCurrent = true) => {
+			setTrigger((current) => {
+				if (rememberCurrent) {
+					dismissedTriggerStartRef.current = current?.start ?? null;
+				}
+				return null;
+			});
+		}, []);
+
 		useEffect(() => {
 			setActiveIndex(0);
 		}, [trigger?.kind, trigger?.query]);
+
+		useEffect(() => {
+			if (trigger?.kind !== "command") {
+				setCommandSearch("");
+				return;
+			}
+
+			setCommandSearch(trigger.query);
+			requestAnimationFrame(() => {
+				// 中文注释：通过 / 打开技能选择后，焦点直接进入弹窗搜索框，避免继续输入写回外层编辑器。
+				pickerRef.current?.querySelector<HTMLInputElement>('[data-slot="command-input"]')?.focus();
+			});
+		}, [trigger]);
 
 		useEffect(() => {
 			if (!activePickerValue) return;
@@ -735,8 +706,14 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		useEffect(() => {
 			if (!isEmptyEditorValue(value)) return;
 			setTokens([]);
-			setTrigger(null);
-		}, [value]);
+			dismissTrigger(false);
+			dismissedTriggerStartRef.current = null;
+		}, [dismissTrigger, value]);
+
+		useEffect(() => {
+			if (!directivesDisabled) return;
+			dismissTrigger(false);
+		}, [directivesDisabled, dismissTrigger]);
 
 		useEffect(() => {
 			if (projectSkillOptions) {
@@ -767,15 +744,6 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				});
 		}, [projectSkillOptions, skillsLoaded, trigger?.kind]);
 
-		const focusAt = useCallback((cursor: number) => {
-			requestAnimationFrame(() => {
-				const editor = editorRef.current;
-				if (!editor) return;
-				editor.focus();
-				setCaretOffset(editor, cursor);
-			});
-		}, []);
-
 		const syncFromEditor = useCallback(() => {
 			const editor = editorRef.current;
 			if (!editor) return;
@@ -786,12 +754,23 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 			const text = isEmptyEditorValue(snapshot.text) ? "" : snapshot.text;
 			onChange(text);
 
+			if (
+				dismissedTriggerStartRef.current !== null &&
+				!["@", "/"].includes(text[dismissedTriggerStartRef.current] ?? "")
+			) {
+				dismissedTriggerStartRef.current = null;
+			}
+
 			if (!composingRef.current) {
 				const caret = getCaretOffset(editor);
 				const nextTokens = resolveDisplayTokens(text, snapshot.tokens);
-				setTrigger(isCursorInsideToken(caret, nextTokens) ? null : findTrigger(text, caret));
+				setTrigger(
+					directivesDisabled || isCursorInsideToken(caret, nextTokens)
+						? null
+						: getActiveTrigger(text, caret),
+				);
 			}
-		}, [onChange]);
+		}, [directivesDisabled, getActiveTrigger, onChange]);
 
 		const handlePaste = useCallback(
 			(event: React.ClipboardEvent<HTMLDivElement>) => {
@@ -823,16 +802,17 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				pendingCaretRef.current = nextCaret;
 
 				if (!composingRef.current) {
-					setTrigger(findTrigger(nextValue, nextCaret));
+					setTrigger(directivesDisabled ? null : getActiveTrigger(nextValue, nextCaret));
 				}
 
 				focusAt(nextCaret);
 			},
-			[focusAt, onChange, onPasteFiles, value],
+			[directivesDisabled, focusAt, getActiveTrigger, onChange, onPasteFiles, value],
 		);
 
 		const insertTrigger = useCallback(
 			(kind: DirectiveKind) => {
+				if (directivesDisabled) return;
 				const editor = editorRef.current;
 				if (!editor) return;
 
@@ -847,10 +827,11 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				setTokens((current) => shiftTokensForTextEdit(current, value, nextValue));
 				onChange(nextValue);
 				pendingCaretRef.current = markerStart + 1;
+				dismissedTriggerStartRef.current = null;
 				setTrigger({ kind, start: markerStart, end: markerStart + 1, query: "" });
 				focusAt(markerStart + 1);
 			},
-			[focusAt, onChange, value],
+			[directivesDisabled, focusAt, onChange, value],
 		);
 
 		const insertToolbarToken = useCallback(
@@ -858,7 +839,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				const editor = editorRef.current;
 				const cursor = editor ? getCaretOffset(editor) : value.length;
 				const needsLeadingSpace = cursor > 0 && !/\s/.test(value[cursor - 1] ?? "");
-				const needsTrailingSpace = cursor < value.length && !/\s/.test(value[cursor] ?? "");
+				const needsTrailingSpace = !/\s/.test(value[cursor] ?? "");
 				const insertion = `${needsLeadingSpace ? " " : ""}${rawLabel}${needsTrailingSpace ? " " : ""}`;
 				const tokenStart = cursor + (needsLeadingSpace ? 1 : 0);
 				const nextValue = `${value.slice(0, cursor)}${insertion}${value.slice(cursor)}`;
@@ -873,11 +854,12 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					shiftTokensForInsert(current, cursor, cursor, insertedToken, insertion.length),
 				);
 				onChange(nextValue);
-				setTrigger(null);
+				dismissedTriggerStartRef.current = null;
+				dismissTrigger(false);
 				pendingCaretRef.current = tokenStart + rawLabel.length + (needsTrailingSpace ? 1 : 0);
 				focusAt(tokenStart + rawLabel.length + (needsTrailingSpace ? 1 : 0));
 			},
-			[focusAt, onChange, value],
+			[dismissTrigger, focusAt, onChange, value],
 		);
 
 		const removeMentionToken = useCallback(
@@ -901,11 +883,11 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				// 中文注释：从已选 tag 区域移除时，同步删除输入框里的 mention token 和对应纯文本。
 				setTokens((current) => shiftTokensForTextEdit(current, value, nextValue));
 				onChange(nextValue);
-				setTrigger(null);
+				dismissTrigger(false);
 				pendingCaretRef.current = start;
 				focusAt(start);
 			},
-			[focusAt, onChange, tokens, value],
+			[dismissTrigger, focusAt, onChange, tokens, value],
 		);
 
 		const removeAssistantToken = useCallback(
@@ -928,32 +910,34 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				insertSkill: (skillLabel: string) => insertToolbarToken("skill", `/${skillLabel}`),
 				removeAssistant: removeAssistantToken,
 				removeSkill: removeSkillToken,
+				getComposerTokens: () => resolveDisplayTokens(value, tokens),
 			}),
-			[insertToolbarToken, insertTrigger, removeAssistantToken, removeSkillToken],
+			[insertToolbarToken, insertTrigger, removeAssistantToken, removeSkillToken, tokens, value],
 		);
 
 		const selectToken = useCallback(
 			(
 				kind: SelectionKind,
-				option: AssistantOption | ChatCommand | ComposerSkillOption,
+				option: AssistantOption | ComposerSkillOption,
 				activeTrigger: ActiveTrigger,
 			) => {
 				const isAssistant = kind === "assistant";
 				const assistantName = isAssistant ? (option as AssistantOption).name : "";
 				const skillLabel = kind === "skill" ? (option as ComposerSkillOption).label : "";
 				if (isAssistant && selectedAssistantNames.includes(assistantName)) {
-					setTrigger(null);
+					dismissTrigger(false);
 					return;
 				}
 				if (kind === "skill" && selectedSkillLabels.includes(skillLabel)) {
-					setTrigger(null);
+					dismissTrigger(false);
 					return;
 				}
 				const label = isAssistant
 					? `@${(option as AssistantOption).name}`
-					: `/${(option as ChatCommand | ComposerSkillOption).label}`;
+					: `/${(option as ComposerSkillOption).label}`;
 				const followingText = value.slice(activeTrigger.end);
-				const trailingSpace = followingText.startsWith(" ") ? "" : " ";
+				// 中文注释：token 后保留一个正文分隔空格，避免继续输入时被当成同一个 / 或 @ 指令查询。
+				const trailingSpace = /^\s/.test(followingText) ? "" : " ";
 				const nextValue = `${value.slice(
 					0,
 					activeTrigger.start,
@@ -977,7 +961,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 							delta,
 						),
 					);
-				} else if (kind === "skill") {
+				} else {
 					const insertedToken: InsertedToken = {
 						label,
 						start: activeTrigger.start,
@@ -996,16 +980,15 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 							delta,
 						),
 					);
-				} else {
-					setTokens((current) => shiftTokensForTextEdit(current, value, nextValue));
 				}
 				onChange(nextValue);
-				setTrigger(null);
+				dismissedTriggerStartRef.current = null;
+				dismissTrigger(false);
 				// mention 节点插入后，显式恢复光标到节点后面的正文位置，避免落到不可编辑节点内部。
 				pendingCaretRef.current = activeTrigger.start + label.length + trailingSpace.length;
 				focusAt(activeTrigger.start + label.length + trailingSpace.length);
 			},
-			[focusAt, onChange, selectedAssistantNames, selectedSkillLabels, value],
+			[dismissTrigger, focusAt, onChange, selectedAssistantNames, selectedSkillLabels, value],
 		);
 
 		const selectActiveItem = useCallback(() => {
@@ -1016,7 +999,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				return;
 			}
 			const option = commandOptions[activeIndex];
-			if (option) selectToken(option.kind === "skill" ? "skill" : "command", option.item, trigger);
+			if (option) selectToken("skill", option.item, trigger);
 		}, [activeIndex, commandOptions, filteredAssistants, selectToken, trigger]);
 
 		const handlePickerValueChange = useCallback(
@@ -1059,7 +1042,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 
 					if (event.key === "Escape") {
 						event.preventDefault();
-						setTrigger(null);
+						dismissTrigger();
 						return;
 					}
 				}
@@ -1073,7 +1056,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					onSubmit();
 				}
 			},
-			[isProjectVariant, onSubmit, pickerItemCount, selectActiveItem, trigger],
+			[dismissTrigger, isProjectVariant, onSubmit, pickerItemCount, selectActiveItem, trigger],
 		);
 
 		const inputSpacingClass = isProjectVariant
@@ -1085,6 +1068,21 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				{trigger && (
 					<div
 						ref={pickerRef}
+						role="dialog"
+						aria-label={trigger.kind === "assistant" ? "选择 AI 队友" : "选择技能"}
+						onBlur={() => {
+							setTimeout(() => {
+								const activeElement = document.activeElement;
+								if (
+									activeElement &&
+									(pickerRef.current?.contains(activeElement) ||
+										editorRef.current?.contains(activeElement))
+								) {
+									return;
+								}
+								dismissTrigger();
+							}, 100);
+						}}
 						// 圆角容器需留足内边距，避免 overflow-hidden 裁切顶部标题文字
 						className="absolute bottom-full left-0 z-30 mb-2 w-full max-w-[360px] overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-2 shadow-[0_12px_36px_rgba(15,23,42,0.12)] backdrop-blur"
 					>
@@ -1095,9 +1093,18 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 							className="rounded-xl! bg-transparent p-0"
 						>
 							<div className="flex items-center gap-2 px-2 py-1 text-xs font-medium text-slate-400">
-								{trigger.kind === "assistant" ? <>AI 队友</> : <>命令和 Skills</>}
-								{trigger.query && <span className="truncate text-slate-400">{trigger.query}</span>}
+								{trigger.kind === "assistant" ? <>AI 队友</> : <>选择技能</>}
+								{trigger.kind === "assistant" && trigger.query && (
+									<span className="truncate text-slate-400">{trigger.query}</span>
+								)}
 							</div>
+							{trigger.kind === "command" && (
+								<CommandInput
+									value={commandSearch}
+									onValueChange={setCommandSearch}
+									placeholder="搜索技能"
+								/>
+							)}
 							<CommandList className="max-h-60">
 								<CommandEmpty className="py-8 text-slate-400">没有匹配项</CommandEmpty>
 								{trigger.kind === "assistant" ? (
@@ -1207,40 +1214,6 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 												</CommandItem>
 											))}
 										</CommandGroup>
-										<CommandGroup heading="命令" className="p-0">
-											{filteredCommands.map((command, index) => {
-												const globalIndex = filteredSkills.length + index;
-												return (
-													<CommandItem
-														key={command.code}
-														value={commandPickerValue({
-															kind: "command",
-															item: command,
-														})}
-														data-picker-item-value={commandPickerValue({
-															kind: "command",
-															item: command,
-														})}
-														onMouseDown={(event: MouseEvent) => event.preventDefault()}
-														onSelect={() => selectToken("command", command, trigger)}
-														className={cn(
-															"rounded-xl px-2.5 py-2",
-															globalIndex === activeIndex && "bg-slate-100",
-														)}
-													>
-														<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
-															<TerminalSquare className="size-4" />
-														</div>
-														<div className="min-w-0 flex-1">
-															<div className="font-medium">/{command.label}</div>
-															<div className="truncate text-xs text-slate-400">
-																{command.description}
-															</div>
-														</div>
-													</CommandItem>
-												);
-											})}
-										</CommandGroup>
 									</>
 								)}
 							</CommandList>
@@ -1272,10 +1245,19 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					onInput={() => syncFromEditor()}
 					onKeyDown={handleKeyDown}
 					onPaste={handlePaste}
+					onMouseDown={() => {
+						if (trigger) {
+							dismissTrigger();
+						}
+					}}
 					onFocus={onFocus}
 					onBlur={() => {
 						onBlur();
-						setTimeout(() => setTrigger(null), 100);
+						setTimeout(() => {
+							const activeElement = document.activeElement;
+							if (activeElement && pickerRef.current?.contains(activeElement)) return;
+							dismissTrigger();
+						}, 100);
 					}}
 					onCompositionStart={() => {
 						composingRef.current = true;

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -11,7 +11,7 @@ import {
 	CommandList,
 } from "@leros/ui/components/ui/command";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Sparkles, X } from "lucide-react";
+import { Bot, Sparkles } from "lucide-react";
 import {
 	forwardRef,
 	type MouseEvent,
@@ -433,6 +433,11 @@ function getCaretOffset(root: HTMLElement): number {
 	if (!selection || selection.rangeCount === 0) return extractSnapshot(root).text.length;
 
 	const range = selection.getRangeAt(0);
+	if (!root.contains(range.endContainer)) {
+		// 中文注释：工具栏弹窗的搜索框会抢走 selection，此时插入技能应追加到输入框末尾。
+		return extractSnapshot(root).text.length;
+	}
+
 	const workingRange = range.cloneRange();
 	workingRange.selectNodeContents(root);
 	workingRange.setEnd(range.endContainer, range.endOffset);
@@ -450,6 +455,11 @@ function getSelectionOffsets(root: HTMLElement): {
 	}
 
 	const range = selection.getRangeAt(0);
+	if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) {
+		const textLength = extractSnapshot(root).text.length;
+		return { start: textLength, end: textLength };
+	}
+
 	const startRange = range.cloneRange();
 	startRange.selectNodeContents(root);
 	startRange.setEnd(range.startContainer, range.startOffset);
@@ -569,6 +579,8 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 		const pendingCaretRef = useRef<number | null>(null);
 		const dismissedTriggerStartRef = useRef<number | null>(null);
 		const shouldAutoScrollPickerRef = useRef(false);
+		const valueRef = useRef(value);
+		const tokensRef = useRef<InsertedToken[]>([]);
 
 		const assistantOptions = useMemo<AssistantOption[]>(() => mockAssistants, []);
 		const displayTokens = useMemo(() => resolveDisplayTokens(value, tokens), [tokens, value]);
@@ -637,6 +649,36 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				setCaretOffset(editor, cursor);
 			});
 		}, []);
+
+		useEffect(() => {
+			valueRef.current = value;
+		}, [value]);
+
+		useEffect(() => {
+			tokensRef.current = tokens;
+		}, [tokens]);
+
+		const commitProgrammaticEdit = useCallback(
+			(nextValue: string, nextTokens: InsertedToken[], nextCaret: number) => {
+				const editor = editorRef.current;
+
+				valueRef.current = nextValue;
+				tokensRef.current = nextTokens;
+				setTokens(nextTokens);
+				onChange(nextValue);
+
+				if (!editor) {
+					pendingCaretRef.current = nextCaret;
+					return;
+				}
+
+				// 中文注释：程序化插入 mention 后立即同步 DOM，避免首个技能在 effect 前被读成普通文本。
+				buildEditorContent(editor, nextValue, resolveDisplayTokens(nextValue, nextTokens));
+				pendingCaretRef.current = null;
+				focusAt(nextCaret);
+			},
+			[focusAt, onChange],
+		);
 
 		const getActiveTrigger = useCallback((text: string, caret: number) => {
 			const nextTrigger = findTrigger(text, caret);
@@ -752,9 +794,11 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 			if (!editor) return;
 
 			const snapshot = extractSnapshot(editor);
+			tokensRef.current = snapshot.tokens;
 			setTokens(snapshot.tokens);
 			// 中文注释：仅空白/换行时归一为空串，避免 placeholder 因 \n 被误判为已输入。
 			const text = isEmptyEditorValue(snapshot.text) ? "" : snapshot.text;
+			valueRef.current = text;
 			onChange(text);
 
 			if (
@@ -796,11 +840,16 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				if (!editor) return;
 
 				const { start, end } = getSelectionOffsets(editor);
-				const nextValue = `${value.slice(0, start)}${pastedText}${value.slice(end)}`;
+				const currentValue = valueRef.current;
+				const currentTokens = tokensRef.current;
+				const nextValue = `${currentValue.slice(0, start)}${pastedText}${currentValue.slice(end)}`;
 				const nextCaret = start + pastedText.length;
+				const nextTokens = shiftTokensForTextEdit(currentTokens, currentValue, nextValue);
 
 				// 富文本编辑器里外部粘贴默认会带入 HTML/样式，这里统一降级成纯文本，保证展示和发送内容一致。
-				setTokens((current) => shiftTokensForTextEdit(current, value, nextValue));
+				valueRef.current = nextValue;
+				tokensRef.current = nextTokens;
+				setTokens(nextTokens);
 				onChange(nextValue);
 				pendingCaretRef.current = nextCaret;
 
@@ -810,7 +859,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 
 				focusAt(nextCaret);
 			},
-			[directivesDisabled, focusAt, getActiveTrigger, onChange, onPasteFiles, value],
+			[directivesDisabled, focusAt, getActiveTrigger, onChange, onPasteFiles],
 		);
 
 		const insertTrigger = useCallback(
@@ -819,33 +868,40 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				const editor = editorRef.current;
 				if (!editor) return;
 
+				const currentValue = valueRef.current;
+				const currentTokens = tokensRef.current;
 				const cursor = getCaretOffset(editor);
 				const marker = kind === "assistant" ? "@" : "/";
-				const needsLeadingSpace = cursor > 0 && !/\s/.test(value[cursor - 1] ?? "");
+				const needsLeadingSpace = cursor > 0 && !/\s/.test(currentValue[cursor - 1] ?? "");
 				const insertion = `${needsLeadingSpace ? " " : ""}${marker}`;
 				const markerStart = cursor + (needsLeadingSpace ? 1 : 0);
-				const nextValue = `${value.slice(0, cursor)}${insertion}${value.slice(cursor)}`;
+				const nextValue = `${currentValue.slice(0, cursor)}${insertion}${currentValue.slice(cursor)}`;
+				const nextTokens = shiftTokensForTextEdit(currentTokens, currentValue, nextValue);
 
 				// 工具栏触发的插入不会经过原生 input 事件，这里手动同步 mention 位置信息。
-				setTokens((current) => shiftTokensForTextEdit(current, value, nextValue));
+				valueRef.current = nextValue;
+				tokensRef.current = nextTokens;
+				setTokens(nextTokens);
 				onChange(nextValue);
 				pendingCaretRef.current = markerStart + 1;
 				dismissedTriggerStartRef.current = null;
 				setTrigger({ kind, start: markerStart, end: markerStart + 1, query: "" });
 				focusAt(markerStart + 1);
 			},
-			[directivesDisabled, focusAt, onChange, value],
+			[directivesDisabled, focusAt, onChange],
 		);
 
 		const insertToolbarToken = useCallback(
 			(kind: TokenKind, rawLabel: string) => {
 				const editor = editorRef.current;
-				const cursor = editor ? getCaretOffset(editor) : value.length;
-				const needsLeadingSpace = cursor > 0 && !/\s/.test(value[cursor - 1] ?? "");
-				const needsTrailingSpace = !/\s/.test(value[cursor] ?? "");
+				const currentValue = valueRef.current;
+				const currentTokens = tokensRef.current;
+				const cursor = editor ? getCaretOffset(editor) : currentValue.length;
+				const needsLeadingSpace = cursor > 0 && !/\s/.test(currentValue[cursor - 1] ?? "");
+				const needsTrailingSpace = !/\s/.test(currentValue[cursor] ?? "");
 				const insertion = `${needsLeadingSpace ? " " : ""}${rawLabel}${needsTrailingSpace ? " " : ""}`;
 				const tokenStart = cursor + (needsLeadingSpace ? 1 : 0);
-				const nextValue = `${value.slice(0, cursor)}${insertion}${value.slice(cursor)}`;
+				const nextValue = `${currentValue.slice(0, cursor)}${insertion}${currentValue.slice(cursor)}`;
 				const insertedToken: InsertedToken = {
 					label: rawLabel,
 					start: tokenStart,
@@ -853,23 +909,30 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					kind,
 				};
 
-				setTokens((current) =>
-					shiftTokensForInsert(current, cursor, cursor, insertedToken, insertion.length),
+				const nextTokens = shiftTokensForInsert(
+					currentTokens,
+					cursor,
+					cursor,
+					insertedToken,
+					insertion.length,
 				);
-				onChange(nextValue);
 				dismissedTriggerStartRef.current = null;
 				dismissTrigger(false);
-				pendingCaretRef.current = tokenStart + rawLabel.length + (needsTrailingSpace ? 1 : 0);
-				focusAt(tokenStart + rawLabel.length + (needsTrailingSpace ? 1 : 0));
+				commitProgrammaticEdit(
+					nextValue,
+					nextTokens,
+					tokenStart + rawLabel.length + (needsTrailingSpace ? 1 : 0),
+				);
 			},
-			[dismissTrigger, focusAt, onChange, value],
+			[commitProgrammaticEdit, dismissTrigger],
 		);
 
 		const removeMentionToken = useCallback(
 			(kind: Extract<TokenKind, "assistant" | "skill">, rawLabel: string) => {
 				const prefix = kind === "assistant" ? "@" : "/";
 				const normalizedLabel = rawLabel.startsWith(prefix) ? rawLabel : `${prefix}${rawLabel}`;
-				const currentTokens = resolveDisplayTokens(value, tokens);
+				const currentValue = valueRef.current;
+				const currentTokens = resolveDisplayTokens(currentValue, tokensRef.current);
 				const target = currentTokens.find(
 					(token) => token.kind === kind && token.label === normalizedLabel,
 				);
@@ -877,20 +940,18 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 
 				let start = target.start;
 				let end = target.end;
-				if (value[end] === " ") {
+				if (currentValue[end] === " ") {
 					end += 1;
-				} else if (start > 0 && value[start - 1] === " ") {
+				} else if (start > 0 && currentValue[start - 1] === " ") {
 					start -= 1;
 				}
-				const nextValue = `${value.slice(0, start)}${value.slice(end)}`;
+				const nextValue = `${currentValue.slice(0, start)}${currentValue.slice(end)}`;
+				const nextTokens = shiftTokensForTextEdit(currentTokens, currentValue, nextValue);
 				// 中文注释：从已选 tag 区域移除时，同步删除输入框里的 mention token 和对应纯文本。
-				setTokens((current) => shiftTokensForTextEdit(current, value, nextValue));
-				onChange(nextValue);
 				dismissTrigger(false);
-				pendingCaretRef.current = start;
-				focusAt(start);
+				commitProgrammaticEdit(nextValue, nextTokens, start);
 			},
-			[dismissTrigger, focusAt, onChange, tokens, value],
+			[commitProgrammaticEdit, dismissTrigger],
 		);
 
 		const removeAssistantToken = useCallback(
@@ -913,9 +974,9 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				insertSkill: (skillLabel: string) => insertToolbarToken("skill", `/${skillLabel}`),
 				removeAssistant: removeAssistantToken,
 				removeSkill: removeSkillToken,
-				getComposerTokens: () => resolveDisplayTokens(value, tokens),
+				getComposerTokens: () => resolveDisplayTokens(valueRef.current, tokensRef.current),
 			}),
-			[insertToolbarToken, insertTrigger, removeAssistantToken, removeSkillToken, tokens, value],
+			[insertToolbarToken, insertTrigger, removeAssistantToken, removeSkillToken],
 		);
 
 		const selectToken = useCallback(
@@ -938,60 +999,40 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 				const label = isAssistant
 					? `@${(option as AssistantOption).name}`
 					: `/${(option as ComposerSkillOption).label}`;
-				const followingText = value.slice(activeTrigger.end);
+				const currentValue = valueRef.current;
+				const currentTokens = tokensRef.current;
+				const followingText = currentValue.slice(activeTrigger.end);
 				// 中文注释：token 后保留一个正文分隔空格，避免继续输入时被当成同一个 / 或 @ 指令查询。
 				const trailingSpace = /^\s/.test(followingText) ? "" : " ";
-				const nextValue = `${value.slice(
+				const nextValue = `${currentValue.slice(
 					0,
 					activeTrigger.start,
 				)}${label}${trailingSpace}${followingText}`;
-				if (isAssistant) {
-					const insertedToken: InsertedToken = {
-						label,
-						start: activeTrigger.start,
-						end: activeTrigger.start + label.length,
-						kind: "assistant",
-					};
-					const delta =
-						label.length + trailingSpace.length - (activeTrigger.end - activeTrigger.start);
-
-					setTokens((current) =>
-						shiftTokensForInsert(
-							current,
-							activeTrigger.start,
-							activeTrigger.end,
-							insertedToken,
-							delta,
-						),
-					);
-				} else {
-					const insertedToken: InsertedToken = {
-						label,
-						start: activeTrigger.start,
-						end: activeTrigger.start + label.length,
-						kind: "skill",
-					};
-					const delta =
-						label.length + trailingSpace.length - (activeTrigger.end - activeTrigger.start);
-
-					setTokens((current) =>
-						shiftTokensForInsert(
-							current,
-							activeTrigger.start,
-							activeTrigger.end,
-							insertedToken,
-							delta,
-						),
-					);
-				}
-				onChange(nextValue);
+				const insertedToken: InsertedToken = {
+					label,
+					start: activeTrigger.start,
+					end: activeTrigger.start + label.length,
+					kind: isAssistant ? "assistant" : "skill",
+				};
+				const delta =
+					label.length + trailingSpace.length - (activeTrigger.end - activeTrigger.start);
+				const nextTokens = shiftTokensForInsert(
+					currentTokens,
+					activeTrigger.start,
+					activeTrigger.end,
+					insertedToken,
+					delta,
+				);
 				dismissedTriggerStartRef.current = null;
 				dismissTrigger(false);
-				// mention 节点插入后，显式恢复光标到节点后面的正文位置，避免落到不可编辑节点内部。
-				pendingCaretRef.current = activeTrigger.start + label.length + trailingSpace.length;
-				focusAt(activeTrigger.start + label.length + trailingSpace.length);
+				// 中文注释：内联弹窗选择后立即重建 mention DOM，避免首个技能先落成普通文本。
+				commitProgrammaticEdit(
+					nextValue,
+					nextTokens,
+					activeTrigger.start + label.length + trailingSpace.length,
+				);
 			},
-			[dismissTrigger, focusAt, onChange, selectedAssistantNames, selectedSkillLabels, value],
+			[commitProgrammaticEdit, dismissTrigger, selectedAssistantNames, selectedSkillLabels],
 		);
 
 		const selectActiveItem = useCallback(() => {
@@ -1113,113 +1154,69 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 							<CommandList className="max-h-60">
 								<CommandEmpty className="py-8 text-slate-400">没有匹配项</CommandEmpty>
 								{trigger.kind === "assistant" ? (
-									<>
-										{selectedAssistantNames.length > 0 && (
-											<div className="px-2.5 pb-2 pt-1">
-												<div className="mb-1 text-[11px] font-medium text-slate-400">
-													已选 AI 队友
+									<CommandGroup className="p-0">
+										{filteredAssistants.map((assistant, index) => (
+											<CommandItem
+												key={assistant.code}
+												value={assistantPickerValue(assistant)}
+												data-picker-item-value={assistantPickerValue(assistant)}
+												onMouseDown={(event: MouseEvent) => event.preventDefault()}
+												onSelect={() => selectToken("assistant", assistant, trigger)}
+												className={cn(
+													"rounded-xl px-2.5 py-2",
+													index === activeIndex && "bg-slate-100",
+												)}
+											>
+												<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+													<Bot className="size-4" />
 												</div>
-												<div className="flex flex-wrap gap-1.5">
-													{selectedAssistantNames.map((name) => (
-														<button
-															key={name}
-															type="button"
-															onClick={() => removeAssistantToken(name)}
-															className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-[11px] text-blue-700 transition-colors hover:bg-blue-100"
-														>
-															@{name}
-															<X className="size-3" />
-														</button>
-													))}
+												<div className="min-w-0 flex-1">
+													<div className="truncate font-medium text-slate-700">
+														{assistant.name}
+													</div>
+													<div className="truncate text-xs text-slate-400">
+														{assistant.description}
+													</div>
 												</div>
-											</div>
-										)}
-										<CommandGroup className="p-0">
-											{filteredAssistants.map((assistant, index) => (
-												<CommandItem
-													key={assistant.code}
-													value={assistantPickerValue(assistant)}
-													data-picker-item-value={assistantPickerValue(assistant)}
-													onMouseDown={(event: MouseEvent) => event.preventDefault()}
-													onSelect={() => selectToken("assistant", assistant, trigger)}
-													className={cn(
-														"rounded-xl px-2.5 py-2",
-														index === activeIndex && "bg-slate-100",
-													)}
-												>
-													<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
-														<Bot className="size-4" />
-													</div>
-													<div className="min-w-0 flex-1">
-														<div className="truncate font-medium text-slate-700">
-															{assistant.name}
-														</div>
-														<div className="truncate text-xs text-slate-400">
-															{assistant.description}
-														</div>
-													</div>
-												</CommandItem>
-											))}
-										</CommandGroup>
-									</>
+											</CommandItem>
+										))}
+									</CommandGroup>
 								) : (
-									<>
-										{selectedSkillLabels.length > 0 && (
-											<div className="px-2.5 pb-2 pt-1">
-												<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
-												<div className="flex flex-wrap gap-1.5">
-													{selectedSkillLabels.map((label) => (
-														<button
-															key={label}
-															type="button"
-															onClick={() => removeSkillToken(label)}
-															className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-														>
-															/{label}
-															<X className="size-3" />
-														</button>
-													))}
-												</div>
-											</div>
+									<CommandGroup heading="Skills" className="p-0">
+										{skillsLoading && (
+											<div className="px-2.5 py-2 text-xs text-slate-400">加载 Skills...</div>
 										)}
-										<CommandGroup heading="Skills" className="p-0">
-											{skillsLoading && (
-												<div className="px-2.5 py-2 text-xs text-slate-400">加载 Skills...</div>
-											)}
-											{!skillsLoading && skillsError && (
-												<div className="px-2.5 py-2 text-xs text-red-400">{skillsError}</div>
-											)}
-											{filteredSkills.map((skill, index) => (
-												<CommandItem
-													key={`skill-${skill.code}`}
-													value={commandPickerValue({
-														kind: "skill",
-														item: skill,
-													})}
-													data-picker-item-value={commandPickerValue({
-														kind: "skill",
-														item: skill,
-													})}
-													onMouseDown={(event: MouseEvent) => event.preventDefault()}
-													onSelect={() => selectToken("skill", skill, trigger)}
-													className={cn(
-														"rounded-xl px-2.5 py-2",
-														index === activeIndex && "bg-slate-100",
-													)}
-												>
-													<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600">
-														<Sparkles className="size-3.5" />
-													</div>
-													<div className="min-w-0 flex-1">
-														<div className="truncate font-medium">/{skill.label}</div>
-														<div className="truncate text-xs text-slate-400">
-															{skill.description}
-														</div>
-													</div>
-												</CommandItem>
-											))}
-										</CommandGroup>
-									</>
+										{!skillsLoading && skillsError && (
+											<div className="px-2.5 py-2 text-xs text-red-400">{skillsError}</div>
+										)}
+										{filteredSkills.map((skill, index) => (
+											<CommandItem
+												key={`skill-${skill.code}`}
+												value={commandPickerValue({
+													kind: "skill",
+													item: skill,
+												})}
+												data-picker-item-value={commandPickerValue({
+													kind: "skill",
+													item: skill,
+												})}
+												onMouseDown={(event: MouseEvent) => event.preventDefault()}
+												onSelect={() => selectToken("skill", skill, trigger)}
+												className={cn(
+													"rounded-xl px-2.5 py-2",
+													index === activeIndex && "bg-slate-100",
+												)}
+											>
+												<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600">
+													<Sparkles className="size-3.5" />
+												</div>
+												<div className="min-w-0 flex-1">
+													<div className="truncate font-medium">/{skill.label}</div>
+													<div className="truncate text-xs text-slate-400">{skill.description}</div>
+												</div>
+											</CommandItem>
+										))}
+									</CommandGroup>
 								)}
 							</CommandList>
 						</Command>

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -11,7 +11,7 @@ import {
 	CommandList,
 } from "@leros/ui/components/ui/command";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Sparkles } from "lucide-react";
+import { Bot, Sparkles, X } from "lucide-react";
 import {
 	forwardRef,
 	type MouseEvent,
@@ -946,7 +946,27 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					start -= 1;
 				}
 				const nextValue = `${currentValue.slice(0, start)}${currentValue.slice(end)}`;
-				const nextTokens = shiftTokensForTextEdit(currentTokens, currentValue, nextValue);
+				const delta = start - end;
+				const nextTokens = sortTokens(
+					currentTokens
+						.flatMap((token) => {
+							if (
+								token.kind === target.kind &&
+								token.label === target.label &&
+								token.start === target.start &&
+								token.end === target.end
+							) {
+								return [];
+							}
+							if (token.end <= start) return [token];
+							if (token.start >= end) {
+								return [{ ...token, start: token.start + delta, end: token.end + delta }];
+							}
+							return [];
+						})
+						// 中文注释：已选区删除只影响目标 token，后续同前缀技能需保留 mention 样式。
+						.filter((token) => nextValue.slice(token.start, token.end) === token.label),
+				);
 				// 中文注释：从已选 tag 区域移除时，同步删除输入框里的 mention token 和对应纯文本。
 				dismissTrigger(false);
 				commitProgrammaticEdit(nextValue, nextTokens, start);
@@ -1154,69 +1174,117 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 							<CommandList className="max-h-60">
 								<CommandEmpty className="py-8 text-slate-400">没有匹配项</CommandEmpty>
 								{trigger.kind === "assistant" ? (
-									<CommandGroup className="p-0">
-										{filteredAssistants.map((assistant, index) => (
-											<CommandItem
-												key={assistant.code}
-												value={assistantPickerValue(assistant)}
-												data-picker-item-value={assistantPickerValue(assistant)}
-												onMouseDown={(event: MouseEvent) => event.preventDefault()}
-												onSelect={() => selectToken("assistant", assistant, trigger)}
-												className={cn(
-													"rounded-xl px-2.5 py-2",
-													index === activeIndex && "bg-slate-100",
-												)}
-											>
-												<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
-													<Bot className="size-4" />
+									<>
+										{selectedAssistantNames.length > 0 && (
+											<div className="px-2.5 pb-2 pt-1">
+												<div className="mb-1 text-[11px] font-medium text-slate-400">
+													已选 AI 队友
 												</div>
-												<div className="min-w-0 flex-1">
-													<div className="truncate font-medium text-slate-700">
-														{assistant.name}
-													</div>
-													<div className="truncate text-xs text-slate-400">
-														{assistant.description}
-													</div>
+												<div className="flex flex-wrap gap-1.5">
+													{selectedAssistantNames.map((name) => (
+														<button
+															key={name}
+															type="button"
+															aria-label={`移除 AI 队友 ${name}`}
+															onMouseDown={(event: MouseEvent) => event.preventDefault()}
+															onClick={() => removeAssistantToken(name)}
+															className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-[11px] text-blue-700 transition-colors hover:bg-blue-100"
+														>
+															@{name}
+															<X className="size-3" />
+														</button>
+													))}
 												</div>
-											</CommandItem>
-										))}
-									</CommandGroup>
+											</div>
+										)}
+										<CommandGroup className="p-0">
+											{filteredAssistants.map((assistant, index) => (
+												<CommandItem
+													key={assistant.code}
+													value={assistantPickerValue(assistant)}
+													data-picker-item-value={assistantPickerValue(assistant)}
+													onMouseDown={(event: MouseEvent) => event.preventDefault()}
+													onSelect={() => selectToken("assistant", assistant, trigger)}
+													className={cn(
+														"rounded-xl px-2.5 py-2",
+														index === activeIndex && "bg-slate-100",
+													)}
+												>
+													<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+														<Bot className="size-4" />
+													</div>
+													<div className="min-w-0 flex-1">
+														<div className="truncate font-medium text-slate-700">
+															{assistant.name}
+														</div>
+														<div className="truncate text-xs text-slate-400">
+															{assistant.description}
+														</div>
+													</div>
+												</CommandItem>
+											))}
+										</CommandGroup>
+									</>
 								) : (
-									<CommandGroup heading="Skills" className="p-0">
-										{skillsLoading && (
-											<div className="px-2.5 py-2 text-xs text-slate-400">加载 Skills...</div>
-										)}
-										{!skillsLoading && skillsError && (
-											<div className="px-2.5 py-2 text-xs text-red-400">{skillsError}</div>
-										)}
-										{filteredSkills.map((skill, index) => (
-											<CommandItem
-												key={`skill-${skill.code}`}
-												value={commandPickerValue({
-													kind: "skill",
-													item: skill,
-												})}
-												data-picker-item-value={commandPickerValue({
-													kind: "skill",
-													item: skill,
-												})}
-												onMouseDown={(event: MouseEvent) => event.preventDefault()}
-												onSelect={() => selectToken("skill", skill, trigger)}
-												className={cn(
-													"rounded-xl px-2.5 py-2",
-													index === activeIndex && "bg-slate-100",
-												)}
-											>
-												<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600">
-													<Sparkles className="size-3.5" />
+									<>
+										{selectedSkillLabels.length > 0 && (
+											<div className="px-2.5 pb-2 pt-1">
+												<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
+												<div className="flex flex-wrap gap-1.5">
+													{selectedSkillLabels.map((label) => (
+														<button
+															key={label}
+															type="button"
+															aria-label={`移除技能 ${label}`}
+															onMouseDown={(event: MouseEvent) => event.preventDefault()}
+															onClick={() => removeSkillToken(label)}
+															className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
+														>
+															/{label}
+															<X className="size-3" />
+														</button>
+													))}
 												</div>
-												<div className="min-w-0 flex-1">
-													<div className="truncate font-medium">/{skill.label}</div>
-													<div className="truncate text-xs text-slate-400">{skill.description}</div>
-												</div>
-											</CommandItem>
-										))}
-									</CommandGroup>
+											</div>
+										)}
+										<CommandGroup heading="Skills" className="p-0">
+											{skillsLoading && (
+												<div className="px-2.5 py-2 text-xs text-slate-400">加载 Skills...</div>
+											)}
+											{!skillsLoading && skillsError && (
+												<div className="px-2.5 py-2 text-xs text-red-400">{skillsError}</div>
+											)}
+											{filteredSkills.map((skill, index) => (
+												<CommandItem
+													key={`skill-${skill.code}`}
+													value={commandPickerValue({
+														kind: "skill",
+														item: skill,
+													})}
+													data-picker-item-value={commandPickerValue({
+														kind: "skill",
+														item: skill,
+													})}
+													onMouseDown={(event: MouseEvent) => event.preventDefault()}
+													onSelect={() => selectToken("skill", skill, trigger)}
+													className={cn(
+														"rounded-xl px-2.5 py-2",
+														index === activeIndex && "bg-slate-100",
+													)}
+												>
+													<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600">
+														<Sparkles className="size-3.5" />
+													</div>
+													<div className="min-w-0 flex-1">
+														<div className="truncate font-medium">/{skill.label}</div>
+														<div className="truncate text-xs text-slate-400">
+															{skill.description}
+														</div>
+													</div>
+												</CommandItem>
+											))}
+										</CommandGroup>
+									</>
 								)}
 							</CommandList>
 						</Command>

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -483,8 +483,8 @@ export function LeftRail({
 											"normal-case leading-snug tracking-normal font-normal",
 										)}
 									>
-										<span className="text-xs">最近项目</span>
-										<span className="text-[11px]">（仅展示5个）</span>
+										<span className="text-sm">最近项目</span>
+										<span className="text-xs">（仅展示5个）</span>
 									</div>
 								) : group.label ? (
 									<div className="leros-nav-section-label">{group.label}</div>

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -474,19 +474,20 @@ export function LeftRail({
 			<ScrollArea hideScrollbar className="min-h-0 flex-1 overflow-hidden">
 				<nav className="leros-nav" aria-label="主导航">
 					{navGroups.map((group) => {
-						const sectionLabel =
-							group.id === "projects" ? "最近项目（默认展示最近5个项目）" : group.label;
 						return (
 							<div key={group.id} className="leros-nav-section">
-								{sectionLabel ? (
+								{group.id === "projects" ? (
 									<div
 										className={cn(
 											"leros-nav-section-label",
-											group.id === "projects" && "normal-case leading-snug tracking-normal",
+											"normal-case leading-snug tracking-normal font-normal",
 										)}
 									>
-										{sectionLabel}
+										<span className="text-xs">最近项目</span>
+										<span className="text-[11px]">（仅展示5个）</span>
 									</div>
+								) : group.label ? (
+									<div className="leros-nav-section-label">{group.label}</div>
 								) : null}
 								{group.id === "projects" ? (
 									<ProjectList

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -780,6 +780,7 @@ function ProjectConfigSidebar({
 						>
 							<Plus className="size-4" />
 						</PopoverTrigger>
+						{/* 固定在按钮上方，和输入框工具栏的技能选择弹窗保持一致。 */}
 						<PopoverContent
 							align="end"
 							side="top"
@@ -794,24 +795,6 @@ function ProjectConfigSidebar({
 									onValueChange={setSkillSearch}
 									placeholder="搜索技能"
 								/>
-								{project.skills.length > 0 && (
-									<div className="px-2 pb-2 pt-1">
-										<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
-										<div className="flex flex-wrap gap-1.5">
-											{project.skills.map((skill) => (
-												<button
-													key={skill.code}
-													type="button"
-													onClick={() => removeProjectSkill(skill.code)}
-													className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-												>
-													/{skill.name}
-													<X className="size-3" />
-												</button>
-											))}
-										</div>
-									</div>
-								)}
 								<CommandList className="max-h-64">
 									<CommandEmpty className="py-6 text-slate-400">没有可继续添加的技能</CommandEmpty>
 									<CommandGroup className="p-0">

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -1297,32 +1297,33 @@ function ProjectFiles({
 	};
 
 	return (
-		<div className="h-full overflow-y-auto px-10 py-8">
+		<div className="h-full overflow-y-auto px-10 py-7">
 			<div className="mx-auto w-full max-w-[1200px]">
-				<div className="mb-8 flex items-center justify-between gap-6">
+				<div className="mb-7 flex items-center justify-between gap-5">
 					<div>
-						<h2 className="text-2xl font-semibold tracking-tight text-[var(--leros-text-strong)]">
+						<h2 className="text-[2rem] font-semibold tracking-tight text-[var(--leros-text-strong)]">
 							项目文件
 						</h2>
-						<p className="mt-1 text-sm text-[var(--leros-text-muted)]">
+						<p className="mt-0.5 text-[13px] text-[var(--leros-text-muted)]">
 							管理当前项目的所有文件资源
 						</p>
 					</div>
-					<div className="flex items-center gap-3">
+					{/* 中文注释：项目文件页顶部筛选条整体收一档，保持结构不变，只降低高度和横向占比，让桌面端视觉更紧凑。 */}
+					<div className="flex items-center gap-2.5">
 						<div className="relative">
 							<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--leros-text-muted)]" />
 							<input
 								value={searchKeyword}
 								onChange={(event) => setSearchKeyword(event.target.value)}
 								placeholder="搜索文件..."
-								className="h-10 w-64 rounded-xl border border-[var(--leros-control-border)] bg-white pl-9 pr-4 text-sm outline-none transition-colors focus:border-[var(--leros-primary)]"
+								className="h-9 w-60 rounded-xl border border-[var(--leros-control-border)] bg-white pl-9 pr-3.5 text-[13px] outline-none transition-colors focus:border-[var(--leros-primary)]"
 							/>
 						</div>
 						<div className="relative">
 							<select
 								value={fileSourceFilter}
 								onChange={(event) => setFileSourceFilter(event.target.value as "all" | FileSource)}
-								className="h-10 cursor-pointer appearance-none rounded-xl border border-[var(--leros-control-border)] bg-white py-0 pl-3.5 pr-9 text-sm outline-none transition-colors focus:border-[var(--leros-primary)]"
+								className="h-9 min-w-[132px] cursor-pointer appearance-none rounded-xl border border-[var(--leros-control-border)] bg-white py-0 pl-3.5 pr-9 text-[13px] outline-none transition-colors focus:border-[var(--leros-primary)]"
 							>
 								<option value="all">全部</option>
 								<option value="task">任务文件</option>
@@ -1362,7 +1363,7 @@ function ProjectFiles({
 					</div>
 				) : (
 					<div className="overflow-hidden rounded-2xl border border-[var(--leros-control-border)] bg-white">
-						<div className="grid grid-cols-[minmax(0,1fr)_90px_120px_180px_180px] border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-6 py-4 text-xs font-semibold uppercase tracking-wider text-[var(--leros-text-muted)]">
+						<div className="grid grid-cols-[minmax(0,1fr)_90px_120px_180px_180px] border-b border-[var(--leros-control-border)] bg-[var(--leros-surface-soft)] px-5 py-3.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--leros-text-muted)]">
 							<div>名称</div>
 							<div>类型</div>
 							<div>大小</div>
@@ -1373,20 +1374,20 @@ function ProjectFiles({
 							{allFlatFiles.map((file) => (
 								<div
 									key={file.path}
-									className="grid grid-cols-[minmax(0,1fr)_90px_120px_180px_180px] items-center px-6 py-5 transition-colors hover:bg-[var(--leros-primary-softer)]/25"
+									className="grid grid-cols-[minmax(0,1fr)_90px_120px_180px_180px] items-center px-5 py-4 transition-colors hover:bg-[var(--leros-primary-softer)]/25"
 								>
 									<button
 										type="button"
 										data-file-preview-trigger
 										onClick={() => setPreviewFile(file)}
-										className="flex min-w-0 cursor-pointer items-center gap-3 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--leros-primary-softer)]/50"
+										className="flex min-w-0 cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--leros-primary-softer)]/50"
 										title="查看"
 									>
-										<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
+										<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
 											<ProjectFileTypeIcon fileName={file.name} />
 										</div>
 										<div className="min-w-0">
-											<p className="truncate text-sm font-semibold text-[var(--leros-text-strong)]">
+											<p className="truncate text-[15px] font-semibold text-[var(--leros-text-strong)]">
 												{file.name}
 											</p>
 											<p className="truncate text-xs text-[var(--leros-text-muted)]">
@@ -1394,22 +1395,22 @@ function ProjectFiles({
 											</p>
 										</div>
 									</button>
-									<div className="text-sm">
-										<span className="inline-block rounded-md bg-[var(--leros-surface-soft)] px-2.5 py-1 text-xs font-medium text-[var(--leros-text-muted)]">
+									<div className="text-[13px]">
+										<span className="inline-block rounded-md bg-[var(--leros-surface-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--leros-text-muted)]">
 											{getFileSource(file.path) === "task" ? "任务文件" : "上传文件"}
 										</span>
 									</div>
-									<div className="text-sm text-[var(--leros-text-muted)]">
+									<div className="text-[13px] text-[var(--leros-text-muted)]">
 										{formatBytes(file.size)}
 									</div>
-									<div className="text-sm text-[var(--leros-text-muted)]">
+									<div className="text-[13px] text-[var(--leros-text-muted)]">
 										{formatTime(file.createdAt)}
 									</div>
-									<div className="flex items-center justify-end gap-2">
+									<div className="flex items-center justify-end gap-1.5">
 										<button
 											type="button"
 											onClick={() => setPreviewFile(file)}
-											className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
+											className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[13px] text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
 											title="查看"
 										>
 											<Eye className="size-4" />
@@ -1418,7 +1419,7 @@ function ProjectFiles({
 										<button
 											type="button"
 											onClick={() => handleDownload(file)}
-											className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
+											className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[13px] text-[var(--leros-text-muted)] transition-colors hover:bg-[var(--leros-primary-softer)] hover:text-[var(--leros-primary)]"
 											title="下载"
 										>
 											<Download className="size-4" />

--- a/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { projectFileApi, useChatStore, useLayoutStore } from "@leros/store";
-import type { Attachment } from "@leros/store/types/chat";
+import type { Attachment, ComposerToken, MessageMetadata } from "@leros/store/types/chat";
 import { Button } from "@leros/ui/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@leros/ui/components/ui/popover";
 import { cn } from "@leros/ui/lib/utils";
@@ -27,6 +27,31 @@ import { PROJECT_ATTACHMENT_ACCEPT } from "../input/ChatInput";
 import { ComposerActionBar } from "../input/ComposerActionBar";
 import { StructuredComposer, type StructuredComposerHandle } from "../input/StructuredComposer";
 import type { AppNavigation } from "./LeftRail";
+
+function removeWorkbenchDirectiveTokens(value: string): string {
+	// 中文注释：选择已有项目后不再支持临时召唤队友/技能，需要同步移除输入框中已插入的指令 token。
+	return value
+		.replace(/(^|\s)(?:@[^\s@/]+|\/[^\s@/]+)(?=\s|$)/g, " ")
+		.replace(/[ \t]{2,}/g, " ")
+		.trimStart();
+}
+
+function buildComposerMetadata(
+	content: string,
+	tokens: ComposerToken[],
+): MessageMetadata | undefined {
+	const trimmed = content.trim();
+	if (!trimmed || tokens.length === 0) return undefined;
+	const leadingOffset = content.length - content.trimStart().length;
+	const composerTokens = tokens
+		.map((token) => ({
+			...token,
+			start: token.start - leadingOffset,
+			end: token.end - leadingOffset,
+		}))
+		.filter((token) => token.start >= 0 && trimmed.slice(token.start, token.end) === token.label);
+	return composerTokens.length > 0 ? { composerTokens } : undefined;
+}
 
 export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 	const {
@@ -91,15 +116,37 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		resetLocalMessages();
 	}, [clearTaskDetailRoute, resetLocalMessages]);
 
+	useEffect(() => {
+		if (!activeWorkbenchProjectId) return;
+		setInput((current) => {
+			const next = removeWorkbenchDirectiveTokens(current);
+			return next === current ? current : next;
+		});
+	}, [activeWorkbenchProjectId]);
+
 	const performSend = async (content: string) => {
 		if (isGenerating || sendingRef.current) return;
 		sendingRef.current = true;
 		try {
-			const data = await sendWorkbenchMessage(content, activeWorkbenchProjectId, attachments);
+			const composerMetadata = buildComposerMetadata(
+				input,
+				composerRef.current?.getComposerTokens() ?? [],
+			);
+			const data = await sendWorkbenchMessage(
+				content,
+				activeWorkbenchProjectId,
+				attachments,
+				composerMetadata,
+			);
 			if (data?.session_id) {
 				const optimisticAttachments = cloneAttachmentsForOptimisticMessage(attachments);
 				// 中文注释：工作台跳转详情页前，先把附件写进 optimistic 消息，避免首屏只剩文本。
-				await startSessionResponseStream(data.session_id, content, optimisticAttachments);
+				await startSessionResponseStream(
+					data.session_id,
+					content,
+					optimisticAttachments,
+					composerMetadata,
+				);
 			}
 			if (navigation && data?.project_id && data?.task_id && data?.session_id) {
 				navigation.goToTaskDetail(data.project_id, data.task_id, data.session_id);
@@ -228,6 +275,9 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 	const handleSelectProject = (projectId: string | null) => {
 		requireAuth(() => {
 			selectWorkbenchProject(projectId);
+			if (projectId) {
+				setInput((current) => removeWorkbenchDirectiveTokens(current));
+			}
 			setProjectMenuOpen(false);
 			setProjectSearch("");
 		});
@@ -371,6 +421,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 								onBlur={() => undefined}
 								placeholder="在这里开始新任务，或输入指令以同步您的项目进度..."
 								isProjectVariant
+								directivesDisabled={Boolean(activeProject)}
 							/>
 						</div>
 						<div className="flex items-center justify-between border-t border-[var(--leros-chat-ai-border)] pt-3">
@@ -386,6 +437,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 										}
 										return true;
 									}}
+									disableAssistantAndSkill={Boolean(activeProject)}
 								/>
 								<Popover open={projectMenuOpen} onOpenChange={handleProjectMenuOpenChange}>
 									<PopoverTrigger

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -726,7 +726,10 @@ function mergeQuestionRequest(
 	next[index] = {
 		...next[index],
 		...update,
-		status: (next[index]?.status ?? "pending") === "pending" ? update.status : next[index]?.status ?? "pending",
+		status:
+			(next[index]?.status ?? "pending") === "pending"
+				? update.status
+				: (next[index]?.status ?? "pending"),
 	};
 	return next;
 }
@@ -1185,7 +1188,7 @@ export class ChatActionImpl {
 		this.#set({ activeSessionId: sessionId });
 	};
 
-	sendMessage = async (content: string, attachments?: Attachment[]) => {
+	sendMessage = async (content: string, attachments?: Attachment[], metadata?: MessageMetadata) => {
 		// 仅上传附件而无文字时后端会报错，必须要求有文本内容
 		if (!content.trim()) return;
 
@@ -1233,6 +1236,9 @@ export class ChatActionImpl {
 				content,
 				message_type: "text",
 				attachments: mapOutgoingAttachments(attachments),
+				metadata: metadata?.composerTokens
+					? { extra: { composerTokens: metadata.composerTokens } }
+					: undefined,
 			});
 		} catch (err) {
 			console.error("sendMessage addMessage error:", err);
@@ -1247,6 +1253,7 @@ export class ChatActionImpl {
 			content,
 			timestamp: now,
 			attachments: mapComposerAttachments(attachments),
+			metadata,
 		};
 
 		const assistantMsg: Message = {
@@ -1273,6 +1280,7 @@ export class ChatActionImpl {
 		content: string,
 		projectId?: string | null,
 		attachments?: Attachment[],
+		metadata?: MessageMetadata,
 	) => {
 		const trimmed = content.trim();
 		if (!trimmed || !projectId) return null;
@@ -1301,7 +1309,7 @@ export class ChatActionImpl {
 				inputAttachments: [],
 			});
 
-			await this.startSessionResponseStream(data.session_id, trimmed, attachments);
+			await this.startSessionResponseStream(data.session_id, trimmed, attachments, metadata);
 
 			const fullState = this.#fullGet() as {
 				fetchProjectDetail?: (projectId: string) => Promise<void>;
@@ -1318,6 +1326,7 @@ export class ChatActionImpl {
 		sessionId: string,
 		content: string,
 		attachments?: Attachment[],
+		metadata?: MessageMetadata,
 	) => {
 		const trimmed = content.trim();
 		if (!sessionId || !trimmed) return;
@@ -1348,6 +1357,7 @@ export class ChatActionImpl {
 			content: trimmed,
 			timestamp: now,
 			attachments: mapComposerAttachments(attachments),
+			metadata,
 		};
 		const assistantMsg: Message = {
 			id: `msg-assistant-${now}`,
@@ -1766,11 +1776,7 @@ export class ChatActionImpl {
 		}
 	};
 
-	submitQuestionAnswer = async (
-		messageId: string,
-		requestId: string,
-		answers: string[][],
-	) => {
+	submitQuestionAnswer = async (messageId: string, requestId: string, answers: string[][]) => {
 		const state = this.#get();
 		const message = state.messagesMap[messageId];
 		const sessionId = message?.conversationId || state.activeSessionId;

--- a/frontend/packages/store/slices/layoutSlice.test.ts
+++ b/frontend/packages/store/slices/layoutSlice.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { Project } from "./layoutSlice";
-import { mergeProjectsFromListResult } from "./layoutSlice";
+import { LayoutActionImpl, mergeProjectsFromListResult } from "./layoutSlice";
 
 function createProject(
 	overrides: Partial<Project> & Pick<Project, "id" | "name" | "updatedAt">,
@@ -77,5 +77,44 @@ describe("mergeProjectsFromListResult", () => {
 		const mergedProjects = mergeProjectsFromListResult(apiProjects, localProjects);
 
 		expect(mergedProjects.map((project) => project.id)).toEqual(["project-1"]);
+	});
+});
+
+describe("LayoutActionImpl composer draft reset", () => {
+	it("从任务详情切回项目页时会清空输入草稿", () => {
+		const clearComposerInput = vi.fn();
+		const setState = vi.fn();
+		const getState = () =>
+			({
+				currentView: "taskDetail",
+				activeProjectId: "project-1",
+				activeTaskDetailProjectId: "project-1",
+				activeTaskDetailTaskId: "task-1",
+				activeTaskDetailSessionId: "session-1",
+				clearComposerInput,
+			}) as never;
+
+		const actions = new LayoutActionImpl(setState, getState);
+		actions.switchProject("project-1");
+
+		expect(clearComposerInput).toHaveBeenCalledTimes(1);
+		expect(setState).toHaveBeenCalledTimes(1);
+	});
+
+	it("切回创建任务首页时会清空输入草稿", () => {
+		const clearComposerInput = vi.fn();
+		const setState = vi.fn();
+		const getState = () =>
+			({
+				currentView: "project",
+				activeProjectId: "project-1",
+				clearComposerInput,
+			}) as never;
+
+		const actions = new LayoutActionImpl(setState, getState);
+		actions.switchView("workbench");
+
+		expect(clearComposerInput).toHaveBeenCalledTimes(1);
+		expect(setState).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -335,6 +335,14 @@ export class LayoutActionImpl {
 		this.#get = get;
 	}
 
+	#clearComposerDraft = () => {
+		const store = this.#get() as LayoutStore & {
+			clearComposerInput?: () => void;
+		};
+		// 中文注释：项目/任务聊天输入框与首页共用同一份草稿状态，离开当前上下文时必须同步清空，避免 token 退化成普通文本残留。
+		store.clearComposerInput?.();
+	};
+
 	toggleLeftRail = () => {
 		this.#set((state) => ({ leftRailCollapsed: !state.leftRailCollapsed }));
 	};
@@ -356,6 +364,10 @@ export class LayoutActionImpl {
 	};
 
 	switchView = (view: ViewMode) => {
+		const state = this.#get();
+		if (state.currentView !== view) {
+			this.#clearComposerDraft();
+		}
 		this.#set({
 			currentView: view,
 			conversationListOpen: view === "chat",
@@ -370,6 +382,10 @@ export class LayoutActionImpl {
 	};
 
 	switchProject = (projectId: string) => {
+		const state = this.#get();
+		if (state.currentView !== "project" || state.activeProjectId !== projectId) {
+			this.#clearComposerDraft();
+		}
 		this.#set({
 			activeProjectId: projectId,
 			activeProjectTab: "chat",
@@ -382,6 +398,10 @@ export class LayoutActionImpl {
 	};
 
 	setProjectRoute = (projectId: string, tab: "chat" | "tasks" | "files" = "chat") => {
+		const state = this.#get();
+		if (state.currentView !== "project" || state.activeProjectId !== projectId) {
+			this.#clearComposerDraft();
+		}
 		this.#set({
 			activeProjectId: projectId,
 			activeProjectTab: tab,
@@ -561,6 +581,15 @@ export class LayoutActionImpl {
 	};
 
 	openTaskDetail = (projectId: string, taskId: string, sessionId: string | null = null) => {
+		const state = this.#get();
+		if (
+			state.currentView !== "taskDetail" ||
+			state.activeTaskDetailProjectId !== projectId ||
+			state.activeTaskDetailTaskId !== taskId ||
+			state.activeTaskDetailSessionId !== sessionId
+		) {
+			this.#clearComposerDraft();
+		}
 		this.#set({
 			activeTaskDetailProjectId: projectId,
 			activeTaskDetailTaskId: taskId,
@@ -570,6 +599,15 @@ export class LayoutActionImpl {
 	};
 
 	setTaskDetailRoute = (projectId: string, taskId: string, sessionId: string | null = null) => {
+		const state = this.#get();
+		if (
+			state.currentView !== "taskDetail" ||
+			state.activeTaskDetailProjectId !== projectId ||
+			state.activeTaskDetailTaskId !== taskId ||
+			state.activeTaskDetailSessionId !== sessionId
+		) {
+			this.#clearComposerDraft();
+		}
 		this.#set({
 			activeProjectId: projectId,
 			activeTaskDetailProjectId: projectId,

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -4,7 +4,7 @@ import { taskApi } from "../api/taskApi";
 import type { BackendArtifact, BackendProject, BackendSession, BackendTask } from "../api/types";
 import { workApi } from "../api/workApi";
 import type { SliceCreator } from "../types";
-import type { Attachment } from "../types/chat";
+import type { Attachment, MessageMetadata } from "../types/chat";
 import { flattenActions } from "../utils";
 import { formatFileSize, parseOptionalTimestamp } from "../utils/format";
 
@@ -420,6 +420,7 @@ export class LayoutActionImpl {
 		content: string,
 		projectId?: string | null,
 		attachments?: Attachment[],
+		_metadata?: MessageMetadata,
 	) => {
 		const trimmed = content.trim();
 		if (!trimmed) return;

--- a/frontend/packages/store/types/chat.ts
+++ b/frontend/packages/store/types/chat.ts
@@ -93,6 +93,14 @@ export type MessageMetadata = {
 	model?: string;
 	tokens?: number;
 	latency?: number;
+	composerTokens?: ComposerToken[];
+};
+
+export type ComposerToken = {
+	kind: "assistant" | "skill";
+	label: string;
+	start: number;
+	end: number;
 };
 
 export type MessageUsage = {

--- a/frontend/packages/store/utils/messageMetrics.ts
+++ b/frontend/packages/store/utils/messageMetrics.ts
@@ -1,10 +1,11 @@
-import type { Message, MessageMetadata, MessageUsage } from "../types/chat";
+import type { ComposerToken, Message, MessageMetadata, MessageUsage } from "../types/chat";
 import { formatLatency, formatTokenCount } from "./format";
 
 type MetadataSource = {
 	model?: string;
 	tokens?: number;
 	latency?: number;
+	composerTokens?: ComposerToken[];
 	extra?: Record<string, unknown>;
 };
 
@@ -22,6 +23,24 @@ function pickNumber(...values: unknown[]): number | undefined {
 		if (typeof value === "number" && Number.isFinite(value)) {
 			return value;
 		}
+	}
+	return undefined;
+}
+
+function pickComposerTokens(...values: unknown[]): ComposerToken[] | undefined {
+	for (const value of values) {
+		if (!Array.isArray(value)) continue;
+		const tokens = value.filter((item): item is ComposerToken => {
+			if (typeof item !== "object" || item === null) return false;
+			const token = item as Partial<ComposerToken>;
+			return (
+				(token.kind === "assistant" || token.kind === "skill") &&
+				typeof token.label === "string" &&
+				typeof token.start === "number" &&
+				typeof token.end === "number"
+			);
+		});
+		if (tokens.length > 0) return tokens;
 	}
 	return undefined;
 }
@@ -49,11 +68,12 @@ export function buildMessageMetadata(
 	const model = pickString(metadata?.model, extra?.model, extra?.model_name);
 	const tokens = pickNumber(metadata?.tokens, extra?.tokens, usage?.totalTokens);
 	const latency = pickNumber(metadata?.latency, extra?.latency, extra?.latency_ms);
+	const composerTokens = pickComposerTokens(metadata?.composerTokens, extra?.composerTokens);
 
-	if (!model && tokens === undefined && latency === undefined) {
+	if (!model && tokens === undefined && latency === undefined && !composerTokens) {
 		return undefined;
 	}
-	return { model, tokens, latency };
+	return { model, tokens, latency, composerTokens };
 }
 
 /** 读取单条 assistant 消息的 tokens / latency 原始指标。 */


### PR DESCRIPTION
## 变更
- 优化左侧“最近项目”标题文案与展示样式
- 统一 `/` 触发和“添加技能”按钮的技能选择弹窗体验
- 技能搜索改为仅按名称/code 匹配，避免描述文本误命中
- 修复技能弹窗 focus、点击输入框关闭、回车选择、token 后正文分隔空格等交互
- 修复普通文本中的 `@` / `/` 被误渲染为队友或技能样式
- 新增 composerTokens metadata，让用户消息中真实选中的队友/技能与普通正文可混排展示
- 选择已有项目时清理并禁用临时队友/技能选择

## 验证
- `biome check` 相关 9 个文件通过
- `git diff --check` 通过
- `tsc --noEmit -p packages/app-ui/tsconfig.json` 通过
- `tsc --noEmit -p packages/store/tsconfig.json` 通过