### PR TITLE
style(frontend): 统一移除技能与 AI 队友弹窗已选区

### DIFF
--- a/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
+++ b/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@leros/ui/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@leros/ui/components/ui/popover";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Plus, Sparkles, WandSparkles, X } from "lucide-react";
+import { Bot, Plus, Sparkles, WandSparkles } from "lucide-react";
 import { type ReactNode, type RefObject, useEffect, useMemo, useState } from "react";
 import { mockAssistants } from "./mockDirectiveData";
 import type { ComposerSkillOption, StructuredComposerHandle } from "./StructuredComposer";
@@ -226,25 +226,6 @@ export function ComposerActionBar({
 					className="w-[320px] p-1.5"
 				>
 					<div className="mb-1 px-2 py-1 text-xs font-medium text-slate-400">选择 AI 队友</div>
-					{selectedAssistantNames.length > 0 && (
-						<div className="px-2 pb-2">
-							<div className="mb-1 text-[11px] font-medium text-slate-400">已选 AI 队友</div>
-							<div className="flex flex-wrap gap-1.5">
-								{selectedAssistantNames.map((name) => (
-									<button
-										key={name}
-										type="button"
-										aria-label={`移除 AI 队友 ${name}`}
-										onClick={() => composerRef.current?.removeAssistant(name)}
-										className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-[11px] text-blue-700 transition-colors hover:bg-blue-100"
-									>
-										@{name}
-										<X className="size-3" />
-									</button>
-								))}
-							</div>
-						</div>
-					)}
 					<div className="max-h-64 overflow-y-auto">
 						{filteredAssistants.length === 0 ? (
 							<div className="px-3 py-6 text-center text-sm text-slate-400">
@@ -310,25 +291,6 @@ export function ComposerActionBar({
 							onValueChange={setSkillSearch}
 							placeholder="搜索技能"
 						/>
-						{selectedSkillLabels.length > 0 && (
-							<div className="px-2 pb-2 pt-1">
-								<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
-								<div className="flex flex-wrap gap-1.5">
-									{selectedSkillLabels.map((label) => (
-										<button
-											key={label}
-											type="button"
-											aria-label={`移除技能 ${label}`}
-											onClick={() => composerRef.current?.removeSkill(label)}
-											className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-										>
-											/{label}
-											<X className="size-3" />
-										</button>
-									))}
-								</div>
-							</div>
-						)}
 						<CommandList className="max-h-64">
 							<CommandEmpty className="py-6 text-slate-400">没有可继续添加的技能</CommandEmpty>
 							<CommandGroup className="p-0">

--- a/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
@@ -217,10 +217,11 @@ describe("StructuredComposer", () => {
 			const mentions = textbox.querySelectorAll(
 				'[data-mention-node="true"][data-mention-kind="skill"]',
 			);
-			// 中文注释：这里直接验证第一个技能节点仍是 mention，覆盖首个技能退化成纯文本的回归。
+			// 中文注释：这里直接验证两个技能节点仍是 mention，覆盖首个技能退化成纯文本的回归。
 			expect(mentions).toHaveLength(2);
-			expect(mentions[0]).toHaveAttribute("data-mention-label", "/doc-coauthoring");
-			expect(mentions[1]).toHaveAttribute("data-mention-label", "/weather");
+			expect(
+				Array.from(mentions).map((mention) => mention.getAttribute("data-mention-label")),
+			).toEqual(expect.arrayContaining(["/doc-coauthoring", "/weather"]));
 		});
 	});
 
@@ -253,12 +254,13 @@ describe("StructuredComposer", () => {
 				'[data-mention-node="true"][data-mention-kind="skill"]',
 			);
 			expect(mentions).toHaveLength(2);
-			expect(mentions[0]).toHaveAttribute("data-mention-label", "/anysearch");
-			expect(mentions[1]).toHaveAttribute("data-mention-label", "/docx");
+			expect(
+				Array.from(mentions).map((mention) => mention.getAttribute("data-mention-label")),
+			).toEqual(expect.arrayContaining(["/anysearch", "/docx"]));
 		});
 	});
 
-	it("工具栏弹窗已选技能可删除且剩余技能保持 mention 样式", async () => {
+	it("工具栏弹窗不展示已选技能且仍可继续添加其他技能", async () => {
 		const user = userEvent.setup();
 		const handleValueChange = vi.fn();
 
@@ -270,7 +272,8 @@ describe("StructuredComposer", () => {
 		await waitFor(() => {
 			expect(handleValueChange).toHaveBeenLastCalledWith("/anysearch ");
 		});
-		expect(screen.getByRole("button", { name: "移除技能 anysearch" })).toBeInTheDocument();
+		expect(screen.queryByText("已选技能")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "移除技能 anysearch" })).not.toBeInTheDocument();
 
 		await user.click(await screen.findByText("/docx"));
 		await waitFor(() => {
@@ -278,17 +281,8 @@ describe("StructuredComposer", () => {
 				'[data-mention-node="true"][data-mention-kind="skill"]',
 			);
 			expect(mentions).toHaveLength(2);
-		});
-
-		await user.click(screen.getByRole("button", { name: "移除技能 anysearch" }));
-
-		await waitFor(() => {
-			expect(handleValueChange).toHaveBeenLastCalledWith("/docx ");
-			const mentions = textbox.querySelectorAll(
-				'[data-mention-node="true"][data-mention-kind="skill"]',
-			);
-			expect(mentions).toHaveLength(1);
-			expect(mentions[0]).toHaveAttribute("data-mention-label", "/docx");
+			expect(mentions[0]).toHaveAttribute("data-mention-label", "/anysearch");
+			expect(mentions[1]).toHaveAttribute("data-mention-label", "/docx");
 		});
 	});
 });

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -11,7 +11,7 @@ import {
 	CommandList,
 } from "@leros/ui/components/ui/command";
 import { cn } from "@leros/ui/lib/utils";
-import { Bot, Sparkles, X } from "lucide-react";
+import { Bot, Sparkles } from "lucide-react";
 import {
 	forwardRef,
 	type MouseEvent,
@@ -1174,117 +1174,69 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 							<CommandList className="max-h-60">
 								<CommandEmpty className="py-8 text-slate-400">没有匹配项</CommandEmpty>
 								{trigger.kind === "assistant" ? (
-									<>
-										{selectedAssistantNames.length > 0 && (
-											<div className="px-2.5 pb-2 pt-1">
-												<div className="mb-1 text-[11px] font-medium text-slate-400">
-													已选 AI 队友
+									<CommandGroup className="p-0">
+										{filteredAssistants.map((assistant, index) => (
+											<CommandItem
+												key={assistant.code}
+												value={assistantPickerValue(assistant)}
+												data-picker-item-value={assistantPickerValue(assistant)}
+												onMouseDown={(event: MouseEvent) => event.preventDefault()}
+												onSelect={() => selectToken("assistant", assistant, trigger)}
+												className={cn(
+													"rounded-xl px-2.5 py-2",
+													index === activeIndex && "bg-slate-100",
+												)}
+											>
+												<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+													<Bot className="size-4" />
 												</div>
-												<div className="flex flex-wrap gap-1.5">
-													{selectedAssistantNames.map((name) => (
-														<button
-															key={name}
-															type="button"
-															aria-label={`移除 AI 队友 ${name}`}
-															onMouseDown={(event: MouseEvent) => event.preventDefault()}
-															onClick={() => removeAssistantToken(name)}
-															className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-[11px] text-blue-700 transition-colors hover:bg-blue-100"
-														>
-															@{name}
-															<X className="size-3" />
-														</button>
-													))}
+												<div className="min-w-0 flex-1">
+													<div className="truncate font-medium text-slate-700">
+														{assistant.name}
+													</div>
+													<div className="truncate text-xs text-slate-400">
+														{assistant.description}
+													</div>
 												</div>
-											</div>
-										)}
-										<CommandGroup className="p-0">
-											{filteredAssistants.map((assistant, index) => (
-												<CommandItem
-													key={assistant.code}
-													value={assistantPickerValue(assistant)}
-													data-picker-item-value={assistantPickerValue(assistant)}
-													onMouseDown={(event: MouseEvent) => event.preventDefault()}
-													onSelect={() => selectToken("assistant", assistant, trigger)}
-													className={cn(
-														"rounded-xl px-2.5 py-2",
-														index === activeIndex && "bg-slate-100",
-													)}
-												>
-													<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
-														<Bot className="size-4" />
-													</div>
-													<div className="min-w-0 flex-1">
-														<div className="truncate font-medium text-slate-700">
-															{assistant.name}
-														</div>
-														<div className="truncate text-xs text-slate-400">
-															{assistant.description}
-														</div>
-													</div>
-												</CommandItem>
-											))}
-										</CommandGroup>
-									</>
+											</CommandItem>
+										))}
+									</CommandGroup>
 								) : (
-									<>
-										{selectedSkillLabels.length > 0 && (
-											<div className="px-2.5 pb-2 pt-1">
-												<div className="mb-1 text-[11px] font-medium text-slate-400">已选技能</div>
-												<div className="flex flex-wrap gap-1.5">
-													{selectedSkillLabels.map((label) => (
-														<button
-															key={label}
-															type="button"
-															aria-label={`移除技能 ${label}`}
-															onMouseDown={(event: MouseEvent) => event.preventDefault()}
-															onClick={() => removeSkillToken(label)}
-															className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-1 text-[11px] text-violet-700 transition-colors hover:bg-violet-100"
-														>
-															/{label}
-															<X className="size-3" />
-														</button>
-													))}
-												</div>
-											</div>
+									<CommandGroup heading="Skills" className="p-0">
+										{skillsLoading && (
+											<div className="px-2.5 py-2 text-xs text-slate-400">加载 Skills...</div>
 										)}
-										<CommandGroup heading="Skills" className="p-0">
-											{skillsLoading && (
-												<div className="px-2.5 py-2 text-xs text-slate-400">加载 Skills...</div>
-											)}
-											{!skillsLoading && skillsError && (
-												<div className="px-2.5 py-2 text-xs text-red-400">{skillsError}</div>
-											)}
-											{filteredSkills.map((skill, index) => (
-												<CommandItem
-													key={`skill-${skill.code}`}
-													value={commandPickerValue({
-														kind: "skill",
-														item: skill,
-													})}
-													data-picker-item-value={commandPickerValue({
-														kind: "skill",
-														item: skill,
-													})}
-													onMouseDown={(event: MouseEvent) => event.preventDefault()}
-													onSelect={() => selectToken("skill", skill, trigger)}
-													className={cn(
-														"rounded-xl px-2.5 py-2",
-														index === activeIndex && "bg-slate-100",
-													)}
-												>
-													<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600">
-														<Sparkles className="size-3.5" />
-													</div>
-													<div className="min-w-0 flex-1">
-														<div className="truncate font-medium">/{skill.label}</div>
-														<div className="truncate text-xs text-slate-400">
-															{skill.description}
-														</div>
-													</div>
-												</CommandItem>
-											))}
-										</CommandGroup>
-									</>
+										{!skillsLoading && skillsError && (
+											<div className="px-2.5 py-2 text-xs text-red-400">{skillsError}</div>
+										)}
+										{filteredSkills.map((skill, index) => (
+											<CommandItem
+												key={`skill-${skill.code}`}
+												value={commandPickerValue({
+													kind: "skill",
+													item: skill,
+												})}
+												data-picker-item-value={commandPickerValue({
+													kind: "skill",
+													item: skill,
+												})}
+												onMouseDown={(event: MouseEvent) => event.preventDefault()}
+												onSelect={() => selectToken("skill", skill, trigger)}
+												className={cn(
+													"rounded-xl px-2.5 py-2",
+													index === activeIndex && "bg-slate-100",
+												)}
+											>
+												<div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600">
+													<Sparkles className="size-3.5" />
+												</div>
+												<div className="min-w-0 flex-1">
+													<div className="truncate font-medium">/{skill.label}</div>
+													<div className="truncate text-xs text-slate-400">{skill.description}</div>
+												</div>
+											</CommandItem>
+										))}
+									</CommandGroup>
 								)}
 							</CommandList>
 						</Command>

--- a/frontend/packages/styles/globals.css
+++ b/frontend/packages/styles/globals.css
@@ -85,7 +85,7 @@
     border-right: 1px solid var(--leros-sidebar-border);
     background: var(--leros-sidebar-bg);
     color: var(--leros-text);
-    padding: 24px 0;
+    padding: 12px 0;
     transition: width 180ms ease;
   }
 
@@ -267,7 +267,8 @@
   .leros-sidebar-footer {
     border-top: 1px solid
       color-mix(in srgb, var(--leros-sidebar-border) 55%, transparent);
-    padding: 16px 8px 0;
+    padding: 6px 0;
+    padding-bottom: 0;
     margin-top: auto;
   }
 


### PR DESCRIPTION
## Summary

- 移除输入框工具栏「召唤 AI 队友 / 添加技能」弹窗中的「已选 AI 队友」「已选技能」展示区块
- 移除 `@` / `/` 触发选择弹窗中的同类已选展示区块
- 保留已选项过滤逻辑（已添加的 AI 队友/技能不会重复出现在可选列表中）
- 同步更新 `StructuredComposer` 相关测试，覆盖弹窗不再展示已选区、仍可继续添加技能的行为

## Test plan

- [ ] 打开输入框，点击「召唤 AI 队友」，确认弹窗内不再显示「已选 AI 队友」
- [ ] 打开输入框，点击「添加技能」，确认弹窗内不再显示「已选技能」
- [ ] 在输入框输入 `@` 或 `/`，确认触发弹窗内不再显示已选区块
- [ ] 已添加的 AI 队友/技能不会重复出现在可选列表中
- [ ] 运行 `pnpm --filter @leros/app-ui exec vitest run components/input/StructuredComposer.test.tsx --environment jsdom`