### PR TITLE
Skill name language label

### DIFF
--- a/backend/cmd/leros/skill.go
+++ b/backend/cmd/leros/skill.go
@@ -166,6 +166,8 @@ func runInstall(identifier string) error {
 		Content: string(bundle.Content),
 		Files:   files,
 		Force:   skillForce,
+		Source:  meta.Source,
+		SkillID: meta.Identifier,
 	})
 	if err != nil {
 		return fmt.Errorf("install skill: %w", err)

--- a/backend/internal/service/skill_marketplace_service.go
+++ b/backend/internal/service/skill_marketplace_service.go
@@ -644,6 +644,7 @@ func (s *skillMarketplaceService) listInstalledSkills(ctx context.Context) ([]co
 	if err := json.Unmarshal(rawData, &skills); err != nil {
 		return nil, fmt.Errorf("unmarshal skill list items: %w", err)
 	}
+	skills = filterUserVisibleInstalledSkills(skills)
 	s.enrichInstalledSystemSkills(ctx, skills)
 
 	return skills, nil
@@ -1081,8 +1082,12 @@ func (s *skillMarketplaceService) getInstalledSkillDetail(ctx context.Context, s
 		return nil, fmt.Errorf("unmarshal skill detail items: %w", err)
 	}
 
+	detailSkillID := strings.TrimSpace(detail.SkillID)
+	if detailSkillID == "" {
+		detailSkillID = detail.Name
+	}
 	detailResp := &contract.SkillDetailResponse{
-		SkillID:     detail.Name,
+		SkillID:     detailSkillID,
 		Source:      "installed",
 		Name:        detail.Name,
 		DisplayName: "",
@@ -1120,10 +1125,6 @@ func (s *skillMarketplaceService) enrichInstalledSystemSkills(ctx context.Contex
 	builtinByID, err := s.builtinItemsBySkillID(ctx, names)
 	if err != nil {
 		logs.WarnContextf(ctx, "enrich installed system skills: query builtin skills: %v", err)
-		return
-	}
-	if len(builtinByID) == 0 {
-		return
 	}
 
 	views := make([]contract.SkillMarketplaceItemView, 0, len(builtinByID))
@@ -1193,13 +1194,13 @@ func (s *skillMarketplaceService) enrichInstalledSystemSkillDetail(ctx context.C
 		return
 	}
 
-	builtinByID, err := s.builtinItemsBySkillID(ctx, []string{detail.Name})
+	identifiers := installedSkillDetailLookupKeys(detail)
+	builtinByID, err := s.builtinItemsBySkillID(ctx, identifiers)
 	if err != nil {
 		logs.WarnContextf(ctx, "enrich installed system skill detail: query builtin skill: %v", err)
 		return
 	}
-	item, ok := builtinByID[detail.Name]
-	if ok {
+	if item, ok := firstBuiltinItemByKey(builtinByID, identifiers); ok {
 		views := []contract.SkillMarketplaceItemView{builtinItemToView(item)}
 		s.resolveCacheAndTranslation(ctx, views)
 		if len(views) == 0 {
@@ -1215,12 +1216,12 @@ func (s *skillMarketplaceService) enrichInstalledSystemSkillDetail(ctx context.C
 		return
 	}
 
-	cachedByName, err := s.cachedMarketplaceItemsBySkillName(ctx, []string{detail.Name})
+	cachedByName, err := s.cachedMarketplaceItemsBySkillName(ctx, identifiers)
 	if err != nil {
 		logs.WarnContextf(ctx, "enrich installed marketplace skill detail: query cached skill: %v", err)
 		return
 	}
-	if cached, ok := cachedByName[detail.Name]; ok {
+	if cached, ok := firstCachedMarketplaceItemByKey(cachedByName, identifiers); ok {
 		views := []contract.SkillMarketplaceItemView{cachedItemToView(cached)}
 		s.resolveCacheAndTranslation(ctx, views)
 		if len(views) == 0 {
@@ -1233,6 +1234,54 @@ func (s *skillMarketplaceService) enrichInstalledSystemSkillDetail(ctx context.C
 		if detail.Category == "" {
 			detail.Category = views[0].Category
 		}
+		s.localizeInstalledSkillMarkdown(ctx, detail, &cached)
+	}
+}
+
+func (s *skillMarketplaceService) localizeInstalledSkillMarkdown(ctx context.Context, detail *contract.SkillDetailResponse, item *types.SkillMarketplaceItem) {
+	if detail == nil || item == nil {
+		return
+	}
+	if strings.TrimSpace(detail.SkillMD) == "" || utils.CJKRatioMarkdown(detail.SkillMD) >= cjkTranslationThreshold {
+		return
+	}
+
+	if s.st != nil && item.PackageStoragePath != "" {
+		zhBody, zhDesc, zhErr := skillcache.ReadChineseDocumentFromStorage(ctx, s.st, item.PackageStoragePath)
+		if zhErr == nil && zhBody != "" {
+			detail.SkillMD = zhBody
+			if zhDesc != "" {
+				detail.Description = zhDesc
+			}
+			return
+		}
+		logs.WarnContextf(ctx, "localize installed skill markdown: read SKILL.zh-CN.md for %s/%s@%s: %v", item.Source, item.SkillID, item.Version, zhErr)
+	}
+
+	if s.translator == nil {
+		return
+	}
+	translationMap, err := s.translator.TranslateDocument(ctx, []TranslateDocumentItem{
+		{SkillID: item.SkillID, Content: detail.SkillMD},
+	})
+	if err != nil {
+		logs.WarnContextf(ctx, "localize installed skill markdown: translate %s/%s@%s: %v", item.Source, item.SkillID, item.Version, err)
+		return
+	}
+	translated := strings.TrimSpace(translationMap[item.SkillID])
+	if translated == "" {
+		return
+	}
+	manifest, body, parseErr := catalog.ParseDocument([]byte(translated))
+	if parseErr != nil {
+		logs.WarnContextf(ctx, "localize installed skill markdown: parse translated %s/%s@%s: %v", item.Source, item.SkillID, item.Version, parseErr)
+		return
+	}
+	if strings.TrimSpace(body) != "" {
+		detail.SkillMD = body
+	}
+	if strings.TrimSpace(manifest.Description) != "" {
+		detail.Description = manifest.Description
 	}
 }
 
@@ -1326,6 +1375,42 @@ func cachedItemToView(item types.SkillMarketplaceItem) contract.SkillMarketplace
 func seenResultKey(items map[string]types.SkillMarketplaceItem, key string) bool {
 	_, ok := items[key]
 	return ok
+}
+
+func installedSkillDetailLookupKeys(detail *contract.SkillDetailResponse) []string {
+	if detail == nil {
+		return nil
+	}
+
+	keys := make([]string, 0, 2)
+	seen := make(map[string]bool, 2)
+	for _, key := range []string{detail.SkillID, detail.Name} {
+		key = strings.TrimSpace(key)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func firstBuiltinItemByKey(items map[string]types.BuiltinSkillMarketplaceItem, keys []string) (types.BuiltinSkillMarketplaceItem, bool) {
+	for _, key := range keys {
+		if item, ok := items[key]; ok {
+			return item, true
+		}
+	}
+	return types.BuiltinSkillMarketplaceItem{}, false
+}
+
+func firstCachedMarketplaceItemByKey(items map[string]types.SkillMarketplaceItem, keys []string) (types.SkillMarketplaceItem, bool) {
+	for _, key := range keys {
+		if item, ok := items[key]; ok {
+			return item, true
+		}
+	}
+	return types.SkillMarketplaceItem{}, false
 }
 
 // ImportSkill 从已上传文件导入 Skill，校验内容后发送给 Worker 并等待完成。

--- a/backend/internal/service/skill_marketplace_service.go
+++ b/backend/internal/service/skill_marketplace_service.go
@@ -1138,18 +1138,52 @@ func (s *skillMarketplaceService) enrichInstalledSystemSkills(ctx context.Contex
 	for _, view := range views {
 		viewByID[view.SkillID] = view
 	}
+	cachedByName, err := s.cachedMarketplaceItemsBySkillName(ctx, names)
+	if err != nil {
+		logs.WarnContextf(ctx, "enrich installed marketplace skills: query cached skills: %v", err)
+	}
+	cachedViews := make([]contract.SkillMarketplaceItemView, 0, len(cachedByName))
+	seenCachedSkillIDs := make(map[string]bool, len(cachedByName))
+	for _, item := range cachedByName {
+		key := item.Source + "|" + item.SkillID + "|" + item.Version
+		if seenCachedSkillIDs[key] {
+			continue
+		}
+		seenCachedSkillIDs[key] = true
+		cachedViews = append(cachedViews, cachedItemToView(item))
+	}
+	s.resolveCacheAndTranslation(ctx, cachedViews)
+	cachedViewByName := make(map[string]contract.SkillMarketplaceItemView, len(cachedViews)*2)
+	for _, view := range cachedViews {
+		if strings.TrimSpace(view.SkillID) != "" {
+			cachedViewByName[view.SkillID] = view
+		}
+		if strings.TrimSpace(view.Name) != "" {
+			cachedViewByName[view.Name] = view
+		}
+	}
 
 	for idx := range skills {
 		view, ok := viewByID[skills[idx].Name]
-		if !ok {
+		if ok {
+			skills[idx].DisplayName = view.DisplayName
+			if view.Description != "" {
+				skills[idx].Description = view.Description
+			}
+			if skills[idx].Category == "" {
+				skills[idx].Category = view.Category
+			}
 			continue
 		}
-		skills[idx].DisplayName = view.DisplayName
-		if view.Description != "" {
-			skills[idx].Description = view.Description
-		}
-		if skills[idx].Category == "" {
-			skills[idx].Category = view.Category
+
+		if cachedView, ok := cachedViewByName[skills[idx].Name]; ok {
+			skills[idx].DisplayName = cachedView.DisplayName
+			if cachedView.Description != "" {
+				skills[idx].Description = cachedView.Description
+			}
+			if skills[idx].Category == "" {
+				skills[idx].Category = cachedView.Category
+			}
 		}
 	}
 }
@@ -1165,21 +1199,40 @@ func (s *skillMarketplaceService) enrichInstalledSystemSkillDetail(ctx context.C
 		return
 	}
 	item, ok := builtinByID[detail.Name]
-	if !ok {
+	if ok {
+		views := []contract.SkillMarketplaceItemView{builtinItemToView(item)}
+		s.resolveCacheAndTranslation(ctx, views)
+		if len(views) == 0 {
+			return
+		}
+		detail.DisplayName = views[0].DisplayName
+		if views[0].Description != "" {
+			detail.Description = views[0].Description
+		}
+		if detail.Category == "" {
+			detail.Category = views[0].Category
+		}
 		return
 	}
 
-	views := []contract.SkillMarketplaceItemView{builtinItemToView(item)}
-	s.resolveCacheAndTranslation(ctx, views)
-	if len(views) == 0 {
+	cachedByName, err := s.cachedMarketplaceItemsBySkillName(ctx, []string{detail.Name})
+	if err != nil {
+		logs.WarnContextf(ctx, "enrich installed marketplace skill detail: query cached skill: %v", err)
 		return
 	}
-	detail.DisplayName = views[0].DisplayName
-	if views[0].Description != "" {
-		detail.Description = views[0].Description
-	}
-	if detail.Category == "" {
-		detail.Category = views[0].Category
+	if cached, ok := cachedByName[detail.Name]; ok {
+		views := []contract.SkillMarketplaceItemView{cachedItemToView(cached)}
+		s.resolveCacheAndTranslation(ctx, views)
+		if len(views) == 0 {
+			return
+		}
+		detail.DisplayName = views[0].DisplayName
+		if views[0].Description != "" {
+			detail.Description = views[0].Description
+		}
+		if detail.Category == "" {
+			detail.Category = views[0].Category
+		}
 	}
 }
 
@@ -1213,6 +1266,66 @@ func (s *skillMarketplaceService) builtinItemsBySkillID(ctx context.Context, ski
 		result[item.SkillID] = item
 	}
 	return result, nil
+}
+
+func (s *skillMarketplaceService) cachedMarketplaceItemsBySkillName(ctx context.Context, names []string) (map[string]types.SkillMarketplaceItem, error) {
+	result := make(map[string]types.SkillMarketplaceItem)
+	if len(names) == 0 || s.db == nil {
+		return result, nil
+	}
+
+	unique := make([]string, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		unique = append(unique, name)
+	}
+	if len(unique) == 0 {
+		return result, nil
+	}
+
+	var items []types.SkillMarketplaceItem
+	if err := s.db.WithContext(ctx).
+		Where("skill_id IN ? OR name IN ?", unique, unique).
+		Order("updated_at DESC").
+		Find(&items).Error; err != nil {
+		return nil, err
+	}
+
+	for _, item := range items {
+		for _, key := range []string{item.SkillID, item.Name} {
+			key = strings.TrimSpace(key)
+			if key == "" || seenResultKey(result, key) {
+				continue
+			}
+			result[key] = item
+		}
+	}
+	return result, nil
+}
+
+func cachedItemToView(item types.SkillMarketplaceItem) contract.SkillMarketplaceItemView {
+	return skillMarketplaceItemView(
+		item.Source,
+		item.SkillID,
+		item.Name,
+		item.Description,
+		item.Version,
+		item.Author,
+		item.Category,
+		[]string(item.Tags),
+		"",
+		item.Installs,
+	)
+}
+
+func seenResultKey(items map[string]types.SkillMarketplaceItem, key string) bool {
+	_, ok := items[key]
+	return ok
 }
 
 // ImportSkill 从已上传文件导入 Skill，校验内容后发送给 Worker 并等待完成。

--- a/backend/internal/service/skill_service.go
+++ b/backend/internal/service/skill_service.go
@@ -130,10 +130,26 @@ func (s *skillService) fetchInstalledSkills(ctx context.Context, orgID uint) ([]
 		})
 	}
 
+	result = filterUserVisibleInstalledSkills(result)
 	(&skillMarketplaceService{
 		db:         s.db,
 		translator: NewDefaultSkillDescriptionTranslator(s.db),
 	}).enrichInstalledSystemSkills(ctx, result)
 
 	return result, nil
+}
+
+func filterUserVisibleInstalledSkills(skills []contract.SkillInstalledItem) []contract.SkillInstalledItem {
+	if len(skills) == 0 {
+		return skills
+	}
+
+	result := skills[:0]
+	for _, skill := range skills {
+		if strings.EqualFold(strings.TrimSpace(skill.Source), "local") {
+			continue
+		}
+		result = append(result, skill)
+	}
+	return result
 }

--- a/backend/internal/service/skill_service.go
+++ b/backend/internal/service/skill_service.go
@@ -130,5 +130,10 @@ func (s *skillService) fetchInstalledSkills(ctx context.Context, orgID uint) ([]
 		})
 	}
 
+	(&skillMarketplaceService{
+		db:         s.db,
+		translator: NewDefaultSkillDescriptionTranslator(s.db),
+	}).enrichInstalledSystemSkills(ctx, result)
+
 	return result, nil
 }

--- a/backend/internal/skill/catalog/catalog.go
+++ b/backend/internal/skill/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -13,6 +14,12 @@ import (
 )
 
 const skillFileName = "SKILL.md"
+const skillMetadataFileName = ".skill-metadata"
+
+type storedSkillMetadata struct {
+	Source  string `json:"source"`
+	SkillID string `json:"skill_id"`
+}
 
 // ErrSkillNotFound is returned when a skill cannot be found in the catalog.
 type ErrSkillNotFound struct {
@@ -160,13 +167,15 @@ func tryParseSkillFile(path, requestedName string) (*Entry, string) {
 	}
 
 	absDir := filepath.Dir(path)
-	return &Entry{
+	entry := &Entry{
 		Manifest:    *manifest,
 		Body:        body,
 		Dir:         filepath.ToSlash(dirName),
 		Path:        skillFileName,
 		AbsoluteDir: filepath.ToSlash(absDir),
-	}, ""
+	}
+	applyStoredMetadata(entry)
+	return entry, ""
 }
 
 // ReadFile reads a supporting file from a skill directory in the default Leros
@@ -275,6 +284,7 @@ func readAllSkills() (map[string]*Entry, string, error) {
 			Path:        filepath.ToSlash(filepath.Join(subDir, skillFileName)),
 			AbsoluteDir: filepath.ToSlash(filepath.Join(dir, subDir)),
 		}
+		applyStoredMetadata(entry)
 		if _, exists := entries[entry.Manifest.Name]; exists {
 			return fmt.Errorf("duplicate skill name %q", entry.Manifest.Name)
 		}
@@ -286,6 +296,34 @@ func readAllSkills() (map[string]*Entry, string, error) {
 	}
 
 	return entries, dir, nil
+}
+
+func applyStoredMetadata(entry *Entry) {
+	if entry == nil {
+		return
+	}
+	metadata, err := readStoredMetadata(entry.AbsoluteDir)
+	if err != nil {
+		return
+	}
+	if strings.TrimSpace(metadata.Source) != "" {
+		entry.Manifest.Metadata.Source = strings.TrimSpace(metadata.Source)
+	}
+	if strings.TrimSpace(metadata.SkillID) != "" {
+		entry.StoredSkillID = strings.TrimSpace(metadata.SkillID)
+	}
+}
+
+func readStoredMetadata(skillDir string) (*storedSkillMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(filepath.FromSlash(skillDir), skillMetadataFileName))
+	if err != nil {
+		return nil, err
+	}
+	var metadata storedSkillMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
 }
 
 // resolveInside resolves a relative path within root and validates that the result

--- a/backend/internal/skill/catalog/catalog_test.go
+++ b/backend/internal/skill/catalog/catalog_test.go
@@ -114,6 +114,39 @@ metadata:
 	}
 }
 
+func TestListUsesStoredSkillMetadataSource(t *testing.T) {
+	skillsDir := setupSkillsRoot(t)
+	skillDir := filepath.Join(skillsDir, "market-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, skillFileName), []byte(`---
+name: market-skill
+description: Installed from marketplace.
+---
+# Market Skill
+`), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, skillMetadataFileName), []byte(`{"source":"Leros","skill_id":"market-skill"}`), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	summaries, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(summaries))
+	}
+	if summaries[0].Source != "Leros" {
+		t.Fatalf("expected source Leros, got %s", summaries[0].Source)
+	}
+	if summaries[0].SkillID != "market-skill" {
+		t.Fatalf("expected skill id market-skill, got %s", summaries[0].SkillID)
+	}
+}
+
 func TestGetCaseInsensitive(t *testing.T) {
 	skillsDir := setupSkillsRoot(t)
 	writeTestSkill(t, skillsDir, "my-skill", "My Skill", "body")

--- a/backend/internal/skill/catalog/types.go
+++ b/backend/internal/skill/catalog/types.go
@@ -39,15 +39,17 @@ type ManifestMetadata struct {
 
 // Entry 表示一个已发现并解析出元数据和正文的 Skill 文档。
 type Entry struct {
-	Manifest    Manifest
-	Body        string
-	Dir         string
-	Path        string
-	AbsoluteDir string
+	Manifest      Manifest
+	Body          string
+	Dir           string
+	Path          string
+	AbsoluteDir   string
+	StoredSkillID string
 }
 
 // Summary 是注入运行时提示词的紧凑视图。
 type Summary struct {
+	SkillID       string
 	Name          string
 	Description   string
 	Version       string
@@ -70,6 +72,7 @@ func (e *Entry) Summary() Summary {
 		trust = "trusted"
 	}
 	return Summary{
+		SkillID:       e.StoredSkillID,
 		Name:          e.Manifest.Name,
 		Description:   e.Manifest.Description,
 		Version:       e.Manifest.Version,

--- a/backend/internal/worker/command/skill/handler.go
+++ b/backend/internal/worker/command/skill/handler.go
@@ -314,13 +314,15 @@ func (h *Handler) handleDetail(ctx context.Context, wcmd messaging.WorkerCommand
 	// catalog.ListFiles excludes SKILL.md by design; always include it as the primary file.
 	supportingFiles, _ := catalog.ListFiles(name, 0)
 	files := append([]string{"SKILL.md"}, supportingFiles...)
+	summary := entry.Summary()
 
 	data := messaging.SkillDetailData{
+		SkillID:     summary.SkillID,
 		Name:        entry.Manifest.Name,
 		Description: entry.Manifest.Description,
 		Category:    entry.Manifest.Metadata.Category,
-		Source:      entry.Summary().Source,
-		Trust:       entry.Summary().Trust,
+		Source:      summary.Source,
+		Trust:       summary.Trust,
 		Version:     entry.Manifest.Version,
 		SkillMD:     entry.Body,
 		Tags:        entry.Manifest.Metadata.Tags,

--- a/backend/pkg/messaging/command.go
+++ b/backend/pkg/messaging/command.go
@@ -250,6 +250,7 @@ type SkillListItem struct {
 
 // SkillDetailData 表示已安装 skill 的完整详情，包括 SKILL.md 内容。
 type SkillDetailData struct {
+	SkillID     string   `json:"skill_id,omitempty"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Category    string   `json:"category"`

--- a/frontend/apps/desktop/src/main/index.ts
+++ b/frontend/apps/desktop/src/main/index.ts
@@ -95,7 +95,8 @@ function hideMainWindow(): void {
 function createTray(): void {
 	if (tray) return;
 
-	const icon = nativeImage.createFromPath(join(__dirname, "../../resources/tray-icon.png"));
+	const trayIconFile = process.platform === "darwin" ? "tray-icon.png" : "icon.png";
+	const icon = nativeImage.createFromPath(join(__dirname, "../../resources", trayIconFile));
 	const trayIcon =
 		process.platform === "darwin" ? icon.resize({ width: 18, height: 18 }) : icon.resize({ width: 20, height: 20 });
 

--- a/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
+++ b/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
@@ -77,6 +77,7 @@ function skillItemFromValue(value: unknown): SkillInstalledItem | null {
 
 	return {
 		name,
+		display_name: stringFromValue(value.display_name),
 		description: stringFromValue(value.description),
 		category: stringFromValue(value.category),
 		source: stringFromValue(value.source || value.source_type),
@@ -103,11 +104,12 @@ function normalizeInstalledSkillsPayload(value: unknown): SkillInstalledItem[] {
 }
 
 function installedSkillToOption(skill: SkillInstalledItem): SkillOption {
+	const label = skill.display_name || skill.name;
 	return {
 		code: skill.name,
-		label: skill.name,
+		label,
 		description: skill.description || skill.category || "已安装技能",
-		keywords: [skill.name, skill.description, skill.category, skill.source, skill.trust].filter(
+		keywords: [label, skill.name, skill.description, skill.category, skill.source, skill.trust].filter(
 			Boolean,
 		),
 	};

--- a/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
+++ b/frontend/packages/app-ui/components/input/ComposerActionBar.tsx
@@ -66,6 +66,7 @@ function skillItemFromValue(value: unknown): SkillInstalledItem | null {
 
 	return {
 		name,
+		display_name: stringFromValue(value.display_name),
 		description: stringFromValue(value.description),
 		category: stringFromValue(value.category),
 		source: stringFromValue(value.source || value.source_type),
@@ -92,11 +93,12 @@ function normalizeInstalledSkillsPayload(value: unknown): SkillInstalledItem[] {
 }
 
 function installedSkillToOption(skill: SkillInstalledItem): SkillOption {
+	const label = skill.display_name || skill.name;
 	return {
 		code: skill.name,
-		label: skill.name,
+		label,
 		description: skill.description || skill.category || "已安装技能",
-		keywords: [skill.name, skill.description, skill.category, skill.source, skill.trust].filter(
+		keywords: [label, skill.name, skill.description, skill.category, skill.source, skill.trust].filter(
 			Boolean,
 		),
 	};

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -587,7 +587,7 @@ function ProjectConfigSidebar({
 			if (selectedSkillCodes.includes(skill.code)) return false;
 			if (!query) return true;
 			// 中文注释：技能弹窗仅按名称搜索。
-			return skill.name.toLowerCase().includes(query);
+			return [skill.name, skill.code].join(" ").toLowerCase().includes(query);
 		});
 	}, [selectedSkillCodes, skillOptions, skillSearch]);
 
@@ -853,7 +853,7 @@ function SkillPickerIcon() {
 function installedSkillToProjectSkill(skill: SkillInstalledItem): ProjectSkill {
 	return {
 		code: skill.name,
-		name: skill.name,
+		name: skill.display_name || skill.name,
 		description: skill.description,
 		category: skill.category,
 		source: skill.source,
@@ -910,6 +910,7 @@ function skillItemFromValue(value: unknown): SkillInstalledItem | null {
 
 	return {
 		name,
+		display_name: stringFromValue(value.display_name),
 		description: stringFromValue(value.description),
 		category: stringFromValue(value.category),
 		source: stringFromValue(value.source || value.source_type),

--- a/frontend/packages/app-ui/components/skills/RecentSkillsPanel.tsx
+++ b/frontend/packages/app-ui/components/skills/RecentSkillsPanel.tsx
@@ -34,26 +34,29 @@ export function RecentSkillsPanel({ onCardClick }: RecentSkillsPanelProps) {
       <h3 className="text-sm font-semibold text-[var(--leros-text-strong)] mb-4">最近使用</h3>
       {recent.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {recent.map((item) => (
-            <button
-              key={item.name}
-              type="button"
-              onClick={() => onCardClick?.(installedToCardItem(item))}
-              className="group flex items-center gap-3 rounded-lg border border-[var(--leros-control-border)] bg-white p-3 text-left transition-all hover:-translate-y-0.5 hover:border-[var(--leros-primary)] hover:shadow-sm"
-            >
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-soft)] text-[var(--leros-primary)] text-sm font-bold group-hover:bg-[var(--leros-primary)] group-hover:text-white transition-colors">
-                {item.name.charAt(0).toUpperCase()}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-[var(--leros-text-strong)]">
-                  {item.name}
-                </p>
-                <p className="truncate text-[11px] text-[var(--leros-text-muted)]">
-                  {item.description}
-                </p>
-              </div>
-            </button>
-          ))}
+          {recent.map((item) => {
+            const displayName = item.display_name || item.name;
+            return (
+              <button
+                key={item.name}
+                type="button"
+                onClick={() => onCardClick?.(installedToCardItem(item))}
+                className="group flex items-center gap-3 rounded-lg border border-[var(--leros-control-border)] bg-white p-3 text-left transition-all hover:-translate-y-0.5 hover:border-[var(--leros-primary)] hover:shadow-sm"
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--leros-primary-soft)] text-[var(--leros-primary)] text-sm font-bold group-hover:bg-[var(--leros-primary)] group-hover:text-white transition-colors">
+                  {displayName.charAt(0).toUpperCase()}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-[var(--leros-text-strong)]">
+                    {displayName}
+                  </p>
+                  <p className="truncate text-[11px] text-[var(--leros-text-muted)]">
+                    {item.description}
+                  </p>
+                </div>
+              </button>
+            );
+          })}
         </div>
       ) : (
         <p className="text-xs text-[var(--leros-text-subtle)] py-4">暂无最近使用的技能</p>


### PR DESCRIPTION
## 变更说明

本 PR 完善技能汉化展示链路。

###  已安装技能汉化展示

- 为“我的技能”、最近使用、技能详情补齐 `display_name` / 中文描述展示逻辑
- 已安装技能读取 `.skill-metadata` 中的 `source` 和 `skill_id`，用于和应用市场缓存数据匹配
- 修复已安装技能未命中内置表时提前返回，导致应用市场安装技能无法补充汉化数据的问题
- `skill-marketplace/skill-detail` 在 `source=installed` 时支持返回汉化后的 `skill_md`
  - 优先读取缓存中的 `SKILL.zh-CN.md`
  - 缓存缺失时按需即时翻译
  - 仅影响接口展示数据，不修改 worker 本地原始 `SKILL.md`
- 对话框、项目技能选择、新建项目弹窗优先展示 `display_name`
- 技能真实调用、卸载、worker 执行仍使用原始 `name/code`

## 验证

- `go test ./backend/internal/skill/catalog ./backend/internal/service ./backend/internal/worker/skillmgmt -run 'TestListUsesStoredSkillMetadataSource|^$'`
- `go test ./backend/internal/service -run '^$'`
- `pnpm --filter @leros/app-ui typecheck`
- `git diff --check`