### PR TITLE
refactor(frontend): 统一产物文件列表走 projectFileApi

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.test.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.test.tsx
@@ -9,23 +9,12 @@ vi.mock("@leros/store", () => ({
 	formatArtifactTime: () => "",
 	formatTime: () => "10:00",
 	getAssistantMessageFooterSegments: () => [],
-	mapBackendArtifactToProjectArtifact: vi.fn(),
-	mergeProjectArtifacts: vi.fn(),
 	messageArtifactToProjectArtifact: vi.fn(),
+	sortProjectArtifactsByNewestFirst: (artifacts: unknown[]) => artifacts,
 	useChatStore: (selector: (state: Record<string, unknown>) => unknown) =>
 		selector({
 			resendMessage: vi.fn(),
 		}),
-	useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) =>
-		selector({
-			activeTaskDetailTaskId: null,
-		}),
-}));
-
-vi.mock("@leros/store/api/artifactApi", () => ({
-	artifactApi: {
-		listTaskArtifacts: vi.fn(),
-	},
 }));
 
 vi.mock("../common/MarkdownRenderer", () => ({

--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -4,14 +4,11 @@ import {
 	formatArtifactTime,
 	formatTime,
 	getAssistantMessageFooterSegments,
-	mapBackendArtifactToProjectArtifact,
-	mergeProjectArtifacts,
 	messageArtifactToProjectArtifact,
 	type ProjectArtifact,
+	sortProjectArtifactsByNewestFirst,
 	useChatStore,
-	useLayoutStore,
 } from "@leros/store";
-import { artifactApi } from "@leros/store/api/artifactApi";
 import type {
 	Message,
 	MessageArtifact,
@@ -25,7 +22,6 @@ import {
 	ChevronDown,
 	ChevronRight,
 	Copy,
-	LoaderCircle,
 	RefreshCw,
 	Rows3,
 	Wrench,
@@ -344,51 +340,15 @@ function MessageArtifactList({
 	projectId?: string;
 }) {
 	const [previewArtifact, setPreviewArtifact] = useState<ProjectArtifact | null>(null);
-	const [taskArtifacts, setTaskArtifacts] = useState<ProjectArtifact[]>([]);
-	const [loadingArtifactId, setLoadingArtifactId] = useState<string | null>(null);
-	const activeTaskDetailTaskId = useLayoutStore((s) => s.activeTaskDetailTaskId);
-	const artifactKey = useMemo(
-		() => artifacts.map((artifact) => artifact.id).join("|"),
-		[artifacts],
-	);
 	const visibleArtifacts = useMemo(() => {
-		// 中文注释：旧历史消息里如果没有独立的文件时间，这里回退到所属消息时间，保证卡片稳定展示时间。
-		const sessionArtifacts = artifacts.map((artifact) => ({
-			...messageArtifactToProjectArtifact(artifact),
-			updatedAt: artifact.updatedAt ?? fallbackTimestamp,
-		}));
-		const artifactIds = new Set(sessionArtifacts.map((artifact) => artifact.id));
-		const enrichedTaskArtifacts = taskArtifacts.filter((artifact) => artifactIds.has(artifact.id));
-		return mergeProjectArtifacts(enrichedTaskArtifacts, sessionArtifacts);
-	}, [artifacts, fallbackTimestamp, taskArtifacts]);
-
-	useEffect(() => {
-		if (!activeTaskDetailTaskId) {
-			setTaskArtifacts([]);
-			return;
-		}
-		const taskId = activeTaskDetailTaskId;
-
-		let cancelled = false;
-		async function fetchTaskArtifacts() {
-			setLoadingArtifactId("__list__");
-			try {
-				const res = await artifactApi.listTaskArtifacts(taskId);
-				if (cancelled) return;
-				setTaskArtifacts((res.data.data ?? []).map(mapBackendArtifactToProjectArtifact));
-			} catch (err) {
-				if (cancelled) return;
-				console.error("MessageArtifactList fetch task artifacts error:", err);
-				setTaskArtifacts([]);
-			} finally {
-				if (!cancelled) setLoadingArtifactId(null);
-			}
-		}
-		fetchTaskArtifacts();
-		return () => {
-			cancelled = true;
-		};
-	}, [activeTaskDetailTaskId, artifactKey]);
+		// 中文注释：消息流里已携带 artifact 元数据，直接展示即可，不再额外请求 ListTaskArtifacts。
+		return sortProjectArtifactsByNewestFirst(
+			artifacts.map((artifact) => ({
+				...messageArtifactToProjectArtifact(artifact),
+				updatedAt: artifact.updatedAt ?? fallbackTimestamp,
+			})),
+		);
+	}, [artifacts, fallbackTimestamp]);
 
 	if (visibleArtifacts.length === 0) return null;
 
@@ -405,9 +365,8 @@ function MessageArtifactList({
 								id: projectId ? `artifacts/${artifact.name}` : artifact.id,
 							})
 						}
-					disabled={loadingArtifactId === artifact.id}
-					className="group/artifact relative flex min-w-0 items-center gap-3 overflow-hidden rounded-xl border border-slate-200/70 bg-white/90 px-3.5 py-3 text-left shadow-sm transition-colors hover:border-blue-200 hover:bg-blue-50/60"
-					title="预览文件"
+						className="group/artifact relative flex min-w-0 items-center gap-3 overflow-hidden rounded-xl border border-slate-200/70 bg-white/90 px-3.5 py-3 text-left shadow-sm transition-colors hover:border-blue-200 hover:bg-blue-50/60"
+						title="预览文件"
 					>
 						<div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-[rgba(15,23,42,0.16)] opacity-0 transition-opacity duration-200 group-hover/artifact:opacity-100">
 							<span className="rounded-full bg-[rgba(15,23,42,0.72)] px-3 py-1 text-xs font-medium tracking-[0.02em] text-white shadow-sm">
@@ -415,11 +374,7 @@ function MessageArtifactList({
 							</span>
 						</div>
 						<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-slate-600">
-							{loadingArtifactId === artifact.id ? (
-								<LoaderCircle className="size-4 animate-spin" />
-							) : (
-								<MessageArtifactIcon fileName={artifact.name} />
-							)}
+							<MessageArtifactIcon fileName={artifact.name} />
 						</div>
 						<div className="min-w-0">
 							<div className="truncate text-sm font-semibold leading-5 text-slate-700">

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -2,7 +2,6 @@
 
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
 import { formatTokenCount, projectFileApi, useChatStore, useLayoutStore } from "@leros/store";
-import { artifactApi } from "@leros/store/api/artifactApi";
 import { taskApi } from "@leros/store/api/taskApi";
 import { Button } from "@leros/ui/components/ui/button";
 import {
@@ -13,7 +12,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@leros/ui/components/ui/dialog";
-import type { ApiError } from "@leros/ui/lib/request";
 import { cn } from "@leros/ui/lib/utils";
 import {
 	ArrowDownToLine,
@@ -48,14 +46,6 @@ const TASK_DETAIL_RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = "leros-task-detail-right-sid
 const TASK_DETAIL_RIGHT_SIDEBAR_DEFAULT_WIDTH = 352;
 const TASK_DETAIL_RIGHT_SIDEBAR_MIN_WIDTH = 300;
 const TASK_DETAIL_RIGHT_SIDEBAR_MAX_WIDTH = 440;
-
-function isDirectoryNotFoundError(error: unknown): boolean {
-	if (typeof error !== "object" || error === null || !("status" in error)) {
-		return false;
-	}
-	const apiError = error as ApiError;
-	return apiError.status === 404 && apiError.message === "directory not found";
-}
 
 function truncateBreadcrumbText(text?: string | null, maxLength = 10) {
 	if (!text) {
@@ -173,28 +163,19 @@ export function TaskDetailPage({
 	const taskChatLayout = getProjectChatLayoutClasses(taskChatLayoutMode);
 
 	const fetchTaskFiles = useCallback(async () => {
-		if (!resolvedProjectId || !resolvedTaskId) return;
+		if (!resolvedProjectId) return;
 		try {
-			// 中文注释：先确认当前任务是否真的有产物；没有的话直接按空列表处理，避免对旧任务额外打 artifacts 目录 404。
-			const artifactResponse = await artifactApi.listTaskArtifacts(resolvedTaskId);
-			if ((artifactResponse.data.data ?? []).length === 0) {
-				setTaskFiles([]);
-				return;
-			}
+			// 中文注释：任务文件列表统一走项目文件接口，不再额外调用 ListTaskArtifacts。
 			const res = await projectFileApi.list({
 				projectId: resolvedProjectId,
-				path: "artifacts",
+				resourceType: "artifact",
 			});
 			setTaskFiles(normalizeProjectFileTree(res.data.data));
 		} catch (err) {
-			if (isDirectoryNotFoundError(err)) {
-				setTaskFiles([]);
-				return;
-			}
 			console.error("TaskDetailPage fetch task files error:", err);
 			setTaskFiles([]);
 		}
-	}, [resolvedProjectId, resolvedTaskId]);
+	}, [resolvedProjectId]);
 
 	useEffect(() => {
 		fetchProjects();

--- a/frontend/packages/store/api/projectFileApi.ts
+++ b/frontend/packages/store/api/projectFileApi.ts
@@ -9,7 +9,7 @@ import type {
 
 export type GetProjectFilesParams = {
 	projectId: string;
-	path?: string;
+	resourceType?: "user_upload" | "artifact";
 };
 
 export type UploadProjectFileParams = {
@@ -89,11 +89,11 @@ async function uploadLooseFile({
 }
 
 export const projectFileApi = {
-	list: ({ projectId, path }: GetProjectFilesParams) =>
+	list: ({ projectId, resourceType }: GetProjectFilesParams) =>
 		apiClient.get<BackendDataResponse<BackendProjectFileNode[]>>(
 			`/projects/${encodeURIComponent(projectId)}/files`,
 			{
-				params: path ? { path } : undefined,
+				params: resourceType ? { resource_type: resourceType } : undefined,
 			},
 		),
 

--- a/frontend/packages/store/api/types.ts
+++ b/frontend/packages/store/api/types.ts
@@ -381,6 +381,7 @@ export type BackendProjectFileNode = {
 	mod_time?: number;
 	created_at?: number;
 	public_id?: string;
+	storage_uri?: string;
 };
 
 export type BackendProjectFileUploadResult = {

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -124,6 +124,7 @@ export {
 	collectSessionArtifacts,
 	mergeProjectArtifacts,
 	messageArtifactToProjectArtifact,
+	sortProjectArtifactsByNewestFirst,
 } from "./utils/artifacts";
 export {
 	AUTH_SESSION_EXPIRED_EVENT,


### PR DESCRIPTION
## Summary
- 消息气泡内的 artifact 卡片改为直接使用会话消息携带的元数据展示，移除对 ListTaskArtifacts 的额外请求与 loading 状态
- 任务详情页「任务文件」侧栏统一走 `projectFileApi.list`，使用 `resource_type=artifact` 筛选产物文件，不再先调 ListTaskArtifacts 再读 artifacts 目录
- `projectFileApi.list` 参数由 `path` 改为 `resourceType`，对齐后端 `resource_type` 查询参数；补充 `BackendProjectFileNode.storage_uri` 类型

## Test plan
- [ ] 任务详情页右侧「任务文件」仅展示产物文件，不包含用户上传文件
- [ ] AI 消息中的 artifact 卡片可正常展示并点击预览
- [ ] 项目页「文件」Tab 仍可正常加载完整文件树
- [ ] 产物预览（含 storage_uri）行为与上一版一致