### PR TITLE
feat(frontend): 输入框 mention chip 支持内联删除

### DIFF
--- a/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.test.tsx
@@ -97,6 +97,38 @@ function ToolbarHarness({ onValueChange }: { onValueChange?: (value: string) => 
 	);
 }
 
+function MentionRemoveHarness({ onValueChange }: { onValueChange?: (value: string) => void }) {
+	const [value, setValue] = useState("");
+	const composerRef = useRef<StructuredComposerHandle | null>(null);
+
+	return (
+		<div>
+			<button type="button" onClick={() => composerRef.current?.insertSkill("anysearch")}>
+				insert skill
+			</button>
+			<button type="button" onClick={() => composerRef.current?.insertAssistant("代码助手")}>
+				insert assistant
+			</button>
+			<StructuredComposer
+				ref={composerRef}
+				value={value}
+				onChange={(nextValue) => {
+					// 中文注释：通过真实 token x 入口验证删除后 value 与 mention DOM 同步清理。
+					setValue(nextValue);
+					onValueChange?.(nextValue);
+				}}
+				onSubmit={vi.fn()}
+				onPasteFiles={vi.fn()}
+				onFocus={vi.fn()}
+				onBlur={vi.fn()}
+				placeholder="请输入"
+				isProjectVariant
+				projectSkillOptions={[]}
+			/>
+		</div>
+	);
+}
+
 function ActionBarHarness({ onValueChange }: { onValueChange?: (value: string) => void }) {
 	const [value, setValue] = useState("");
 	const composerRef = useRef<StructuredComposerHandle | null>(null);
@@ -257,6 +289,52 @@ describe("StructuredComposer", () => {
 			expect(
 				Array.from(mentions).map((mention) => mention.getAttribute("data-mention-label")),
 			).toEqual(expect.arrayContaining(["/anysearch", "/docx"]));
+		});
+	});
+
+	it("技能 mention 上的 x 可以删除已选技能", async () => {
+		const user = userEvent.setup();
+		const handleValueChange = vi.fn();
+
+		render(<MentionRemoveHarness onValueChange={handleValueChange} />);
+
+		await user.click(screen.getByRole("button", { name: "insert skill" }));
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("/anysearch ");
+		});
+
+		const textbox = screen.getByRole("textbox", { name: "请输入" });
+		const removeButton = textbox.querySelector('[data-mention-remove="true"]');
+		expect(removeButton).toBeInstanceOf(HTMLElement);
+
+		await user.click(removeButton as HTMLElement);
+
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("");
+			expect(textbox.querySelector('[data-mention-node="true"]')).not.toBeInTheDocument();
+		});
+	});
+
+	it("AI 员工 mention 上的 x 可以删除已选员工", async () => {
+		const user = userEvent.setup();
+		const handleValueChange = vi.fn();
+
+		render(<MentionRemoveHarness onValueChange={handleValueChange} />);
+
+		await user.click(screen.getByRole("button", { name: "insert assistant" }));
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("@代码助手 ");
+		});
+
+		const textbox = screen.getByRole("textbox", { name: "请输入" });
+		const removeButton = textbox.querySelector('[data-mention-remove="true"]');
+		expect(removeButton).toBeInstanceOf(HTMLElement);
+
+		await user.click(removeButton as HTMLElement);
+
+		await waitFor(() => {
+			expect(handleValueChange).toHaveBeenLastCalledWith("");
+			expect(textbox.querySelector('[data-mention-node="true"]')).not.toBeInTheDocument();
 		});
 	});
 

--- a/frontend/packages/app-ui/components/input/StructuredComposer.tsx
+++ b/frontend/packages/app-ui/components/input/StructuredComposer.tsx
@@ -316,6 +316,42 @@ function createSkillSparklesIcon(): SVGElement {
 	return svg;
 }
 
+function createRemoveIcon(): SVGElement {
+	const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+	svg.setAttribute("viewBox", "0 0 24 24");
+	svg.setAttribute("fill", "none");
+	svg.setAttribute("stroke", "currentColor");
+	svg.setAttribute("stroke-width", "2");
+	svg.setAttribute("stroke-linecap", "round");
+	svg.setAttribute("stroke-linejoin", "round");
+	svg.setAttribute("class", "size-2.5");
+
+	for (const d of ["M18 6 6 18", "m6 6 12 12"]) {
+		const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+		path.setAttribute("d", d);
+		svg.appendChild(path);
+	}
+
+	return svg;
+}
+
+function createMentionRemoveControl(token: InsertedToken): HTMLSpanElement {
+	const control = document.createElement("span");
+	control.dataset.mentionRemove = "true";
+	control.dataset.mentionLabel = token.label;
+	control.dataset.mentionKind = token.kind;
+	control.setAttribute("role", "button");
+	control.setAttribute("tabindex", "-1");
+	control.setAttribute(
+		"aria-label",
+		`移除${token.kind === "skill" ? "技能" : "AI队友"} ${token.label}`,
+	);
+	control.className =
+		"ml-0.5 inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center rounded-full opacity-65 transition-opacity hover:bg-current/10 hover:opacity-100";
+	control.appendChild(createRemoveIcon());
+	return control;
+}
+
 function buildEditorContent(root: HTMLElement, value: string, tokens: InsertedToken[]) {
 	const fragment = document.createDocumentFragment();
 	const orderedTokens = sortTokens(tokens);
@@ -341,11 +377,14 @@ function buildEditorContent(root: HTMLElement, value: string, tokens: InsertedTo
 			const label = document.createElement("span");
 			label.className = "truncate";
 			label.textContent = token.label;
-			mention.append(iconShell, label);
+			mention.append(iconShell, label, createMentionRemoveControl(token));
 		} else {
 			mention.className =
-				"inline-flex rounded-md bg-blue-100 px-1.5 py-0.5 text-[11px] text-blue-700 align-baseline";
-			mention.textContent = token.label;
+				"inline-flex items-center gap-1 rounded-md bg-blue-100 px-1.5 py-0.5 text-[11px] text-blue-700 align-baseline";
+			const label = document.createElement("span");
+			label.className = "truncate";
+			label.textContent = token.label;
+			mention.append(label, createMentionRemoveControl(token));
 		}
 		fragment.appendChild(mention);
 		cursor = token.end;
@@ -984,6 +1023,32 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 			[removeMentionToken],
 		);
 
+		const handleEditorMouseDown = useCallback(
+			(event: MouseEvent<HTMLDivElement>) => {
+				const target = event.target;
+				const removeControl =
+					target instanceof Element ? target.closest('[data-mention-remove="true"]') : null;
+
+				if (removeControl instanceof HTMLElement && editorRef.current?.contains(removeControl)) {
+					event.preventDefault();
+					event.stopPropagation();
+
+					const kind = removeControl.dataset.mentionKind === "skill" ? "skill" : "assistant";
+					const label = removeControl.dataset.mentionLabel;
+					if (label) {
+						// 中文注释：token 内的 x 只删除对应的 mention 文本，保留输入框其他内容和 token 样式。
+						removeMentionToken(kind, label);
+					}
+					return;
+				}
+
+				if (trigger) {
+					dismissTrigger();
+				}
+			},
+			[dismissTrigger, removeMentionToken, trigger],
+		);
+
 		useImperativeHandle(
 			ref,
 			() => ({
@@ -1267,11 +1332,7 @@ export const StructuredComposer = forwardRef<StructuredComposerHandle, Structure
 					onInput={() => syncFromEditor()}
 					onKeyDown={handleKeyDown}
 					onPaste={handlePaste}
-					onMouseDown={() => {
-						if (trigger) {
-							dismissTrigger();
-						}
-					}}
+					onMouseDown={handleEditorMouseDown}
 					onFocus={onFocus}
 					onBlur={() => {
 						onBlur();


### PR DESCRIPTION
## Summary
- 在 StructuredComposer 的 @员工 与 /技能 mention chip 上增加内联 x 删除按钮，用户可直接在输入框内移除已选项
- 点击 x 时通过 `removeMentionToken` 同步清理 value 与 mention DOM，不影响其他输入内容
- 补充单元测试，覆盖技能/AI 员工 mention 删除及工具栏弹窗不再展示已选技能区

## Test plan
- [x] `pnpm exec vitest run --environment jsdom components/input/StructuredComposer.test.tsx`
- [ ] 项目页输入框插入 @员工 或 /技能 后，点击 chip 上 x 可删除对应项
- [ ] 输入框内同时存在多个 mention 时，删除其中一个不影响其他 mention 样式
- [ ] 工具栏「添加技能」弹窗仍可继续添加未选技能