### PR TITLE
fix(file): 统一文件卡片元信息展示

### DIFF
--- a/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/AIMessageBubble.tsx
@@ -194,7 +194,7 @@ function ProcessTimelineBlock({
 			}
 			if (toolCall.name === "web_fetch" || toolCall.name === "webfetch") {
 				const url = typeof args.url === "string" && args.url.trim() ? decodeURIComponent(args.url.trim()) : "";
-				return url ? "浏览 " + url : "浏览";
+				return url ? `浏览 ${url}` : "浏览";
 			}
 			return `调用：${toolCall.name}`;
 		}
@@ -378,12 +378,12 @@ function MessageArtifactList({
 						</div>
 						<div className="min-w-0">
 							<div className="truncate text-sm font-semibold leading-5 text-slate-700">
-								{artifact.title || artifact.name}
+								{artifact.name}
 							</div>
 							<div className="mt-0.5 truncate text-[13px] leading-4 text-slate-400">
-								{artifact.name}
-								{artifact.updatedAt ? ` · ${formatArtifactTime(artifact.updatedAt)}` : ""}
-								{artifact.size ? ` · ${artifact.size}` : ""}
+								{[artifact.size, artifact.updatedAt ? formatArtifactTime(artifact.updatedAt) : ""]
+									.filter(Boolean)
+									.join(" · ")}
 							</div>
 						</div>
 					</button>

--- a/frontend/packages/app-ui/components/chat/UserMessageBubble.tsx
+++ b/frontend/packages/app-ui/components/chat/UserMessageBubble.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { fetchFileDownload, formatFileSize, formatTime } from "@leros/store";
+import { fetchFileDownload, formatArtifactTime, formatFileSize, formatTime } from "@leros/store";
 import type { Message, MessageAttachment } from "@leros/store/types/chat";
 import { Button } from "@leros/ui/components/ui/button";
 import { Check, Copy, ImageIcon, LoaderCircle } from "lucide-react";
@@ -139,6 +139,12 @@ function ImageAttachmentCard({
 		isInlinePreviewableUrl(attachment.url) ? (attachment.url ?? null) : null,
 	);
 	const [thumbnailLoading, setThumbnailLoading] = useState(false);
+	const metaText = [
+		formatFileSize(attachment.size),
+		attachment.createdAt ? formatArtifactTime(attachment.createdAt) : "",
+	]
+		.filter(Boolean)
+		.join(" · ");
 
 	useEffect(() => {
 		if (attachment.url && isInlinePreviewableUrl(attachment.url)) {
@@ -183,20 +189,28 @@ function ImageAttachmentCard({
 		<button
 			type="button"
 			onClick={onClick}
-			className="group/attachment relative size-[92px] overflow-hidden rounded-2xl border border-blue-200/70 bg-white shadow-sm transition-colors hover:border-blue-300"
+			className="group/attachment relative flex w-[260px] min-w-0 items-center gap-3 overflow-hidden rounded-xl border border-slate-200/70 bg-white/90 px-3.5 py-3 text-left shadow-sm transition-colors hover:border-blue-200 hover:bg-blue-50/60"
 			title={attachment.name}
 		>
-			{thumbnailUrl ? (
-				<img src={thumbnailUrl} alt={attachment.name} className="h-full w-full object-cover" />
-			) : (
-				<div className="flex h-full w-full items-center justify-center bg-slate-100 text-slate-400">
-					{thumbnailLoading ? (
-						<LoaderCircle className="size-5 animate-spin" />
-					) : (
-						<ImageIcon className="size-6" />
-					)}
+			<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--leros-primary-softer)] text-slate-400">
+				{thumbnailUrl ? (
+					<img src={thumbnailUrl} alt={attachment.name} className="h-full w-full object-cover" />
+				) : thumbnailLoading ? (
+					<LoaderCircle className="size-5 animate-spin" />
+				) : (
+					<ImageIcon className="size-5" />
+				)}
+			</div>
+			<div className="min-w-0">
+				<div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">
+					{attachment.name}
 				</div>
-			)}
+				{metaText ? (
+					<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
+						{metaText}
+					</div>
+				) : null}
+			</div>
 			<AttachmentHoverMask />
 		</button>
 	);
@@ -209,7 +223,12 @@ function FileAttachmentCard({
 	attachment: MessageAttachment;
 	onClick: () => void;
 }) {
-	const sizeText = attachment.size > 0 ? formatFileSize(attachment.size) : "";
+	const metaText = [
+		formatFileSize(attachment.size),
+		attachment.createdAt ? formatArtifactTime(attachment.createdAt) : "",
+	]
+		.filter(Boolean)
+		.join(" · ");
 
 	return (
 		<button
@@ -226,9 +245,9 @@ function FileAttachmentCard({
 				<div className="truncate text-sm font-normal leading-5 text-[var(--leros-text-strong)]">
 					{attachment.name}
 				</div>
-				{sizeText ? (
+				{metaText ? (
 					<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
-						{sizeText}
+						{metaText}
 					</div>
 				) : null}
 			</div>

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -1427,9 +1427,6 @@ function ProjectFiles({
 											<p className="truncate text-[15px] font-semibold text-[var(--leros-text-strong)]">
 												{file.name}
 											</p>
-											<p className="truncate text-xs text-[var(--leros-text-muted)]">
-												/{file.path}
-											</p>
 										</div>
 									</button>
 									<div className="text-[13px]">

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import type { ProjectArtifact, ProjectTask } from "@leros/store";
-import { formatTokenCount, projectFileApi, useChatStore, useLayoutStore } from "@leros/store";
+import {
+	formatArtifactTime,
+	formatTokenCount,
+	projectFileApi,
+	useChatStore,
+	useLayoutStore,
+} from "@leros/store";
 import { taskApi } from "@leros/store/api/taskApi";
 import { Button } from "@leros/ui/components/ui/button";
 import {
@@ -756,7 +762,12 @@ function TaskFileList({
 							{file.name}
 						</div>
 						<div className="mt-1 truncate text-xs leading-4 text-[var(--leros-text-muted)]">
-							{file.size > 0 ? formatBytes(file.size) : ""}
+							{[
+								file.size > 0 ? formatBytes(file.size) : "",
+								file.createdAt ? formatArtifactTime(file.createdAt) : "",
+							]
+								.filter(Boolean)
+								.join(" · ")}
 						</div>
 					</div>
 				</button>

--- a/frontend/packages/store/api/sessionApi.ts
+++ b/frontend/packages/store/api/sessionApi.ts
@@ -61,6 +61,7 @@ export type AddMessageParams = {
 		file_upload_id: string;
 		name: string;
 		mime_type: string;
+		size?: number;
 	}[];
 	thinking?: string;
 	metadata?: {

--- a/frontend/packages/store/api/workApi.ts
+++ b/frontend/packages/store/api/workApi.ts
@@ -11,6 +11,7 @@ export type NewMessageParams = {
 		file_upload_id: string;
 		name: string;
 		mime_type: string;
+		size?: number;
 	}[];
 };
 

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -128,8 +128,9 @@ function mapBackendMessage(msg: BackendMessage): Message {
     }
   }
   if (msg.attachments?.length) {
+    const messageCreatedAt = parseOptionalTimestamp(msg.created_at) ?? msg.timestamp;
     const attachments = msg.attachments
-      .map(mapBackendAttachment)
+      .map((attachment) => mapBackendAttachment(attachment, messageCreatedAt))
       .filter(
         (attachment): attachment is MessageAttachment =>
           attachment !== undefined,
@@ -143,6 +144,7 @@ function mapBackendMessage(msg: BackendMessage): Message {
 
 function mapBackendAttachment(
   attachment: BackendMessageAttachment,
+  messageCreatedAt?: number,
 ): MessageAttachment | undefined {
   const fileUploadId = attachment.file_upload_id?.trim();
   if (!fileUploadId) return undefined;
@@ -153,6 +155,7 @@ function mapBackendAttachment(
     name: attachment.name?.trim() || fileUploadId,
     mimeType: attachment.mime_type?.trim() || "application/octet-stream",
     size: attachment.size ?? 0,
+    createdAt: messageCreatedAt,
     url:
       attachment.PublicURL?.trim() ||
       attachment.public_url?.trim() ||
@@ -175,6 +178,7 @@ function mapComposerAttachment(
       attachment.file?.type ||
       "application/octet-stream",
     size: attachment.size,
+    createdAt: Date.now(),
     url: attachment.url,
     storageUri: attachment.storageUri,
   };
@@ -194,7 +198,7 @@ function mapComposerAttachments(
 function mapOutgoingAttachments(
   attachments?: Attachment[],
 ):
-  | Array<{ file_upload_id: string; name: string; mime_type: string }>
+  | Array<{ file_upload_id: string; name: string; mime_type: string; size: number }>
   | undefined {
   const mapped = attachments
     ?.filter(
@@ -208,6 +212,8 @@ function mapOutgoingAttachments(
         attachment.mimeType ||
         attachment.file?.type ||
         "application/octet-stream",
+      // 中文注释：上传接口已经返回真实大小，随消息落库后历史会话才能展示准确文件大小。
+      size: attachment.size,
     }));
   return mapped?.length ? mapped : undefined;
 }

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -505,6 +505,7 @@ export class LayoutActionImpl {
 								name: attachment.name,
 								mime_type:
 									attachment.mimeType || attachment.file?.type || "application/octet-stream",
+								size: attachment.size,
 							})),
 					});
 					const data = {
@@ -538,6 +539,7 @@ export class LayoutActionImpl {
 				file_upload_id: string;
 				name: string;
 				mime_type: string;
+				size: number;
 			}[];
 		} = { content: trimmed };
 
@@ -556,6 +558,7 @@ export class LayoutActionImpl {
 					file_upload_id: attachment.fileUploadId.trim(),
 					name: attachment.name,
 					mime_type: attachment.mimeType || attachment.file?.type || "application/octet-stream",
+					size: attachment.size,
 				}));
 		}
 

--- a/frontend/packages/store/types/chat.ts
+++ b/frontend/packages/store/types/chat.ts
@@ -116,6 +116,7 @@ export type MessageAttachment = {
 	name: string;
 	mimeType: string;
 	size: number;
+	createdAt?: number;
 	url?: string;
 	storageUri?: string;
 };


### PR DESCRIPTION
## Summary
- 统一会话上传文件、AI 产物、任务侧栏文件的名称/大小/时间展示
- 发送 /NewMessage 和 /AddMessage 时补传附件 size，确保历史消息可回显真实大小
- 项目文件 Tab 移除文件名下方路径副标题，保留现有列表列和操作

## Verification
- ./node_modules/.bin/biome.cmd check --formatter-enabled=false <9 个改动文件>
- git diff --check