### PR TITLE
fix(frontend): 移除 store 中无效的技能状态类型导出

### DIFF
--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -42,8 +42,6 @@ export type {
 	SkillDetailParams,
 	SkillInstalledItem,
 	SkillMarketplaceItem,
-	ToggleSkillStatusParams,
-	ToggleSkillStatusResponse,
 	UninstallSkillParams,
 	UninstallSkillResponse,
 } from "./api/skillMarketplaceApi";


### PR DESCRIPTION
## Summary

- 修复 `frontend/packages/store/index.ts` 从 `skillMarketplaceApi` 再导出 `ToggleSkillStatusParams` / `ToggleSkillStatusResponse` 的问题
- 这两个类型在源模块中不存在，导致 `frontend/apps/desktop` CI 构建时报 `TS2305` 编译错误
- 移除无效导出后，TypeScript 编译可通过

## Test plan

- [x] 本地执行 `pnpm exec tsc --noEmit`（desktop app）通过
- [ ] CI desktop 构建通过
