### PR TITLE
fix(desktop): 修复自动更新无法退出安装

### DIFF
--- a/frontend/apps/desktop/src/main/app-lifecycle.ts
+++ b/frontend/apps/desktop/src/main/app-lifecycle.ts
@@ -1,0 +1,9 @@
+let appQuitting = false;
+
+export function isAppQuitting(): boolean {
+	return appQuitting;
+}
+
+export function markAppQuitting(): void {
+	appQuitting = true;
+}

--- a/frontend/apps/desktop/src/main/auto-update.ts
+++ b/frontend/apps/desktop/src/main/auto-update.ts
@@ -13,6 +13,7 @@ import {
 	desktopUpdateGetStateChannel,
 	desktopUpdateRestartChannel,
 } from "../shared/auto-update";
+import { markAppQuitting } from "./app-lifecycle";
 
 const autoUpdateIntervalMs = 30 * 60 * 1000;
 const initialAutoUpdateDelayMs = 1 * 1000;
@@ -290,6 +291,7 @@ export function registerDesktopAutoUpdate() {
 			return false;
 		}
 
+		markAppQuitting();
 		updater.quitAndInstall();
 		return true;
 	});

--- a/frontend/apps/desktop/src/main/index.ts
+++ b/frontend/apps/desktop/src/main/index.ts
@@ -13,11 +13,11 @@ import {
 	desktopOpenPolicyPdfChannel,
 	type DesktopPolicyDocument,
 } from "../shared/auto-update";
+import { isAppQuitting, markAppQuitting } from "./app-lifecycle";
 import { getDesktopUpdateState, registerDesktopAutoUpdate } from "./auto-update";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
-let isQuitting = false;
 
 function getPolicyPdfPath(document: DesktopPolicyDocument): string {
 	const fileName = document === "terms" ? "terms-of-service.pdf" : "privacy-policy.pdf";
@@ -58,7 +58,7 @@ function createWindow(): void {
 	});
 
 	mainWindow.on("close", (event) => {
-		if (isQuitting) return;
+		if (isAppQuitting()) return;
 
 		event.preventDefault();
 		hideMainWindow();
@@ -149,7 +149,7 @@ function formatAvailableVersion(version: string | undefined): string {
 }
 
 function quitApp(): void {
-	isQuitting = true;
+	markAppQuitting();
 	app.quit();
 }
 
@@ -184,5 +184,5 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
-	isQuitting = true;
+	markAppQuitting();
 });


### PR DESCRIPTION
在触发 quitAndInstall 前标记应用进入真实退出状态，避免主窗口 close 事件被托盘隐藏逻辑拦截，导致更新下载完成后需要手动退出才能安装。

同时抽出桌面端 app lifecycle 状态，复用普通退出和更新安装退出判断。