### PR TITLE
fix(project): 修复项目列表活跃时间排序

### DIFF
--- a/backend/internal/infra/db/project_dao.go
+++ b/backend/internal/infra/db/project_dao.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -33,6 +34,14 @@ func GetProjectByPublicID(ctx context.Context, db *gorm.DB, orgID uint, publicID
 // UpdateProject 更新项目
 func UpdateProject(ctx context.Context, db *gorm.DB, project *types.Project) error {
 	return db.WithContext(ctx).Save(project).Error
+}
+
+// TouchProjectUpdatedAt 仅刷新项目活跃时间，避免覆盖项目其他字段。
+func TouchProjectUpdatedAt(ctx context.Context, db *gorm.DB, id uint, updatedAt time.Time) error {
+	return db.WithContext(ctx).
+		Model(&types.Project{}).
+		Where("id = ?", id).
+		Update("updated_at", updatedAt).Error
 }
 
 // DeleteProject 删除项目（软删除）
@@ -124,7 +133,8 @@ func ListProjects(ctx context.Context, d *gorm.DB, opt *types.PageQuery) ([]*typ
 	if len(opt.OrderBy) > 0 {
 		query = query.Order(strings.Join(opt.OrderBy, ","))
 	} else {
-		query = query.Order("created_at DESC")
+		// 中文注释：项目列表默认按最近活跃时间排序，避免项目内新增任务/消息后仍停留在旧位置。
+		query = query.Order("updated_at DESC, created_at DESC")
 	}
 
 	query = query.Offset(opt.Offset)

--- a/backend/internal/infra/db/project_dao_test.go
+++ b/backend/internal/infra/db/project_dao_test.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/types"
+)
+
+func setupProjectTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+
+	if err := database.AutoMigrate(&types.Project{}); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+
+	return database
+}
+
+func TestListProjects_DefaultOrderUsesUpdatedAtDesc(t *testing.T) {
+	database := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectOld := &types.Project{
+		PublicID: "prj_list_old",
+		OrgID:    1,
+		OwnerID:  1,
+		Name:     "Old Project",
+		Status:   string(types.ProjectStatusActive),
+	}
+	projectNew := &types.Project{
+		PublicID: "prj_list_new",
+		OrgID:    1,
+		OwnerID:  1,
+		Name:     "New Project",
+		Status:   string(types.ProjectStatusActive),
+	}
+	if err := CreateProject(ctx, database, projectOld); err != nil {
+		t.Fatalf("CreateProject old failed: %v", err)
+	}
+	if err := CreateProject(ctx, database, projectNew); err != nil {
+		t.Fatalf("CreateProject new failed: %v", err)
+	}
+
+	if err := TouchProjectUpdatedAt(ctx, database, projectOld.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("TouchProjectUpdatedAt old failed: %v", err)
+	}
+	if err := TouchProjectUpdatedAt(ctx, database, projectNew.ID, time.Now().Add(-time.Hour).UTC()); err != nil {
+		t.Fatalf("TouchProjectUpdatedAt new failed: %v", err)
+	}
+
+	items, total, err := ListProjects(ctx, database, &types.PageQuery{
+		Caller: types.Caller{OrgID: 1, Uin: 1},
+		Pagination: types.Pagination{
+			Offset: 0,
+			Limit:  20,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListProjects failed: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].PublicID != projectOld.PublicID {
+		t.Fatalf("expected first project %q, got %q", projectOld.PublicID, items[0].PublicID)
+	}
+}

--- a/backend/internal/service/message_poster.go
+++ b/backend/internal/service/message_poster.go
@@ -178,6 +178,10 @@ func (p *MessagePoster) RunNewMessage(
 		logs.ErrorContextf(ctx, "NewMessage PostMessage failed: %v", err)
 		return nil, err
 	}
+	// 中文注释：项目页里通过 NewMessage 创建任务/首条消息后，要立即刷新项目活跃时间，供左侧列表排序使用。
+	if err := infradb.TouchProjectUpdatedAt(ctx, p.db, o.project.ID, time.Now()); err != nil {
+		logs.WarnContextf(ctx, "NewMessage touch project updated_at failed: %v", err)
+	}
 
 	logs.InfoContextf(ctx, "NewMessage completed: project=%s task=%s session=%s message=%d assistant=%d",
 		o.project.PublicID, o.task.PublicID, o.taskSession.PublicID, message.ID, o.taskSession.AllocatedAssistantID)

--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -351,6 +351,13 @@ func (s *sessionService) AddMessage(ctx context.Context, sessionID string, req *
 		return nil, err
 	}
 
+	if session.ProjectID != nil && *session.ProjectID != 0 && req.Role == string(types.MessageRoleUser) {
+		// 中文注释：只在用户主动发言时刷新项目活跃时间，避免助手流式输出把项目顺序不断顶来顶去。
+		if err := db.TouchProjectUpdatedAt(ctx, s.db, *session.ProjectID, time.Now()); err != nil {
+			logs.WarnContextf(ctx, "touch project updated_at after add message %s: %v", session.PublicID, err)
+		}
+	}
+
 	return convertToContractSessionMessage(message, session.PublicID), nil
 }
 

--- a/backend/internal/service/session_service_test.go
+++ b/backend/internal/service/session_service_test.go
@@ -736,6 +736,63 @@ func TestAddMessage_UpdatesSession(t *testing.T) {
 	}
 }
 
+func TestAddMessage_TouchesProjectUpdatedAtForUserMessage(t *testing.T) {
+	database := setupTestDB(t)
+	service := NewSessionService(database, &mockEventBus{}, &mockInferrer{assistantID: 1}, nil, nil, "test")
+	ctx := setupTestContextWithCaller(t)
+
+	project := &types.Project{
+		PublicID: "prj_test_add_message_touch",
+		OrgID:    1,
+		OwnerID:  1,
+		Name:     "Project Chat",
+		Status:   string(types.ProjectStatusActive),
+	}
+	if err := db.CreateProject(ctx, database, project); err != nil {
+		t.Fatalf("CreateProject failed: %v", err)
+	}
+
+	session := &types.Session{
+		PublicID:    "sess_test_add_message_touch",
+		Type:        types.SessionTypeProject,
+		Uin:         1,
+		OrgID:       1,
+		AssistantID: 1,
+		ProjectID:   &project.ID,
+		Status:      string(types.SessionStatusActive),
+		Title:       "项目协作",
+	}
+	if err := db.CreateSession(ctx, database, session); err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	oldUpdatedAt := time.Now().Add(-time.Hour).UTC()
+	if err := database.Model(&types.Project{}).
+		Where("id = ?", project.ID).
+		Update("updated_at", oldUpdatedAt).Error; err != nil {
+		t.Fatalf("set old project updated_at: %v", err)
+	}
+
+	_, err := service.AddMessage(ctx, session.PublicID, &contract.AddMessageRequest{
+		Role:    string(types.MessageRoleUser),
+		Content: "项目里补充一条用户消息",
+	})
+	if err != nil {
+		t.Fatalf("AddMessage failed: %v", err)
+	}
+
+	refreshedProject, err := db.GetProjectByID(ctx, database, project.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID failed: %v", err)
+	}
+	if refreshedProject == nil {
+		t.Fatal("expected project to exist after AddMessage")
+	}
+	if !refreshedProject.UpdatedAt.After(oldUpdatedAt) {
+		t.Fatalf("expected project updated_at after %v, got %v", oldUpdatedAt, refreshedProject.UpdatedAt)
+	}
+}
+
 func TestAddMessage_AutoSequence(t *testing.T) {
 	service := setupTestService(t)
 	ctx := setupTestContextWithCaller(t)

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/insmtx/Leros/backend/internal/infra/db"
 	"github.com/insmtx/Leros/backend/types"
 	"github.com/ygpkg/yg-go/encryptor/snowflake"
+	"github.com/ygpkg/yg-go/logs"
 )
 
 type taskService struct {
@@ -82,6 +84,10 @@ func (s *taskService) CreateTask(ctx context.Context, req *contract.CreateTaskRe
 
 	if err := db.CreateTask(ctx, s.db, task); err != nil {
 		return nil, err
+	}
+	// 中文注释：在项目内手动创建任务属于项目活跃行为，需要同步刷新项目排序时间。
+	if err := db.TouchProjectUpdatedAt(ctx, s.db, project.ID, time.Now()); err != nil {
+		logs.WarnContextf(ctx, "touch project updated_at after create task %s: %v", task.PublicID, err)
 	}
 	return convertToContractTask(task, project.PublicID), nil
 }

--- a/backend/internal/service/task_service_test.go
+++ b/backend/internal/service/task_service_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/insmtx/Leros/backend/internal/api/contract"
+	dbpkg "github.com/insmtx/Leros/backend/internal/infra/db"
+	"github.com/insmtx/Leros/backend/types"
+)
+
+func TestCreateTask_TouchesProjectUpdatedAt(t *testing.T) {
+	database := setupTestDB(t)
+	service := NewTaskService(database)
+	ctx := setupTestContextWithCaller(t)
+
+	project := &types.Project{
+		PublicID: "prj_test_create_task_touch",
+		OrgID:    1,
+		OwnerID:  1,
+		Name:     "Task Project",
+		Status:   string(types.ProjectStatusActive),
+	}
+	if err := dbpkg.CreateProject(ctx, database, project); err != nil {
+		t.Fatalf("CreateProject failed: %v", err)
+	}
+
+	oldUpdatedAt := time.Now().Add(-time.Hour).UTC()
+	if err := database.Model(&types.Project{}).
+		Where("id = ?", project.ID).
+		Update("updated_at", oldUpdatedAt).Error; err != nil {
+		t.Fatalf("set old project updated_at: %v", err)
+	}
+
+	_, err := service.CreateTask(ctx, &contract.CreateTaskRequest{
+		ProjectID: project.PublicID,
+		Title:     "新建任务",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask failed: %v", err)
+	}
+
+	refreshedProject, err := dbpkg.GetProjectByID(ctx, database, project.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID failed: %v", err)
+	}
+	if refreshedProject == nil {
+		t.Fatal("expected project to exist after CreateTask")
+	}
+	if !refreshedProject.UpdatedAt.After(oldUpdatedAt) {
+		t.Fatalf("expected project updated_at after %v, got %v", oldUpdatedAt, refreshedProject.UpdatedAt)
+	}
+}

--- a/backend/internal/service/work_service_test.go
+++ b/backend/internal/service/work_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -123,5 +124,47 @@ func TestWorkServiceNewMessage_PersistsAttachmentsOnFirstMessage(t *testing.T) {
 			types.ProjectFileResourceTypeUserUpload,
 			projectFile.ResourceType,
 		)
+	}
+}
+
+func TestWorkServiceNewMessage_TouchesProjectUpdatedAt(t *testing.T) {
+	service, database := setupTestWorkService(t)
+	ctx := setupTestContextWithCaller(t)
+
+	project := &types.Project{
+		PublicID: "prj_test_new_message_touch",
+		OrgID:    1,
+		OwnerID:  1,
+		Name:     "Touch Project",
+		Status:   string(types.ProjectStatusActive),
+	}
+	if err := database.Create(project).Error; err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	oldUpdatedAt := time.Now().Add(-time.Hour).UTC()
+	if err := database.Model(&types.Project{}).
+		Where("id = ?", project.ID).
+		Update("updated_at", oldUpdatedAt).Error; err != nil {
+		t.Fatalf("set old project updated_at: %v", err)
+	}
+
+	_, err := service.NewMessage(ctx, &contract.NewMessageRequest{
+		ProjectID: project.PublicID,
+		Content:   "请在这个项目里新建一个任务",
+	})
+	if err != nil {
+		t.Fatalf("NewMessage failed: %v", err)
+	}
+
+	refreshedProject, err := dbpkg.GetProjectByID(context.Background(), database, project.ID)
+	if err != nil {
+		t.Fatalf("reload project failed: %v", err)
+	}
+	if refreshedProject == nil {
+		t.Fatal("expected project to exist after NewMessage")
+	}
+	if !refreshedProject.UpdatedAt.After(oldUpdatedAt) {
+		t.Fatalf("expected project updated_at after %v, got %v", oldUpdatedAt, refreshedProject.UpdatedAt)
 	}
 }


### PR DESCRIPTION
## 变更说明
- 项目内用户发消息、通过 NewMessage 创建任务、手动创建任务后，同步刷新 project.updated_at
- ListProjects 默认改为按 updated_at DESC, created_at DESC 排序，保证最近活跃项目靠前
- 补充对应后端测试，覆盖项目活跃时间刷新和默认排序

## 验证
- 已执行 `go build ./backend/internal/service ./backend/internal/infra/db`
- 本地 `go test` 未跑通：当前环境缺少 `gcc`，且 sqlite 测试依赖 cgo