### PR TITLE
fix(sse-replay): 重构 SSE 回放与消息加载机制

### DIFF
--- a/backend/internal/service/session_service.go
+++ b/backend/internal/service/session_service.go
@@ -929,11 +929,14 @@ func (s *sessionService) StreamSessionEvents(ctx context.Context, sessionPID str
 		if err != nil {
 			return err
 		}
-		if replayState.StreamStartSeq > 0 && replayState.StreamStartSeq <= math.MaxInt64 {
-			streamStartSeq = int64(replayState.StreamStartSeq)
-		}
 		if replayState.StateStartSeq > 0 && replayState.StateStartSeq <= math.MaxInt64 {
 			stateStartSeq = int64(replayState.StateStartSeq)
+		}
+		// 两条 lane 在同一个 NATS stream 中，共享全局 Sequence.Stream 序号。
+		// state_start_seq（run.started 事件到达时记录）必然早于所有 run.stream 事件，
+		// 因此两条 lane 都使用 stateStartSeq 即可覆盖所有需要回放的内容。
+		if stateStartSeq > 0 {
+			streamStartSeq = stateStartSeq
 		}
 	}
 
@@ -1386,6 +1389,9 @@ func (s *sessionService) CompleteSessionMessage(ctx context.Context, req *contra
 	now := time.Now()
 	if err := db.UpdateLastMessageAt(ctx, s.db, session.ID, now); err != nil {
 		logs.WarnContextf(ctx, "update last_message_at for %s: %v", req.SessionID, err)
+	}
+	if err := db.IncrementMessageCount(ctx, s.db, session.ID); err != nil {
+		logs.WarnContextf(ctx, "increment message count for %s: %v", req.SessionID, err)
 	}
 
 	logs.DebugContextf(ctx, "persisted completed session message: session_id=%s seq=%d", req.SessionID, sequence)

--- a/frontend/packages/app-ui/components/layout/CenterCanvas.tsx
+++ b/frontend/packages/app-ui/components/layout/CenterCanvas.tsx
@@ -1,19 +1,27 @@
 "use client";
 
 import { useChatStore, useLayoutStore } from "@leros/store";
-import { useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { ChatHeader } from "../chat/ChatHeader";
 import { MessageTimeline } from "../chat/MessageTimeline";
 import { ChatInput } from "../input/ChatInput";
 
 export function CenterCanvas() {
-	const { resetLocalMessages } = useChatStore((s) => s);
+	const { loadConversationMessages, activeSessionId } = useChatStore(
+		(s) => s,
+	);
 	const { clearTaskDetailRoute } = useLayoutStore((s) => s);
 
 	useLayoutEffect(() => {
 		clearTaskDetailRoute();
-		resetLocalMessages();
-	}, [clearTaskDetailRoute, resetLocalMessages]);
+	}, [clearTaskDetailRoute]);
+
+	// 挂载时重新加载会话消息，若 runtime_status 为 "responding" 则自动触发 SSE 回放
+	useEffect(() => {
+		if (activeSessionId) {
+			loadConversationMessages(activeSessionId);
+		}
+	}, [activeSessionId, loadConversationMessages]);
 
 	return (
 		<div data-slot="center-canvas" className="flex h-full flex-1 flex-col bg-slate-50/80">

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -139,6 +139,7 @@ export function ProjectPage({
 		isGenerating,
 		pendingBootstrapSessionId,
 		setActiveSession,
+		clearLocalMessages,
 		loadConversationMessages,
 		resetLocalMessages,
 	} = useChatStore((s) => s);
@@ -289,6 +290,8 @@ export function ProjectPage({
 		// 项目消息刚创建 session 并准备开流时，跳过这次自动拉历史，避免旧数据覆盖 optimistic 消息。
 		if (pendingBootstrapSessionId === nextSessionId) return;
 		if (isGenerating && activeSessionId === nextSessionId) return;
+		// 先清空旧消息，避免 loadConversationMessages 返回前显示旧数据闪烁
+		clearLocalMessages();
 		loadConversationMessages(nextSessionId);
 	}, [
 		resolvedSessionId,
@@ -299,9 +302,17 @@ export function ProjectPage({
 		pendingBootstrapSessionId,
 		activeSessionId,
 		setActiveSession,
+		clearLocalMessages,
 		loadConversationMessages,
 		resetLocalMessages,
 	]);
+
+	// 离开项目页时清理消息并关闭 SSE
+	useEffect(() => {
+		return () => {
+			clearLocalMessages();
+		};
+	}, [clearLocalMessages]);
 
 	const handleRightSidebarResizeStart = (event: React.PointerEvent<HTMLHRElement>) => {
 		const startX = event.clientX;

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -83,13 +83,13 @@ export function TaskDetailPage({
 	} = useLayoutStore((s) => s);
 
 	const {
-		activeSessionId,
 		isGenerating,
 		messageIds,
 		messagesMap,
 		pendingBootstrapSessionId,
 		streamingMessageId,
 		setActiveSession,
+		clearLocalMessages,
 		loadConversationMessages,
 	} = useChatStore((s) => s);
 
@@ -198,16 +198,25 @@ export function TaskDetailPage({
 		setActiveSession(resolvedSessionId);
 		// 项目消息刚切页时，先等 store 完成 optimistic 初始化，避免旧历史抢先覆盖 UI。
 		if (pendingBootstrapSessionId === resolvedSessionId) return;
-		if (activeSessionId === resolvedSessionId && isGenerating) return;
+		// 先清空旧消息，避免 loadConversationMessages 返回前显示旧数据闪烁
+		clearLocalMessages();
+		// 不检查 isGenerating——可能来自 workbench 跳转，SSE 连接还未建立，
+		// loadConversationMessages 内部会根据 runtime_status 决定是否回放。
 		loadConversationMessages(resolvedSessionId);
 	}, [
 		resolvedSessionId,
-		activeSessionId,
-		isGenerating,
 		pendingBootstrapSessionId,
 		setActiveSession,
+		clearLocalMessages,
 		loadConversationMessages,
 	]);
+
+	// 离开任务详情页时清理消息并关闭 SSE
+	useEffect(() => {
+		return () => {
+			clearLocalMessages();
+		};
+	}, [clearLocalMessages]);
 
 	useEffect(() => {
 		if (!resolvedTaskId) return;

--- a/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPanel.tsx
@@ -64,7 +64,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		fetchProjects,
 		clearTaskDetailRoute,
 	} = useLayoutStore((s) => s);
-	const { startSessionResponseStream, resetLocalMessages, addUploadedAttachment, isGenerating } =
+	const { addUploadedAttachment, isGenerating } =
 		useChatStore((s) => s);
 	const { isAuthenticated, openAuthDialog, requireAuth } = useAuth();
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -91,18 +91,6 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		setAttachments([]);
 	};
 
-	const cloneAttachmentsForOptimisticMessage = (items: Attachment[]) =>
-		items.map((attachment) => {
-			// 中文注释：工作台清空输入区前，先为图片附件复制一份独立预览地址，避免跳页后首屏丢图。
-			if (attachment.type === "image" && attachment.file) {
-				return {
-					...attachment,
-					url: URL.createObjectURL(attachment.file),
-				};
-			}
-			return { ...attachment };
-		});
-
 	useEffect(() => {
 		attachmentsRef.current = attachments;
 	}, [attachments]);
@@ -113,8 +101,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 
 	useLayoutEffect(() => {
 		clearTaskDetailRoute();
-		resetLocalMessages();
-	}, [clearTaskDetailRoute, resetLocalMessages]);
+	}, [clearTaskDetailRoute]);
 
 	useEffect(() => {
 		if (!activeWorkbenchProjectId) return;
@@ -139,14 +126,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 				composerMetadata,
 			);
 			if (data?.session_id) {
-				const optimisticAttachments = cloneAttachmentsForOptimisticMessage(attachments);
-				// 中文注释：工作台跳转详情页前，先把附件写进 optimistic 消息，避免首屏只剩文本。
-				await startSessionResponseStream(
-					data.session_id,
-					content,
-					optimisticAttachments,
-					composerMetadata,
-				);
+				// 不在 workbench 发起 SSE 连接，跳转到 TaskDetailPage 后通过回放建立
 			}
 			if (navigation && data?.project_id && data?.task_id && data?.session_id) {
 				navigation.goToTaskDetail(data.project_id, data.task_id, data.session_id);

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -1532,7 +1532,7 @@ export class ChatActionImpl {
     content: string,
     projectId?: string | null,
     attachments?: Attachment[],
-    metadata?: MessageMetadata,
+    _metadata?: MessageMetadata,
   ) => {
     const trimmed = content.trim();
     if (!trimmed || !projectId) return null;
@@ -1552,21 +1552,14 @@ export class ChatActionImpl {
         activeTaskDetailProjectId: data.project_id,
         activeTaskDetailTaskId: data.task_id,
         activeTaskDetailSessionId: data.session_id,
-        // 先标记这个新 session 正在接管流式响应，避免切页副作用把旧消息列表提前刷回来。
-        pendingBootstrapSessionId: data.session_id,
+        // 此处不设置 pendingBootstrapSessionId，SSE 回放由 TaskDetailPage 的
+        // loadConversationMessages 来建立，不需要防止历史消息覆盖。
         currentView: "taskDetail",
         activeProjectTab: "chat",
         conversationListOpen: false,
         inputText: "",
         inputAttachments: [],
       });
-
-      await this.startSessionResponseStream(
-        data.session_id,
-        trimmed,
-        attachments,
-        metadata,
-      );
 
       const fullState = this.#fullGet() as {
         fetchProjectDetail?: (projectId: string) => Promise<void>;
@@ -1825,14 +1818,16 @@ export class ChatActionImpl {
   #loadConversationMessages = async (
     sessionId: string,
     options?: { resumeStream?: boolean },
-  ) => {
+  ): Promise<void> => {
     try {
       const shouldCheckRuntime = options?.resumeStream !== false;
       let runtimeStatus: string | undefined;
+      let messageCount: number | undefined;
       if (shouldCheckRuntime) {
         try {
           const sessionRes = await sessionApi.get({ session_id: sessionId });
           runtimeStatus = sessionRes.data.data?.runtime_status;
+          messageCount = sessionRes.data.data?.message_count;
         } catch (err) {
           console.error("loadConversationMessages get session error:", err);
         }
@@ -1844,6 +1839,11 @@ export class ChatActionImpl {
         sessionId,
       ).filter(isOptimisticMessage).length;
       const items = await this.#fetchAllConversationMessages(sessionId);
+
+      const shouldPoll =
+        runtimeStatus !== "responding" &&
+        messageCount === 1;
+
       const persistedMessages = items.map(mapBackendMessage);
       const state = this.#get();
       if (state.pendingBootstrapSessionId === sessionId) return;
@@ -1913,6 +1913,59 @@ export class ChatActionImpl {
       if (resumeMessage) {
         this.#startSSE(sessionId, resumeMessage.id, true);
       }
+
+      // workbench 跳转场景：runtime_status 尚未流转，后台轮询等待 responding 后建 SSE 回放
+      if (shouldPoll) {
+        // 先插入 assistant 占位消息，显示"任务执行中"的 UI 状态
+        const pollPlaceholderMsg: Message = {
+          id: `msg-assistant-poll-${Date.now()}`,
+          conversationId: sessionId,
+          role: "assistant",
+          content: "",
+          timestamp: Date.now(),
+        };
+        this.#set({
+          messagesMap: {
+            ...this.#get().messagesMap,
+            [pollPlaceholderMsg.id]: pollPlaceholderMsg,
+          },
+          messageIds: [...this.#get().messageIds, pollPlaceholderMsg.id],
+          streamingMessageId: pollPlaceholderMsg.id,
+          isGenerating: true,
+        });
+        pollRuntimeStatus(sessionId, 60_000).then((pollResult) => {
+          if (!pollResult) return;
+          const st = this.#get();
+          if (st.activeSessionId !== sessionId) return;
+          if (pollResult.status === "responding") {
+            // 用回放占位替换轮询占位，SSE 回放接管输出
+            const resumeMsgId = `msg-assistant-resume-${Date.now()}`;
+            const newMap = { ...st.messagesMap };
+            delete newMap[pollPlaceholderMsg.id];
+            const resumeMsg: Message = {
+              id: resumeMsgId,
+              conversationId: sessionId,
+              role: "assistant",
+              content: "",
+              timestamp: Date.now(),
+            };
+            newMap[resumeMsgId] = resumeMsg;
+            const newIds = st.messageIds.map((id) =>
+              id === pollPlaceholderMsg.id ? resumeMsgId : id,
+            );
+            this.#set({
+              messagesMap: newMap,
+              messageIds: newIds,
+              streamingMessageId: resumeMsgId,
+              isGenerating: true,
+            });
+            this.#startSSE(sessionId, resumeMsgId, true);
+          } else {
+            // 消息已增加但未 responding，重新拉取消息列表同步最新数据
+            this.#loadConversationMessages(sessionId, { resumeStream: false });
+          }
+        });
+      }
     } catch (err) {
       console.error("loadConversationMessages error:", err);
     }
@@ -1930,6 +1983,34 @@ export class ChatActionImpl {
       streamingMessageId: null,
       isGenerating: false,
       pendingBootstrapSessionId: null,
+      streamCancelRef: null,
+    });
+  };
+
+  /** 只关闭 SSE 连接并重置流标记位，保留 messagesMap/messageIds/activeSessionId 等会话数据。 */
+  closeSseConnection = () => {
+    if (this.#sseClient) {
+      this.#sseClient.close();
+      this.#sseClient = null;
+    }
+    this.#set({
+      streamingMessageId: null,
+      isGenerating: false,
+      streamCancelRef: null,
+    });
+  };
+
+  /** 关闭 SSE 连接并清空本地消息数据，保留 activeSessionId 等会话路由状态。 */
+  clearLocalMessages = () => {
+    if (this.#sseClient) {
+      this.#sseClient.close();
+      this.#sseClient = null;
+    }
+    this.#set({
+      messagesMap: {},
+      messageIds: [],
+      streamingMessageId: null,
+      isGenerating: false,
       streamCancelRef: null,
     });
   };
@@ -2323,3 +2404,28 @@ export const chatSlice: SliceCreator<ChatStore> = (...params) => ({
     ),
   ]),
 });
+
+/** 轮询等待 session 的 runtime_status 变为 "responding"，最长等待 timeoutMs 毫秒。 */
+async function pollRuntimeStatus(
+  sessionId: string,
+  timeoutMs: number,
+): Promise<{ status: string; messageCount?: number } | undefined> {
+  const startTime = Date.now();
+  const POLL_INTERVAL = 2000;
+  while (Date.now() - startTime < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+    try {
+      const res = await sessionApi.get({ session_id: sessionId });
+      const status = res.data.data?.runtime_status;
+      const messageCount = res.data.data?.message_count;
+      if (status === "responding") return { status: "responding", messageCount };
+      // 状态未变但消息已增加，说明 worker 已完成但状态还未流转
+      if (messageCount !== undefined && messageCount > 1) {
+        return { status: "completed", messageCount };
+      }
+    } catch {
+      // 轮询失败继续
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
- refactor(backend): 两条 lane 共享 stateStartSeq 定位回放起点， 移除独立的 StreamStartSeq 判断
- feat(store): 新增 clearLocalMessages / closeSseConnection 方法
- feat(store): loadConversationMessages 支持占位消息轮询等待 runtime_status=responding 后自动建 SSE 回放
- refactor(store): createConversationAndSend 不再建立 SSE 连接， 改为由页面组件统一通过 loadConversationMessages 触发
- refactor(ui): CenterCanvas / ProjectPage / TaskDetailPage 统一 使用 clearLocalMessages + loadConversationMessages 模式， 离开页面时 cleanup 关闭 SSE
- fix(ui): WorkbenchPanel 移除乐观消息预建逻辑，不再前置 SSE 连接，避免跳转后状态冲突