### PR TITLE
fix(desktop): 修复 Windows 重复启动多窗口问题

### DIFF
--- a/frontend/apps/desktop/src/main/app-lifecycle.ts
+++ b/frontend/apps/desktop/src/main/app-lifecycle.ts
@@ -1,4 +1,10 @@
+import { BrowserWindow } from "electron";
+
 let appQuitting = false;
+let appQuitPrepared = false;
+let appQuitPreparation: Promise<void> | null = null;
+
+const leaveFullScreenTimeoutMs = 1200;
 
 export function isAppQuitting(): boolean {
 	return appQuitting;
@@ -6,4 +12,75 @@ export function isAppQuitting(): boolean {
 
 export function markAppQuitting(): void {
 	appQuitting = true;
+}
+
+export function isAppQuitPrepared(): boolean {
+	return appQuitPrepared;
+}
+
+export async function prepareForAppQuit(): Promise<void> {
+	if (appQuitPrepared) {
+		return;
+	}
+
+	if (!appQuitPreparation) {
+		appQuitPreparation = Promise.all(BrowserWindow.getAllWindows().map(prepareWindowForQuit)).then(
+			() => {
+				appQuitPrepared = true;
+			},
+		);
+	}
+
+	await appQuitPreparation;
+}
+
+export async function prepareWindowForHide(window: BrowserWindow): Promise<void> {
+	if (window.isDestroyed()) {
+		return;
+	}
+
+	if (window.isFullScreen()) {
+		await leaveFullScreen(window);
+	}
+}
+
+async function prepareWindowForQuit(window: BrowserWindow): Promise<void> {
+	if (window.isDestroyed()) {
+		return;
+	}
+
+	if (window.isFullScreen()) {
+		await leaveFullScreen(window);
+	}
+
+	if (window.isDestroyed()) {
+		return;
+	}
+
+	if (window.isMinimized()) {
+		window.restore();
+	}
+
+	if (!window.isVisible()) {
+		window.showInactive();
+	}
+}
+
+function leaveFullScreen(window: BrowserWindow): Promise<void> {
+	return new Promise((resolve) => {
+		let timeout: NodeJS.Timeout | null = null;
+
+		const cleanup = () => {
+			window.off("leave-full-screen", cleanup);
+			if (timeout) {
+				clearTimeout(timeout);
+				timeout = null;
+			}
+			resolve();
+		};
+
+		window.once("leave-full-screen", cleanup);
+		timeout = setTimeout(cleanup, leaveFullScreenTimeoutMs);
+		window.setFullScreen(false);
+	});
 }

--- a/frontend/apps/desktop/src/main/auto-update.ts
+++ b/frontend/apps/desktop/src/main/auto-update.ts
@@ -13,11 +13,12 @@ import {
 	desktopUpdateGetStateChannel,
 	desktopUpdateRestartChannel,
 } from "../shared/auto-update";
-import { markAppQuitting } from "./app-lifecycle";
+import { markAppQuitting, prepareForAppQuit } from "./app-lifecycle";
 
 const autoUpdateIntervalMs = 30 * 60 * 1000;
 const initialAutoUpdateDelayMs = 1 * 1000;
-const desktopUpdateBaseURL = "https://leros-1395325824.cos.ap-beijing.myqcloud.com/application/stable";
+const desktopUpdateBaseURL =
+	"https://leros-1395325824.cos.ap-beijing.myqcloud.com/application/stable";
 const enableDevAutoUpdate = !app.isPackaged;
 
 let updateState: DesktopUpdateState = createState({
@@ -95,7 +96,10 @@ function markUnsupported(message: string) {
 }
 
 function canUseAutoUpdate(): boolean {
-	return (app.isPackaged || enableDevAutoUpdate) && (process.platform === "darwin" || process.platform === "win32");
+	return (
+		(app.isPackaged || enableDevAutoUpdate) &&
+		(process.platform === "darwin" || process.platform === "win32")
+	);
 }
 
 function getUpdateFeedURL(): string {
@@ -281,7 +285,7 @@ export function registerDesktopAutoUpdate() {
 	ipcMain.handle(desktopUpdateCheckChannel, async () => {
 		return checkForUpdates({ manual: true });
 	});
-	ipcMain.handle(desktopUpdateRestartChannel, () => {
+	ipcMain.handle(desktopUpdateRestartChannel, async () => {
 		if (!updateState.canRestart) {
 			return false;
 		}
@@ -292,6 +296,7 @@ export function registerDesktopAutoUpdate() {
 		}
 
 		markAppQuitting();
+		await prepareForAppQuit();
 		updater.quitAndInstall();
 		return true;
 	});

--- a/frontend/apps/desktop/src/main/index.ts
+++ b/frontend/apps/desktop/src/main/index.ts
@@ -1,23 +1,19 @@
 import { join } from "node:path";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
+import { app, BrowserWindow, ipcMain, Menu, nativeImage, shell, Tray } from "electron";
+import { desktopOpenPolicyPdfChannel, type DesktopPolicyDocument } from "../shared/auto-update";
 import {
-	app,
-	BrowserWindow,
-	ipcMain,
-	Menu,
-	nativeImage,
-	shell,
-	Tray,
-} from "electron";
-import {
-	desktopOpenPolicyPdfChannel,
-	type DesktopPolicyDocument,
-} from "../shared/auto-update";
-import { isAppQuitting, markAppQuitting } from "./app-lifecycle";
+	isAppQuitPrepared,
+	isAppQuitting,
+	markAppQuitting,
+	prepareForAppQuit,
+	prepareWindowForHide,
+} from "./app-lifecycle";
 import { getDesktopUpdateState, registerDesktopAutoUpdate } from "./auto-update";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
+let mainWindowHideInProgress = false;
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 
 if (!gotSingleInstanceLock) {
@@ -67,7 +63,7 @@ function createWindow(): void {
 		if (isAppQuitting()) return;
 
 		event.preventDefault();
-		hideMainWindow();
+		void hideMainWindow();
 	});
 
 	mainWindow.on("closed", () => {
@@ -101,10 +97,20 @@ function focusMainWindow(): void {
 	}
 }
 
-function hideMainWindow(): void {
+async function hideMainWindow(): Promise<void> {
 	if (!mainWindow || mainWindow.isDestroyed()) return;
+	if (mainWindowHideInProgress) return;
 
-	mainWindow.hide();
+	mainWindowHideInProgress = true;
+	const window = mainWindow;
+	try {
+		await prepareWindowForHide(window);
+		if (!window.isDestroyed()) {
+			window.hide();
+		}
+	} finally {
+		mainWindowHideInProgress = false;
+	}
 }
 
 function createTray(): void {
@@ -113,7 +119,9 @@ function createTray(): void {
 	const trayIconFile = process.platform === "darwin" ? "tray-icon.png" : "icon.png";
 	const icon = nativeImage.createFromPath(join(__dirname, "../../resources", trayIconFile));
 	const trayIcon =
-		process.platform === "darwin" ? icon.resize({ width: 18, height: 18 }) : icon.resize({ width: 20, height: 20 });
+		process.platform === "darwin"
+			? icon.resize({ width: 18, height: 18 })
+			: icon.resize({ width: 20, height: 20 });
 
 	tray = new Tray(trayIcon);
 	tray.setToolTip("Lework");
@@ -163,8 +171,9 @@ function formatAvailableVersion(version: string | undefined): string {
 	return `${version}（重启服务后生效）`;
 }
 
-function quitApp(): void {
+async function quitApp(): Promise<void> {
 	markAppQuitting();
+	await prepareForAppQuit();
 	app.quit();
 }
 
@@ -202,6 +211,15 @@ app.on("window-all-closed", () => {
 	if (process.platform !== "darwin") app.quit();
 });
 
-app.on("before-quit", () => {
+app.on("before-quit", (event) => {
 	markAppQuitting();
+
+	if (isAppQuitPrepared()) {
+		return;
+	}
+
+	event.preventDefault();
+	void prepareForAppQuit().finally(() => {
+		app.quit();
+	});
 });


### PR DESCRIPTION
为桌面端增加单实例锁，重复点击应用图标时退出新进程，并通过 second-instance 事件恢复和聚焦已有主窗口。Windows 下短暂置顶窗口以提升前台聚焦稳定性。